### PR TITLE
Colour code errors in example

### DIFF
--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -51,13 +51,23 @@ int main(int /*argc*/, char ** /*argv*/)
         return 1;
     }
 
+
+    // Set up callback to monitor altitude while the vehicle is in flight
     device.telemetry().position_async([](Telemetry::Position position) {
         std::cout << "\033[34m" // set to blue
                   << "Altitude: " << position.relative_altitude_m << " m"
                   << "\033[0m" // set to default color again
                   << std::endl;
     });
+    
 
+    // Check if vehicle is ready to arm
+    if (device.telemetry().health_all_ok()!=true) {
+        std::cout << "\033[31m" << "Vehicle not ready to arm" << "\033[0m" << std::endl;
+        return 1;
+        }
+
+    // Arm vehicle
     std::cout << "Arming..." << std::endl;
     const Action::Result arm_result = device.action().arm();
 
@@ -66,6 +76,7 @@ int main(int /*argc*/, char ** /*argv*/)
         return 1;
     }
 
+    // Take off
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = device.action().takeoff();
     if (takeoff_result != Action::Result::SUCCESS) {

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -20,8 +20,8 @@ int main(int /*argc*/, char ** /*argv*/)
     DroneCore::ConnectionResult connection_result = dc.add_udp_connection();
 
     if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
-        std::cout << "Connection failed: " << DroneCore::connection_result_str(
-                      connection_result) << std::endl;
+        std::cout << "\033[31m" << "Connection failed: " << DroneCore::connection_result_str(
+                      connection_result) << "\033[0m" << std::endl;
         return 1;
     }
 
@@ -35,7 +35,7 @@ int main(int /*argc*/, char ** /*argv*/)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     if (!discovered_device) {
-        std::cout << "No device found, exiting." << std::endl;
+        std::cout << "\033[31m" << "No device found, exiting." << "\033[0m" << std::endl;
         return 1;
     }
 
@@ -47,7 +47,7 @@ int main(int /*argc*/, char ** /*argv*/)
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = dc.device().telemetry().set_rate_position(1.0);
     if (set_rate_result != Telemetry::Result::SUCCESS) {
-        std::cout << "Setting rate failed:" << Telemetry::result_str(set_rate_result) << std::endl;
+        std::cout << "\033[31m" << "Setting rate failed:" << Telemetry::result_str(set_rate_result) << "\033[0m" << std::endl;
         return 1;
     }
 
@@ -62,14 +62,14 @@ int main(int /*argc*/, char ** /*argv*/)
     const Action::Result arm_result = device.action().arm();
 
     if (arm_result != Action::Result::SUCCESS) {
-        std::cout << "Arming failed:" << Action::result_str(arm_result) << std::endl;
+        std::cout << "\033[31m" << "Arming failed:" << Action::result_str(arm_result) << "\033[0m" << std::endl;
         return 1;
     }
 
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = device.action().takeoff();
     if (takeoff_result != Action::Result::SUCCESS) {
-        std::cout << "Takeoff failed:" << Action::result_str(takeoff_result) << std::endl;
+        std::cout << "\033[31m" << "Takeoff failed:" << Action::result_str(takeoff_result) << "\033[0m" << std::endl;
         return 1;
     }
 
@@ -79,11 +79,11 @@ int main(int /*argc*/, char ** /*argv*/)
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = device.action().land();
     if (land_result != Action::Result::SUCCESS) {
-        std::cout << "Land failed:" << Action::result_str(land_result) << std::endl;
+        std::cout << "\033[31m" << "Land failed:" << Action::result_str(land_result) << "\033[0m" << std::endl;
         return 1;
     }
 
-    // We are relying on auto-disarming but let's keep watching the telemetry infos a bit longer.
+    // We are relying on auto-disarming but let's keep watching the telemetry for a bit longer.
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
     return 0;

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -11,6 +11,10 @@
 
 using namespace dronecore;
 
+#define ERROR_CONSOLE_TEXT "\033[31m" //Turn text on console red
+#define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
+#define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
+
 int main(int /*argc*/, char ** /*argv*/)
 {
     DroneCore dc;
@@ -20,8 +24,9 @@ int main(int /*argc*/, char ** /*argv*/)
     DroneCore::ConnectionResult connection_result = dc.add_udp_connection();
 
     if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
-        std::cout << "\033[31m" << "Connection failed: " << DroneCore::connection_result_str(
-                      connection_result) << "\033[0m" << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Connection failed: "
+                  << DroneCore::connection_result_str(connection_result)
+                  << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
@@ -35,7 +40,7 @@ int main(int /*argc*/, char ** /*argv*/)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     if (!discovered_device) {
-        std::cout << "\033[31m" << "No device found, exiting." << "\033[0m" << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "No device found, exiting." << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
@@ -47,32 +52,34 @@ int main(int /*argc*/, char ** /*argv*/)
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = dc.device().telemetry().set_rate_position(1.0);
     if (set_rate_result != Telemetry::Result::SUCCESS) {
-        std::cout << "\033[31m" << "Setting rate failed:" << Telemetry::result_str(set_rate_result) << "\033[0m" << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Setting rate failed:" << Telemetry::result_str(
+                      set_rate_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
 
     // Set up callback to monitor altitude while the vehicle is in flight
     device.telemetry().position_async([](Telemetry::Position position) {
-        std::cout << "\033[34m" // set to blue
+        std::cout << TELEMETRY_CONSOLE_TEXT // set to blue
                   << "Altitude: " << position.relative_altitude_m << " m"
-                  << "\033[0m" // set to default color again
+                  << NORMAL_CONSOLE_TEXT // set to default color again
                   << std::endl;
     });
-    
+
 
     // Check if vehicle is ready to arm
-    if (device.telemetry().health_all_ok()!=true) {
-        std::cout << "\033[31m" << "Vehicle not ready to arm" << "\033[0m" << std::endl;
+    if (device.telemetry().health_all_ok() != true) {
+        std::cout << ERROR_CONSOLE_TEXT << "Vehicle not ready to arm" << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
-        }
+    }
 
     // Arm vehicle
     std::cout << "Arming..." << std::endl;
     const Action::Result arm_result = device.action().arm();
 
     if (arm_result != Action::Result::SUCCESS) {
-        std::cout << "\033[31m" << "Arming failed:" << Action::result_str(arm_result) << "\033[0m" << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(
+                      arm_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
@@ -80,7 +87,8 @@ int main(int /*argc*/, char ** /*argv*/)
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = device.action().takeoff();
     if (takeoff_result != Action::Result::SUCCESS) {
-        std::cout << "\033[31m" << "Takeoff failed:" << Action::result_str(takeoff_result) << "\033[0m" << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(
+                      takeoff_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
@@ -90,12 +98,13 @@ int main(int /*argc*/, char ** /*argv*/)
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = device.action().land();
     if (land_result != Action::Result::SUCCESS) {
-        std::cout << "\033[31m" << "Land failed:" << Action::result_str(land_result) << "\033[0m" << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(
+                      land_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
     // We are relying on auto-disarming but let's keep watching the telemetry for a bit longer.
     std::this_thread::sleep_for(std::chrono::seconds(5));
-
+    std::cout << "Finished..." << std::endl;
     return 0;
 }


### PR DESCRIPTION
This makes errors show up a little more clear in the output. 

I also added a check for the vehicle being in an armable state, as I think this is a useful thing to show users. Note that none of the checks are necessarily realistic but good for the example (e.g. in real code I might way for armable state rather than exiting).