### PR TITLE
Improve timeout functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ add_library(dronecore STATIC
     core/plugin_impl_base.cpp
     core/curl_wrapper.cpp
     core/http_loader.cpp
+    core/timeout_handler.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/core/device_plugin_container.cpp
     ${plugin_source_files}
 )
@@ -151,6 +152,7 @@ if(NOT IOS AND NOT ANDROID)
         core/mavlink_channels_test.cpp
         core/unittests_main.cpp
         core/http_loader_test.cpp
+        core/timeout_handler_test.cpp
         ${plugin_unittest_source_files}
         ${unit_tests_src}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
 if(NOT MSVC)
     # Clang and GCC
     # We are not using exceptions to make it easier to write wrappers.
-    add_definitions("-std=c++11 -Wall -Wextra -Werror -fno-exceptions")
+    add_definitions("-std=c++11 -Wall -Wextra -Werror -fno-exceptions -Wshadow")
     set(platform_libs "pthread")
     set(curl_lib "curl")
 else()

--- a/core/http_loader_test.cpp
+++ b/core/http_loader_test.cpp
@@ -86,7 +86,7 @@ protected:
                                                   const std::string &url, const std::string &path)
     {
         EXPECT_CALL(*curl_wrapper, download_file_to_path(url, path, _))
-        .WillOnce(Invoke([&](const std::string &/*url*/, const std::string & path,
+        .WillOnce(Invoke([&](const std::string &/*url*/, const std::string & got_path,
         const progress_callback_t &progress_callback) {
             for (size_t i = 0; i <= 100; i++) {
                 if (progress_callback != nullptr) {
@@ -94,7 +94,7 @@ protected:
                 }
             }
 
-            write_file(path, "downloaded file content\n");
+            write_file(got_path, "downloaded file content\n");
 
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
@@ -120,10 +120,10 @@ TEST_F(HttpLoaderTest, HttpLoader_DownloadAsync_OneBad)
     progress_callback_t progress = [&callback_results_progress,
                                     &callback_finished_counter,
                                     &callback_error_counter]
-    (int progress, Status status, CURLcode curl_code) -> int {
+    (int got_progress, Status status, CURLcode curl_code) -> int {
         if (status == Status::Downloading)
         {
-            callback_results_progress.push_back(progress);
+            callback_results_progress.push_back(got_progress);
         } else if (status == Status::Error && curl_code == CURLcode::CURLE_COULDNT_RESOLVE_HOST)
         {
             callback_error_counter++;
@@ -168,10 +168,10 @@ TEST_F(HttpLoaderTest, HttpLoader_DownloadAsync_AllGood)
     progress_callback_t progress = [&callback_results_progress,
                                     &callback_finished_counter,
                                     &callback_error_counter]
-    (int progress, Status status, CURLcode curl_code) -> int {
+    (int got_progress, Status status, CURLcode curl_code) -> int {
         if (status == Status::Downloading)
         {
-            callback_results_progress.push_back(progress);
+            callback_results_progress.push_back(got_progress);
         } else if (status == Status::Error && curl_code == CURLcode::CURLE_COULDNT_RESOLVE_HOST)
         {
             callback_error_counter++;

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -76,6 +76,8 @@ private:
     DeviceImpl *_parent;
     LockedQueue<Work> _work_queue {};
 
+    void *_timeout_cookie = nullptr;
+
 #ifdef NO_PROMISES
     std::mutex _promise_mutex {};
     enum class PromiseState {

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -29,7 +29,11 @@ void MavlinkParameters::set_param_async(const std::string &name,
                                         set_param_callback_t callback,
                                         bool extended)
 {
-    // Debug() << "setting param " << name << " to " << value.get_int();
+    // if (value.is_float()) {
+    //     Debug() << "setting param " << name << " to " << value.get_float();
+    // } else {
+    //     Debug() << "setting param " << name << " to " << value.get_int();
+    // }
 
     if (name.size() > PARAM_ID_LEN) {
         Debug() << "Error: param name too long";

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -119,7 +119,6 @@ void MavlinkParameters::do_work()
                                            param_value_buf,
                                            work.param_value.get_mav_param_type());
         } else {
-            mavlink_message_t message = {};
             mavlink_msg_param_set_pack(_parent->get_own_system_id(),
                                        _parent->get_own_component_id(),
                                        &message,

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -140,7 +140,7 @@ void MavlinkParameters::do_work()
         // We want to get notified if a timeout happens
         _parent->register_timeout_handler(std::bind(&MavlinkParameters::receive_timeout, this),
                                           0.5,
-                                          this);
+                                          &_timeout_cookie);
 
     } else if (_get_param_queue.size() > 0) {
 
@@ -197,7 +197,7 @@ void MavlinkParameters::do_work()
         // We want to get notified if a timeout happens
         _parent->register_timeout_handler(std::bind(&MavlinkParameters::receive_timeout, this),
                                           0.5,
-                                          this);
+                                          &_timeout_cookie);
     }
 }
 
@@ -228,7 +228,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
                     work.callback(true, value);
                 }
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _get_param_queue.pop_front();
             }
@@ -250,7 +250,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
@@ -284,7 +284,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
                     work.callback(true, value);
                 }
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _get_param_queue.pop_front();
             }
@@ -307,7 +307,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
@@ -343,14 +343,14 @@ void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
 
             } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
 
                 // Reset timeout and wait again.
-                _parent->refresh_timeout_handler(this);
+                _parent->refresh_timeout_handler(_timeout_cookie);
 
             } else {
 
@@ -361,7 +361,7 @@ void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -118,6 +118,11 @@ public:
             return _int_value;
         }
 
+        bool is_float() const
+        {
+            return (_type == Type::FLOAT);
+        }
+
     private:
         float _float_value = NAN;
         int32_t _int_value = 0;

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -174,6 +174,8 @@ private:
     };
     LockedQueue<GetParamWork> _get_param_queue {};
 
+    void *_timeout_cookie = nullptr;
+
     // dl_time_t _last_request_time = {};
 };
 

--- a/core/timeout_handler.cpp
+++ b/core/timeout_handler.cpp
@@ -1,0 +1,83 @@
+#include "timeout_handler.h"
+
+namespace dronecore {
+
+TimeoutHandler::TimeoutHandler()
+{
+}
+
+TimeoutHandler::~TimeoutHandler()
+{
+}
+
+void TimeoutHandler::add(std::function<void()> callback, double duration_s, void **cookie)
+{
+    auto new_timeout = std::make_shared<Timeout>();
+    new_timeout->callback = callback;
+    new_timeout->time = steady_time_in_future(duration_s);
+    new_timeout->duration_s = duration_s;
+
+    void *new_cookie = static_cast<void *>(new_timeout.get());
+
+    {
+        std::lock_guard<std::mutex> lock(_timeouts_mutex);
+        _timeouts.insert(std::pair<void *, std::shared_ptr<Timeout>>(new_cookie, new_timeout));
+    }
+
+    if (cookie != nullptr) {
+        *cookie = new_cookie;
+    }
+}
+
+void TimeoutHandler::refresh(const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
+
+    auto it = _timeouts.find((void *)(cookie));
+    if (it != _timeouts.end()) {
+        dl_time_t future_time = steady_time_in_future(it->second->duration_s);
+        it->second->time = future_time;
+    }
+}
+
+void TimeoutHandler::remove(const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
+
+    auto it = _timeouts.find((void *)cookie);
+    if (it != _timeouts.end()) {
+        _timeouts.erase((void *)cookie);
+    }
+}
+
+void TimeoutHandler::run_once()
+{
+    _timeouts_mutex.lock();
+
+    dl_time_t now = steady_time();
+
+    for (auto it = _timeouts.begin(); it != _timeouts.end(); /* no ++it */) {
+
+        // If time is passed, call timeout callback.
+        if (it->second->time < now) {
+
+            if (it->second->callback) {
+
+                // Unlock while we callback because it might in turn want to add timeouts.
+                std::function<void()> callback = it->second->callback;
+                _timeouts_mutex.unlock();
+                callback();
+                _timeouts_mutex.lock();
+            }
+
+            // Self-destruct before calling to avoid locking issues.
+            _timeouts.erase(it++);
+
+        } else {
+            ++it;
+        }
+    }
+    _timeouts_mutex.unlock();
+}
+
+} // namespace dronecore

--- a/core/timeout_handler.h
+++ b/core/timeout_handler.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <mutex>
+#include <memory>
+#include <functional>
+#include <map>
+#include "global_include.h"
+
+namespace dronecore {
+
+class TimeoutHandler
+{
+public:
+    TimeoutHandler();
+    ~TimeoutHandler();
+
+    // delete copy and move constructors and assign operators
+    TimeoutHandler(TimeoutHandler const &) = delete;            // Copy construct
+    TimeoutHandler(TimeoutHandler &&) = delete;                 // Move construct
+    TimeoutHandler &operator=(TimeoutHandler const &) = delete; // Copy assign
+    TimeoutHandler &operator=(TimeoutHandler &&) = delete;      // Move assign
+
+    void add(std::function<void()> callback, double duration_s, void **cookie);
+    void refresh(const void *cookie);
+    void remove(const void *cookie);
+
+    void run_once();
+
+private:
+    struct Timeout {
+        std::function<void()> callback;
+        dl_time_t time;
+        double duration_s;
+    };
+
+    std::map<void *, std::shared_ptr<Timeout>> _timeouts {};
+    std::mutex _timeouts_mutex {};
+};
+
+} // namespace dronecore

--- a/core/timeout_handler_test.cpp
+++ b/core/timeout_handler_test.cpp
@@ -1,0 +1,118 @@
+#include "timeout_handler.h"
+#include <gtest/gtest.h>
+#include <atomic>
+
+using namespace dronecore;
+
+TEST(TimeoutHandler, Timeout)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+
+    UNUSED(cookie);
+}
+
+TEST(TimeoutHandler, TimeoutNoCookie)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    // This time we supply nullptr and don't want a cookie.
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, nullptr);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+}
+
+TEST(TimeoutHandler, CallTimeoutInTimeoutCallback)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie1 = nullptr;
+    void *cookie2 = nullptr;
+    th.add([&th, &timeout_happened, &cookie2]() {
+        timeout_happened = true;
+        // This tests the case where we want to set yet another timeout when we
+        // are called because of a timeout. This tests if there are no locking
+        // issues.
+        th.add([]() {
+        }, 5.0, &cookie2);
+    }, 0.5, &cookie1);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+
+    UNUSED(cookie1);
+    UNUSED(cookie2);
+}
+
+TEST(TimeoutHandler, TimeoutRefreshed)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(400));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    th.refresh(cookie);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+
+    UNUSED(cookie);
+}
+
+TEST(TimeoutHandler, TimeoutRemoved)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    th.remove(cookie);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+}

--- a/integration_tests/curl.cpp
+++ b/integration_tests/curl.cpp
@@ -106,8 +106,8 @@ TEST_F(CurlTest, Curl_DownloadFile_ProgressFeedback_Success)
     CURLcode last_curl_code;
 
     auto progress = [&last_progress, &last_status, &last_curl_code]
-    (int progress, Status status, CURLcode curl_code) -> int {
-        last_progress = progress;
+    (int got_progress, Status status, CURLcode curl_code) -> int {
+        last_progress = got_progress;
         last_status = status;
         last_curl_code = curl_code;
         return 0;
@@ -132,8 +132,8 @@ TEST_F(CurlTest, Curl_DownloadFile_ProgressFeedback_COULDNT_RESOLVE_HOST)
     CURLcode last_curl_code;
 
     auto progress = [&last_progress, &last_status, &last_curl_code]
-    (int progress, Status status, CURLcode curl_code) -> int {
-        last_progress = progress;
+    (int got_progress, Status status, CURLcode curl_code) -> int {
+        last_progress = got_progress;
         last_status = status;
         last_curl_code = curl_code;
         return 0;

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -88,6 +88,8 @@ private:
     static constexpr uint8_t PX4_CUSTOM_MAIN_MODE_AUTO = 4;
     static constexpr uint8_t PX4_CUSTOM_SUB_MODE_AUTO_LOITER = 3;
     static constexpr uint8_t PX4_CUSTOM_SUB_MODE_AUTO_MISSION = 4;
+
+    void *_timeout_cookie = nullptr;
 };
 
 //static std::function<void(MavlinkCommands::Result)> empty_callback;

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -92,7 +92,8 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
 
     _result_callback = callback;
 
-    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0, this);
+    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0,
+                                      &_timeout_cookie);
 }
 
 void OffboardImpl::stop_async(Offboard::result_callback_t callback)
@@ -117,14 +118,15 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
 
     _result_callback = callback;
 
-    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0, this);
+    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0,
+                                      &_timeout_cookie);
 }
 
 void OffboardImpl::receive_command_result(MavlinkCommands::Result result,
                                           const Offboard::result_callback_t &callback)
 {
     // We got a command back, so we can get rid of the timeout handler.
-    _parent->unregister_timeout_handler(this);
+    _parent->unregister_timeout_handler(_timeout_cookie);
 
     Offboard::Result offboard_result = offboard_result_from_command_result(result);
 

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -36,11 +36,12 @@ private:
     static Offboard::Result offboard_result_from_command_result(
         MavlinkCommands::Result result);
 
-
     void timeout_happened();
 
     bool _offboard_mode_active;
     Offboard::result_callback_t _result_callback;
+
+    void *_timeout_cookie = nullptr;
 };
 
 } // namespace dronecore

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -96,7 +96,7 @@ void TelemetryImpl::init()
         std::bind(&TelemetryImpl::process_rc_channels, this, _1), (void *)this);
 
     _parent->register_timeout_handler(
-        std::bind(&TelemetryImpl::receive_rc_channels_timeout, this), 1.0, (const void *)this);
+        std::bind(&TelemetryImpl::receive_rc_channels_timeout, this), 1.0, &_timeout_cookie);
 
     // FIXME: The calibration check should eventually be better than this.
     //        For now, we just do the same as QGC does.
@@ -484,7 +484,7 @@ void TelemetryImpl::process_rc_channels(const mavlink_message_t &message)
     bool rc_ok = (rc_channels.chancount > 0);
     set_rc_status(rc_ok, rc_channels.rssi);
 
-    _parent->refresh_timeout_handler(this);
+    _parent->refresh_timeout_handler(_timeout_cookie);
 }
 
 Telemetry::FlightMode TelemetryImpl::to_flight_mode_from_custom_mode(uint32_t custom_mode)

--- a/plugins/telemetry/telemetry_impl.h
+++ b/plugins/telemetry/telemetry_impl.h
@@ -181,6 +181,8 @@ private:
     // the faster between the two.
     double _ground_speed_ned_rate_hz;
     double _position_rate_hz;
+
+    void *_timeout_cookie = nullptr;
 };
 
 } // namespace dronecore


### PR DESCRIPTION
This improves the timeout checker: 

- supports multiple timeouts per plugin/class
- is unit tested

Along with the change:
- a param set bugfix because of shadowing
- shadowing warnings