### PR TITLE
Make examples have consistent buildfiles

### DIFF
--- a/example/fly_mission/CMakeLists.txt
+++ b/example/fly_mission/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(fly_mission)
 
-add_definitions("-std=c++11 -Wall -Wextra -Werror")
+if(NOT MSVC)
+    add_definitions("-std=c++11 -Wall -Wextra -Werror")
+else()
+    add_definitions("-std=c++11 -WX -W2")
+    set(platform_libs "Ws2_32.lib")
+endif()
 
 # Add DEBUG define for Debug target
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
@@ -19,9 +24,16 @@ add_executable(fly_mission
     fly_mission_dronecore.cpp
 )
 
+if(WINDOWS)
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/dronecore.lib")
+else()
+    set(dronecore_lib "${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a")
+endif()
+
 target_link_libraries(fly_mission
-    ${CMAKE_SOURCE_DIR}/../../install/lib/libdronecore.a
+    ${dronecore_lib}
     # If installed system-wide:
     # dronecore
     ${CMAKE_THREAD_LIBS_INIT}
+    ${platform_libs}
 )

--- a/example/takeoff_land/CMakeLists.txt
+++ b/example/takeoff_land/CMakeLists.txt
@@ -14,7 +14,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
 
 # This finds thread libs on Linux, Mac, and Windows.
 find_package(Threads REQUIRED)
-message(${CMAKE_SOURCE_DIR})
 
 include_directories(
     # Not needed if installed system-wide


### PR DESCRIPTION
The fly mission example was linux specific - this adds the required windows compatibility (copied from takeoff_and_land example). It also removes a spurious message for the cmake source directory from the takeoff example. 

1. If we have installed the DroneCore artifacts system wide will the example pick these up instead of the relative path to the include directory that I see defined mid-way up?
2. The instructions we given in  [Install Artifacts](http://localhost:4000/en/contributing/build.html#install-artifacts) state that to install files system wide you do the following when building DroneCore:
   ```
   INSTALL_PREFIX=/usr/local make default install
   ```
   - Won't this only work on linux?
   - Does cmake look for this location when creating make files for examples?
   - Is there a way to get this to work on windows or should I add note "not supported on Windows".
3. Do we have an intention to deploy DroneCore library as a binary?

