### PR TITLE
gitmodules: use https link for curl-android-ios

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = https://github.com/google/googletest
 [submodule "curl-android-ios"]
 	path = curl-android-ios
-	url = git@github.com:gcesarmza/curl-android-ios.git
+	url = https://github.com/gcesarmza/curl-android-ios.git
 	ignore = dirty


### PR DESCRIPTION
This makes cloning of the public dependency easier.