### PR TITLE
Makefile: don't always install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ default:
 	$(call cmake-build)
 
 # install basically just runs default install
+install: ARGS += install
 install: default
-    ARGS=install
 
 docs: install
 	- mkdir install/docs


### PR DESCRIPTION
This did not actually do what it was supposed to but always ran install.

@hamishwillee this should fix your error:

```
make default Build dir: build/default ninja: error: loading 'build.ninja': No such file or directory Makefile:71: recipe for target 'default' failed make: *** [default] Error 1
```

Can you re-test with this?