### PR TITLE
Initial changes to generate Java bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,17 @@ if(NOT IOS AND NOT ANDROID)
     install(FILES ${CMAKE_BINARY_DIR}/dronecore.py DESTINATION ${PYTHON_SITE_PACKAGES})
 endif()
 
+if(ANDROID)
+    find_package(SWIG REQUIRED)
+    find_package(Java REQUIRED COMPONENTS Runtime Development)
+    include(${SWIG_USE_FILE})
+    add_definitions(-DSWIG_TYPE_TABLE=dronecore -fPIC)
+    set_source_files_properties(swig/dronecore.i
+        PROPERTIES CPLUSPLUS ON)
+    swig_add_module(dronecore_java java swig/dronecore.i )
+    swig_link_libraries(dronecore_java -L${NDK_ROOT}/sysroot/usr/lib -llog dronecore)
+endif()
+
 if(INTEGRATION_TESTS)
     add_subdirectory(integration_tests)
 

--- a/Makefile
+++ b/Makefile
@@ -85,36 +85,43 @@ ios_simulator:
 		-DIOS_PLATFORM:STRING=SIMULATOR)
 
 android_x86: android_curl
+	sed 's/<ARCH>/android_x86/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
     -DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=x86)
 
 android_x86_64: android_curl
+	sed 's/<ARCH>/android_x86_64/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=x86_64)
 
 android_mips: android_curl
+	sed 's/<ARCH>/android_mips/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=mips)
 
 android_mips64: android_curl
+	sed 's/<ARCH>/android_mips64/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=mips64)
 
 android_armeabi: android_curl
+	sed 's/<ARCH>/android_armeabi/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=armeabi)
 
 android_armeabi-v7a: android_curl
+	sed 's/<ARCH>/android_armeabi-v7a/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=armeabi-v7a)
 
 android_arm64-v8a: android_curl
+	sed 's/<ARCH>/android_arm64-v8a/' swig/dronecore.i.in > swig/dronecore.i
 	$(call cmake-build, \
         -DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
 		-DANDROID_ABI=arm64-v8a)

--- a/swig/dronecore.i
+++ b/swig/dronecore.i
@@ -5,7 +5,7 @@
     #define SWIG_FILE_WITH_INIT
     #include "../include/dronecore.h"
     #include "../core/plugin_base.h"
-    #include "../build/default/include/device_plugin_container.h"
+    #include "../build/android_x86/include/device_plugin_container.h"
     #include "../include/device.h"
     #include "../plugins/action/action.h"
     #include "../plugins/info/info.h"
@@ -19,7 +19,7 @@
 %include <typemaps.i>
 %include "../include/dronecore.h";
 %include "../core/plugin_base.h"
-%include "../build/default/include/device_plugin_container.h";
+%include "../build/android_x86/include/device_plugin_container.h";
 %include "../include/device.h"
 %include "../plugins/action/action.h"
 %include "../plugins/info/info.h"

--- a/swig/dronecore.i.in
+++ b/swig/dronecore.i.in
@@ -1,0 +1,29 @@
+%module dronecore
+%feature("autodoc", "3");
+
+%{
+    #define SWIG_FILE_WITH_INIT
+    #include "../include/dronecore.h"
+    #include "../core/plugin_base.h"
+    #include "../build/<ARCH>/include/device_plugin_container.h"
+    #include "../include/device.h"
+    #include "../plugins/action/action.h"
+    #include "../plugins/info/info.h"
+    #include "../plugins/logging/logging.h"
+    #include "../plugins/mission/mission.h"
+    #include "../plugins/mission/mission_item.h"
+    #include "../plugins/telemetry/telemetry.h"
+    using namespace dronecore;
+%}
+
+%include <typemaps.i>
+%include "../include/dronecore.h";
+%include "../core/plugin_base.h"
+%include "../build/android_x86/include/device_plugin_container.h";
+%include "../include/device.h"
+%include "../plugins/action/action.h"
+%include "../plugins/info/info.h"
+%include "../plugins/logging/logging.h"
+%include "../plugins/mission/mission.h"
+%include "../plugins/mission/mission_item.h"
+%include "../plugins/telemetry/telemetry.h"


### PR DESCRIPTION
It is currently generating JAVA bindings for `android_x86` arch. For other arch it is having an issue as `dronecode.i` is having hardcoded build directory name as below,

`%include "../build/android_x86/include/device_plugin_container.h";`