### PR TITLE
core: ignore messages from QGC

### DIFF
--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -54,6 +54,14 @@ void DroneCoreImpl::receive_message(const mavlink_message_t &message)
         return;
     }
 
+    // FIXME: Ignore messages from QGroundControl for now. Usually QGC identifies
+    //        itself with sysid 255.
+    //        A better way would probably be to parse the heartbeat message and
+    //        look at type and check if it is MAV_TYPE_GCS.
+    if (message.sysid == 255) {
+        return;
+    }
+
     std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
 
     // Change system id of null device


### PR DESCRIPTION
This ignores messages from system ID 255 for now.
In the future we might consider checking the heartbeat type field and
check it for MAV_TYPE_GCS, however this might require some refactoring
because devices are created if any messages arrive and not just
heartbeats.

FYI: @sanderux