### PR TITLE
Tcp and Serial connection Support, Fix Install Errors on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+set(CMAKE_INSTALL_PREFIX "../install" CACHE PATH "default cache path")
 project(dronecore)
 
 # Add DEBUG define for Debug target
@@ -65,6 +66,10 @@ if (ANDROID)
     include_directories(curl-android-ios/prebuilt-with-ssl/android/include)
 endif()
 
+if(NOT IOS AND NOT MSVC)
+    set(serial_source "core/serial_connection.cpp")
+endif()
+
 # We build one static library.
 add_library(dronecore STATIC
     core/global_include.cpp
@@ -77,7 +82,7 @@ add_library(dronecore STATIC
     core/dronecore_impl.cpp
     core/mavlink_channels.cpp
     core/mavlink_receiver.cpp
-    core/serial_connection.cpp
+    ${serial_source}
     core/tcp_connection.cpp
     core/udp_connection.cpp
     core/plugin_impl_base.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,6 @@ if (ANDROID)
     include_directories(curl-android-ios/prebuilt-with-ssl/android/include)
 endif()
 
-if(NOT IOS AND NOT MSVC)
-    set(serial_source "core/serial_connection.cpp")
-endif()
-
 # We build one static library.
 add_library(dronecore STATIC
     core/global_include.cpp
@@ -82,7 +78,7 @@ add_library(dronecore STATIC
     core/dronecore_impl.cpp
     core/mavlink_channels.cpp
     core/mavlink_receiver.cpp
-    ${serial_source}
+    core/serial_connection.cpp
     core/tcp_connection.cpp
     core/udp_connection.cpp
     core/plugin_impl_base.cpp

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -122,8 +122,8 @@ const char *DroneCore::connection_result_str(ConnectionResult result)
             return "Socket error";
         case ConnectionResult::BIND_ERROR:
             return "Bind error";
-		case ConnectionResult::SOCKET_CONNECTION_ERROR:
-			return "Socket connection error";
+        case ConnectionResult::SOCKET_CONNECTION_ERROR:
+            return "Socket connection error";
         case ConnectionResult::CONNECTION_ERROR:
             return "Connection error";
         case ConnectionResult::NOT_IMPLEMENTED:

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -3,6 +3,10 @@
 #include "global_include.h"
 #include "connection.h"
 #include "udp_connection.h"
+#include "tcp_connection.h"
+#ifndef WINDOWS
+#include "serial_connection.h"
+#endif
 
 
 namespace dronecore {
@@ -37,6 +41,50 @@ DroneCore::ConnectionResult DroneCore::add_udp_connection(int local_port_number)
     _impl->add_connection(new_connection);
     return DroneCore::ConnectionResult::SUCCESS;
 }
+
+DroneCore::ConnectionResult DroneCore::add_tcp_connection()
+{
+    return add_tcp_connection("", 0);
+}
+
+DroneCore::ConnectionResult DroneCore::add_tcp_connection(std::string remote_ip,
+                                                          int remote_port)
+{
+    Connection *new_connection = new TcpConnection(_impl, remote_ip, remote_port);
+    DroneCore::ConnectionResult ret = new_connection->start();
+
+    if (ret != DroneCore::ConnectionResult::SUCCESS) {
+        delete new_connection;
+        return ret;
+    }
+
+    _impl->add_connection(new_connection);
+    return DroneCore::ConnectionResult::SUCCESS;
+}
+
+#ifndef WINDOWS
+DroneCore::ConnectionResult DroneCore::add_serial_connection()
+{
+    return add_serial_connection("", 0);
+}
+#endif
+
+#ifndef WINDOWS
+DroneCore::ConnectionResult DroneCore::add_serial_connection(std::string dev_path,
+                                                             int baudrate)
+{
+    Connection *new_connection = new SerialConnection(_impl, dev_path, baudrate);
+    DroneCore::ConnectionResult ret = new_connection->start();
+
+    if (ret != DroneCore::ConnectionResult::SUCCESS) {
+        delete new_connection;
+        return ret;
+    }
+
+    _impl->add_connection(new_connection);
+    return DroneCore::ConnectionResult::SUCCESS;
+}
+#endif
 
 const std::vector<uint64_t> &DroneCore::device_uuids() const
 {
@@ -74,6 +122,8 @@ const char *DroneCore::connection_result_str(ConnectionResult result)
             return "Socket error";
         case ConnectionResult::BIND_ERROR:
             return "Bind error";
+		case ConnectionResult::SOCKET_CONNECTION_ERROR:
+			return "Socket connection error";
         case ConnectionResult::CONNECTION_ERROR:
             return "Connection error";
         case ConnectionResult::NOT_IMPLEMENTED:

--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -1,14 +1,42 @@
 #include "serial_connection.h"
 #include "global_include.h"
 
+#ifndef WINDOWS
+#include <asm/termbits.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#endif
+
+#include <cassert>
+
+#ifndef WINDOWS
+#define GET_ERROR(_x) strerror(_x)
+#else
+#define GET_ERROR(_x) WSAGetLastError()
+#endif
+
 namespace dronecore {
 
 SerialConnection::SerialConnection(DroneCoreImpl *parent, const std::string &path, int baudrate) :
-    Connection(parent)
+    Connection(parent),
+    _serial_node(path),
+    _baudrate(baudrate)
 {
-    UNUSED(path);
-    UNUSED(baudrate);
+    if (baudrate == 0) {
+        _baudrate = DEFAULT_SERIAL_BAUDRATE;
+    }
+    if (path == "") {
+        _serial_node = DEFAULT_SERIAL_DEV_PATH;
+    }
 }
+
+SerialConnection::~SerialConnection()
+{
+    // If no one explicitly called stop before, we should at least do it.
+    stop();
+}
+
 
 bool SerialConnection::is_ok() const
 {
@@ -17,20 +45,128 @@ bool SerialConnection::is_ok() const
 
 DroneCore::ConnectionResult SerialConnection::start()
 {
+    if (!start_mavlink_receiver()) {
+        return DroneCore::ConnectionResult::CONNECTIONS_EXHAUSTED;
+    }
+
+    DroneCore::ConnectionResult ret = setup_port();
+    if (ret != DroneCore::ConnectionResult::SUCCESS) {
+        return ret;
+    }
+
+    start_recv_thread();
+
     return DroneCore::ConnectionResult::SUCCESS;
+}
+
+DroneCore::ConnectionResult SerialConnection::setup_port()
+{
+    struct termios2 tc;
+
+    bzero(&tc, sizeof(tc));
+
+    _fd = open(_serial_node.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);// | O_NDELAY);
+    if (_fd == -1) {
+        return DroneCore::ConnectionResult::CONNECTION_ERROR;
+    }
+    if (ioctl(_fd, TCGETS2, &tc) == -1) {
+        Debug() << "Could not get termios2 " << GET_ERROR(errno);
+        close(_fd);
+        return DroneCore::ConnectionResult::CONNECTION_ERROR;
+    }
+
+    tc.c_iflag &= ~(IGNBRK | BRKINT | ICRNL | INLCR | PARMRK | INPCK | ISTRIP | IXON);
+    tc.c_oflag &= ~(OCRNL | ONLCR | ONLRET | ONOCR | OFILL | OPOST);
+    tc.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG | TOSTOP);
+    tc.c_cflag &= ~(CSIZE | PARENB | CBAUD | CRTSCTS);
+    tc.c_cflag |= CS8 | BOTHER;
+
+    tc.c_cc[VMIN] = 0;
+    tc.c_cc[VTIME] = 0;
+    tc.c_ispeed = _baudrate;
+    tc.c_ospeed = _baudrate;
+
+    if (ioctl(_fd, TCSETS2, &tc) == -1) {
+        Debug() << "Could not set terminal attributes " << GET_ERROR(errno);
+        close(_fd);
+        return DroneCore::ConnectionResult::CONNECTION_ERROR;
+    }
+
+    if (ioctl(_fd, TCFLSH, TCIOFLUSH) == -1) {
+        Debug() << "Could not flush terminal " << GET_ERROR(errno);
+        close(_fd);
+        return DroneCore::ConnectionResult::CONNECTION_ERROR;
+    }
+    return DroneCore::ConnectionResult::SUCCESS;
+}
+
+void SerialConnection::start_recv_thread()
+{
+    _recv_thread = new std::thread(receive, this);
 }
 
 DroneCore::ConnectionResult SerialConnection::stop()
 {
+    _should_exit = true;
+    //TODO for windows
+    close(_fd);
+
+    if (_recv_thread) {
+        _recv_thread->join();
+        delete _recv_thread;
+        _recv_thread = nullptr;
+    }
+
+    // We need to stop this after stopping the receive thread, otherwise
+    // it can happen that we interfere with the parsing of a message.
+    stop_mavlink_receiver();
+
     return DroneCore::ConnectionResult::SUCCESS;
 }
 
 bool SerialConnection::send_message(const mavlink_message_t &message)
 {
-    UNUSED(message);
-    Debug() << "Not implemented";
-    return false;
+    if (_serial_node.empty()) {
+        Debug() << "Dev Path unknown";
+        return false;
+    }
+
+    if (_baudrate == 0) {
+        Debug() << "Baudrate unknown";
+        return false;
+    }
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    uint16_t buffer_len = mavlink_msg_to_send_buffer(buffer, &message);
+
+    int send_len =  write(_fd, buffer, buffer_len);
+
+    if (send_len != buffer_len) {
+        Debug() << "write failure: " << GET_ERROR(errno);
+        return false;
+    }
+
+    return true;
 }
 
+void SerialConnection::receive(SerialConnection *parent)
+{
+    // Enough for MTU 1500 bytes.
+    char buffer[2048];
 
+    while (!parent->_should_exit) {
+        int recv_len = read(parent->_fd, buffer, sizeof(buffer));
+        if (recv_len < -1) {
+            Debug() << "read failure: " << GET_ERROR(errno);
+        }
+        if (recv_len > sizeof(buffer) || recv_len == 0) {
+            continue;
+        }
+        parent->_mavlink_receiver->set_new_datagram(buffer, recv_len);
+        // Parse all mavlink messages in one data packet. Once exhausted, we'll exit while.
+        while (parent->_mavlink_receiver->parse_message()) {
+            parent->receive_message(parent->_mavlink_receiver->get_last_message());
+        }
+    }
+}
 } // namespace dronecore

--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -1,3 +1,4 @@
+#if !defined(WINDOWS) && !defined(APPLE)
 #include "serial_connection.h"
 #include "global_include.h"
 
@@ -170,3 +171,4 @@ void SerialConnection::receive(SerialConnection *parent)
     }
 }
 } // namespace dronecore
+#endif

--- a/core/serial_connection.h
+++ b/core/serial_connection.h
@@ -1,3 +1,4 @@
+#if !defined(WINDOWS) && !defined(APPLE)
 #pragma once
 
 #include "dronecore.h"
@@ -37,3 +38,4 @@ private:
 };
 
 } // namespace dronecore
+#endif

--- a/core/serial_connection.h
+++ b/core/serial_connection.h
@@ -13,10 +13,27 @@ public:
     bool is_ok() const;
     DroneCore::ConnectionResult start();
     DroneCore::ConnectionResult stop();
+    ~SerialConnection();
 
     bool send_message(const mavlink_message_t &message);
+    // Non-copyable
+    SerialConnection(const SerialConnection &) = delete;
+    const SerialConnection &operator=(const SerialConnection &) = delete;
 
 private:
+    DroneCore::ConnectionResult setup_port();
+    void start_recv_thread();
+    static void receive(SerialConnection *parent);
+
+    static constexpr int DEFAULT_SERIAL_BAUDRATE = 9600;
+    static constexpr auto DEFAULT_SERIAL_DEV_PATH = "/dev/ttyS0";
+    std::string _serial_node = {};
+    int _baudrate = DEFAULT_SERIAL_BAUDRATE;
+
+    std::mutex _mutex = {};
+    int _fd = -1;
+    std::thread *_recv_thread = nullptr;
+    std::atomic_bool _should_exit;
 };
 
 } // namespace dronecore

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -80,9 +80,9 @@ DroneCore::ConnectionResult TcpConnection::setup_port()
     }
 
     sockaddr_in remote_addr {};
-	remote_addr.sin_family = AF_INET;
-	remote_addr.sin_port = htons(_remote_port_number);
-	remote_addr.sin_addr.s_addr = inet_addr(_remote_ip.c_str());
+    remote_addr.sin_family = AF_INET;
+    remote_addr.sin_port = htons(_remote_port_number);
+    remote_addr.sin_addr.s_addr = inet_addr(_remote_ip.c_str());
 
     if (connect(_socket_fd, (sockaddr *)&remote_addr, sizeof(struct sockaddr_in)) < 0) {
         Debug() << "connect error: " << GET_ERROR(errno);

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -1,14 +1,44 @@
 #include "tcp_connection.h"
 #include "global_include.h"
 
+#ifndef WINDOWS
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <unistd.h> // for close()
+#endif
+#include <cassert>
+
+#ifndef WINDOWS
+#define GET_ERROR(_x) strerror(_x)
+#else
+#define GET_ERROR(_x) WSAGetLastError()
+#endif
+
 namespace dronecore {
 
-TcpConnection::TcpConnection(DroneCoreImpl *parent, const std::string &ip, int port_number) :
-    Connection(parent)
+/* change to remote_ip and remote_port */
+TcpConnection::TcpConnection(DroneCoreImpl *parent, const std::string &remote_ip, int remote_port) :
+    Connection(parent),
+    _remote_ip(remote_ip),
+    _remote_port_number(remote_port),
+    _should_exit(false)
 {
-    UNUSED(ip);
-    UNUSED(port_number);
+    if (_remote_port_number == 0) {
+        _remote_port_number = DEFAULT_TCP_REMOTE_PORT;
+    }
+    if (_remote_ip == "") {
+        _remote_ip = DEFAULT_TCP_REMOTE_IP;
+    }
 }
+
+TcpConnection::~TcpConnection()
+{
+    // If no one explicitly called stop before, we should at least do it.
+    stop();
+}
+
 
 bool TcpConnection::is_ok() const
 {
@@ -17,20 +47,152 @@ bool TcpConnection::is_ok() const
 
 DroneCore::ConnectionResult TcpConnection::start()
 {
+    if (!start_mavlink_receiver()) {
+        return DroneCore::ConnectionResult::CONNECTIONS_EXHAUSTED;
+    }
+
+    DroneCore::ConnectionResult ret = setup_port();
+    if (ret != DroneCore::ConnectionResult::SUCCESS) {
+        return ret;
+    }
+
+    start_recv_thread();
+
     return DroneCore::ConnectionResult::SUCCESS;
+}
+
+DroneCore::ConnectionResult TcpConnection::setup_port()
+{
+
+#ifdef WINDOWS
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        Debug() << "Error: Winsock failed, error: %d", WSAGetLastError();
+        return DroneCore::ConnectionResult::SOCKET_ERROR;
+    }
+#endif
+
+    _socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (_socket_fd < 0) {
+        Debug() << "socket error" << GET_ERROR(errno);
+        return DroneCore::ConnectionResult::SOCKET_ERROR;
+    }
+
+    sockaddr_in remote_addr {};
+	remote_addr.sin_family = AF_INET;
+	remote_addr.sin_port = htons(_remote_port_number);
+	remote_addr.sin_addr.s_addr = inet_addr(_remote_ip.c_str());
+
+    if (connect(_socket_fd, (sockaddr *)&remote_addr, sizeof(struct sockaddr_in)) < 0) {
+        Debug() << "connect error: " << GET_ERROR(errno);
+        return DroneCore::ConnectionResult::SOCKET_CONNECTION_ERROR;
+    }
+
+    return DroneCore::ConnectionResult::SUCCESS;
+}
+
+void TcpConnection::start_recv_thread()
+{
+    _recv_thread = new std::thread(receive, this);
 }
 
 DroneCore::ConnectionResult TcpConnection::stop()
 {
+    _should_exit = true;
+
+#ifndef WINDOWS
+    // This should interrupt a recv/recvfrom call.
+    shutdown(_socket_fd, SHUT_RDWR);
+
+    // But on Mac, closing is also needed to stop blocking recv/recvfrom.
+    close(_socket_fd);
+#else
+    shutdown(_socket_fd, SD_BOTH);
+
+    closesocket(_socket_fd);
+
+    WSACleanup();
+#endif
+
+    if (_recv_thread) {
+        _recv_thread->join();
+        delete _recv_thread;
+        _recv_thread = nullptr;
+    }
+
+    // We need to stop this after stopping the receive thread, otherwise
+    // it can happen that we interfere with the parsing of a message.
+    stop_mavlink_receiver();
+
     return DroneCore::ConnectionResult::SUCCESS;
 }
 
 bool TcpConnection::send_message(const mavlink_message_t &message)
 {
-    UNUSED(message);
-    Debug() << "Not implemented";
-    return false;
+    if (_remote_ip.empty()) {
+        Debug() << "Remote IP unknown";
+        return false;
+    }
+
+    if (_remote_port_number == 0) {
+        Debug() << "Remote port unknown";
+        return false;
+    }
+
+    struct sockaddr_in dest_addr;
+    memset((char *)&dest_addr, 0, sizeof(dest_addr));
+    dest_addr.sin_family = AF_INET;
+
+    inet_pton(AF_INET, _remote_ip.c_str(), &dest_addr.sin_addr.s_addr);
+
+    dest_addr.sin_port = htons(_remote_port_number);
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    uint16_t buffer_len = mavlink_msg_to_send_buffer(buffer, &message);
+
+    // TODO: remove this assert again
+    assert(buffer_len <= MAVLINK_MAX_PACKET_LEN);
+
+    int send_len = sendto(_socket_fd, (const char *)buffer, buffer_len, 0,
+                          (const sockaddr *)&dest_addr, sizeof(dest_addr));
+
+    if (send_len != buffer_len) {
+        Debug() << "sendto failure: " << GET_ERROR(errno);
+        return false;
+    }
+    return true;
 }
 
+void TcpConnection::receive(TcpConnection *parent)
+{
+    // Enough for MTU 1500 bytes.
+    char buffer[2048];
+
+    while (!parent->_should_exit) {
+
+        int recv_len = recv(parent->_socket_fd, buffer, sizeof(buffer), 0);
+
+        if (recv_len == 0) {
+            // This can happen when shutdown is called on the socket,
+            // therefore we check _should_exit again.
+            continue;
+        }
+
+        if (recv_len < 0) {
+            // This happens on desctruction when close(_socket_fd) is called,
+            // therefore be quiet.
+            //Debug() << "recvfrom error: " << GET_ERROR(errno);
+            continue;
+        }
+
+        parent->_mavlink_receiver->set_new_datagram(buffer, recv_len);
+
+        // Parse all mavlink messages in one data packet. Once exhausted, we'll exit while.
+        while (parent->_mavlink_receiver->parse_message()) {
+            parent->receive_message(parent->_mavlink_receiver->get_last_message());
+        }
+    }
+}
 
 } // namespace dronecore

--- a/core/tcp_connection.h
+++ b/core/tcp_connection.h
@@ -3,6 +3,14 @@
 #include "dronecore.h"
 #include "dronecore_impl.h"
 #include "connection.h"
+#include <sys/types.h>
+#ifndef WINDOWS
+#include <netdb.h>
+#else
+#include <winsock2.h>
+#include <Ws2tcpip.h> // For InetPton
+#undef SOCKET_ERROR
+#endif
 
 namespace dronecore {
 
@@ -10,13 +18,34 @@ class TcpConnection : public Connection
 {
 public:
     explicit TcpConnection(DroneCoreImpl *parent, const std::string &ip, int port_number);
+    ~TcpConnection();
     bool is_ok() const;
     DroneCore::ConnectionResult start();
     DroneCore::ConnectionResult stop();
 
     bool send_message(const mavlink_message_t &message);
 
+    // Non-copyable
+    TcpConnection(const TcpConnection &) = delete;
+    const TcpConnection &operator=(const TcpConnection &) = delete;
+
 private:
+    DroneCore::ConnectionResult setup_port();
+    void start_recv_thread();
+    int resolve_address(const std::string &ip_address, int port, sockaddr_in *addr);
+    static void receive(TcpConnection *parent);
+
+    static constexpr int DEFAULT_TCP_REMOTE_PORT = 5760;
+    static constexpr auto DEFAULT_TCP_REMOTE_IP = "127.0.0.1";
+    std::string _local_ip = "127.0.0.1";
+    int _local_port_number = 14580; //unused port
+    std::string _remote_ip = {};
+    int _remote_port_number;
+
+    std::mutex _mutex = {};
+    int _socket_fd = -1;
+    std::thread *_recv_thread = nullptr;
+    std::atomic_bool _should_exit;
 };
 
 } // namespace dronecore

--- a/example/takeoff_land/CMakeLists.txt
+++ b/example/takeoff_land/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(takeoff_and_land)
 
-add_definitions("-std=c++11 -Wall -Wextra -Werror")
+if(NOT MSVC)
+    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+else()
+    add_definitions("-std=c++11 -WX -W2")
+    set(platform_libs "Ws2_32.lib")
+endif()
 
 # Add DEBUG define for Debug target
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
@@ -20,9 +25,16 @@ add_executable(takeoff_and_land
     takeoff_and_land.cpp
 )
 
+if(WINDOWS)
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
+else()
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
+endif()
+
 target_link_libraries(takeoff_and_land
-    ${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a
+    ${dronecore_lib}
     # If installed system-wide:
     # dronecore
     ${CMAKE_THREAD_LIBS_INIT}
+    ${platform_libs}
 )

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -45,6 +45,7 @@ public:
         TIMEOUT, /**< @brief %Connection timed out. */
         SOCKET_ERROR, /**< @brief Socket error. */
         BIND_ERROR, /**< @brief Bind error. */
+        SOCKET_CONNECTION_ERROR,
         CONNECTION_ERROR, /**< @brief %Connection error. */
         NOT_IMPLEMENTED, /**< @brief %Connection type not implemented. */
         DEVICE_NOT_CONNECTED, /**< @brief No device is connected. */
@@ -75,6 +76,40 @@ public:
      * @return The result of adding the connection.
      */
     ConnectionResult add_udp_connection(int local_port_number);
+
+    /**
+     * @brief Adds a TCP connection with the default arguments.
+     *
+     * This will connect to local TCP port 5760.
+     *
+     * @return The result of adding the connection.
+     */
+    ConnectionResult add_tcp_connection();
+
+    /**
+     * @brief Adds a TCP connection with a specific ip and specific port number.
+     *
+     * @param remote_port The TCP port to connect to.
+     * @return The result of adding the connection.
+     */
+    ConnectionResult add_tcp_connection(std::string remote_ip, int remote_port);
+
+    /**
+     * @brief Adds a Serial connection with the default arguments.
+     *
+     * This will connect to serial port ttyS1(COM0).
+     *
+     * @return The result of adding the connection.
+     */
+    ConnectionResult add_serial_connection();
+
+    /**
+     * @brief Adds a Serial connection with a specific COM port(uart dev node) and baudrate as specified.
+     *
+     * @param baudrate Baudrate of the serial port.
+     * @return The result of adding the connection.
+     */
+    ConnectionResult add_serial_connection(std::string dev_path, int baudrate);
 
     /**
      * @brief Get vector of device UUIDs.

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -61,7 +61,7 @@ public:
     static const char *connection_result_str(ConnectionResult);
 
     /**
-     * @brief Adds a UDP connection with the default arguments.
+     * @brief Adds a UDP connection to the default port.
      *
      * This will listen on UDP port 14540.
      *
@@ -70,7 +70,7 @@ public:
     ConnectionResult add_udp_connection();
 
     /**
-     * @brief Adds a UDP connection with a specific port number.
+     * @brief Adds a UDP connection to the specified port number.
      *
      * @param local_port_number The local UDP port to listen to.
      * @return The result of adding the connection.
@@ -78,7 +78,7 @@ public:
     ConnectionResult add_udp_connection(int local_port_number);
 
     /**
-     * @brief Adds a TCP connection with the default arguments.
+     * @brief Adds a TCP connection to the default IP address/port.
      *
      * This will connect to local TCP port 5760.
      *
@@ -87,7 +87,7 @@ public:
     ConnectionResult add_tcp_connection();
 
     /**
-     * @brief Adds a TCP connection with a specific ip and specific port number.
+     * @brief Adds a TCP connection with a specific IP address and port number.
      *
      * @param remote_port The TCP port to connect to.
      * @return The result of adding the connection.
@@ -95,16 +95,16 @@ public:
     ConnectionResult add_tcp_connection(std::string remote_ip, int remote_port);
 
     /**
-     * @brief Adds a Serial connection with the default arguments.
+     * @brief Adds a serial connection with the default arguments.
      *
-     * This will connect to serial port ttyS1(COM0).
+     * This will connect to serial port ttyS1 (COM0).
      *
      * @return The result of adding the connection.
      */
     ConnectionResult add_serial_connection();
 
     /**
-     * @brief Adds a Serial connection with a specific COM port(uart dev node) and baudrate as specified.
+     * @brief Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
      *
      * @param baudrate Baudrate of the serial port.
      * @return The result of adding the connection.


### PR DESCRIPTION
Tcp Connection Support : Default Ip as 127.0.0.1 and port as 5760
Serial Connection Support(only for Linux) : Default Port as ttyS0 and Baudrate as 9600.

Fix Install Errors For Dronecore Library and Example
Fix install path for Dronecore library on Windows in CMakeLists
Fix Error flags for Takeoff_and_land Example on Windows