### PR TITLE
Improve debugging printfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
     add_definitions("-Wno-missing-field-initializers")
 endif()
 
+# Add definition for __FILENAME__ so we don't need to use __FILE__ because it also
+# contains the path.
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
+
 # Set these in a module to add a library.
 set (additional_includes "")
 set (additional_libs "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
 if(NOT MSVC)
     # Clang and GCC
     # We are not using exceptions to make it easier to write wrappers.
-    add_definitions("-std=c++11 -Wall -Wextra -Werror -fno-exceptions -Wshadow")
+    add_definitions("-std=c++11 -Wall -Wextra -Werror -fno-exceptions -Wshadow -Wno-strict-aliasing")
     set(platform_libs "pthread")
     set(curl_lib "curl")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(NOT IOS AND NOT ANDROID)
         add_definitions("-Wno-sign-compare")
     endif()
 
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DTESTING")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTESTING")
 
     add_executable(unit_tests_runner
         core/global_include_test.cpp

--- a/core/curl_wrapper.cpp
+++ b/core/curl_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "global_include.h"
+#include "log.h"
 #include "curl_wrapper.h"
 #include <sstream>
 #include <iostream>

--- a/core/curl_wrapper.cpp
+++ b/core/curl_wrapper.cpp
@@ -44,11 +44,11 @@ bool CurlWrapper::download_text(const std::string &url, std::string &content)
         if (res == CURLcode::CURLE_OK) {
             return true;
         } else {
-            Debug() << "Error while downloading text, curl error code: " << curl_easy_strerror(res);
+            LogErr() << "Error while downloading text, curl error code: " << curl_easy_strerror(res);
             return false;
         }
     } else {
-        Debug() << "Error: cannot start uploading because of curl initialization error. ";
+        LogErr() << "Error: cannot start uploading because of curl initialization error. ";
         return false;
     }
 }
@@ -151,11 +151,11 @@ bool CurlWrapper::upload_file(const std::string &url, const std::string &path,
             if (nullptr != progress_callback) {
                 progress_callback(0, Status::Error, res);
             }
-            Debug() << "Error while uploading file, curl error code: " << curl_easy_strerror(res);
+            LogErr() << "Error while uploading file, curl error code: " << curl_easy_strerror(res);
             return false;
         }
     } else {
-        Debug() << "Error: cannot start uploading because of curl initialization error.";
+        LogErr() << "Error: cannot start uploading because of curl initialization error.";
         return false;
     }
 }
@@ -218,11 +218,11 @@ bool CurlWrapper::download_file_to_path(const std::string &url, const std::strin
                 progress_callback(0, Status::Error, res);
             }
             remove(path.c_str());
-            Debug() << "Error while downloading file, curl error code: " << curl_easy_strerror(res);
+            LogErr() << "Error while downloading file, curl error code: " << curl_easy_strerror(res);
             return false;
         }
     } else {
-        Debug() << "Error: cannot start downloading file because of curl initialization error. ";
+        LogErr() << "Error: cannot start downloading file because of curl initialization error. ";
         return false;
     }
 }

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -142,7 +142,7 @@ void DeviceImpl::process_autopilot_version(const mavlink_message_t &message)
 
     } else {
         // TODO: this is bad, we should raise a flag to invalidate device.
-        Debug() << "Error: UUID changed";
+        LogErr() << "Error: UUID changed";
     }
 }
 

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -87,7 +87,7 @@ void DroneCoreImpl::receive_message(const mavlink_message_t &message)
     }
 
     if (message.sysid != 1) {
-        Debug() << "sysid: " << int(message.sysid);
+        LogDebug() << "sysid: " << int(message.sysid);
     }
 
     if (_device_impls.find(message.sysid) != _device_impls.end()) {
@@ -101,7 +101,7 @@ bool DroneCoreImpl::send_message(const mavlink_message_t &message)
 
     for (auto it = _connections.begin(); it != _connections.end(); ++it) {
         if (!(**it).send_message(message)) {
-            Debug() << "send fail";
+            LogErr() << "send fail";
             return false;
         }
     }
@@ -142,18 +142,18 @@ Device &DroneCoreImpl::get_device()
         }
 
         if (_device_impls.size() > 1) {
-            Debug() << "Error: more than one device found:";
+            LogErr() << "Error: more than one device found:";
 
             int i = 0;
             for (auto it = _device_impls.begin(); it != _device_impls.end(); ++it) {
-                Debug() << "strange: " << i << ": " << int(it->first) << ", " << it->second;
+                LogWarn() << "strange: " << i << ": " << int(it->first) << ", " << it->second;
                 ++i;
             }
 
             // Just return first device instead of failing.
             return *_devices.begin()->second;
         } else {
-            Debug() << "Error: no device found.";
+            LogErr() << "Error: no device found.";
             uint8_t system_id = 0;
             create_device_if_not_existing(system_id);
             return *_devices[system_id];
@@ -175,7 +175,7 @@ Device &DroneCoreImpl::get_device(uint64_t uuid)
 
     // We have not found a device with this UUID.
     // TODO: this is an error condition that we ought to handle properly.
-    Debug() << "device with UUID: " << uuid << " not found";
+    LogErr() << "device with UUID: " << uuid << " not found";
 
     // Create a dummy
     uint8_t system_id = 0;
@@ -195,7 +195,7 @@ void DroneCoreImpl::create_device_if_not_existing(uint8_t system_id)
 
     // existing already.
     if (_devices.find(system_id) != _devices.end()) {
-        //Debug() << "ID: " << int(system_id) << " exists already.";
+        //LogDebug() << "ID: " << int(system_id) << " exists already.";
         return;
     }
 

--- a/core/global_include.h
+++ b/core/global_include.h
@@ -2,15 +2,8 @@
 
 #define UNUSED(x) (void)(x)
 
-#include <sstream>
 #include <chrono>
 #include <thread>
-
-#if ANDROID
-#include <android/log.h>
-#else
-#include <iostream>
-#endif
 
 #ifdef WINDOWS
 #ifndef _USE_MATH_DEFINES
@@ -33,45 +26,6 @@
 
 
 namespace dronecore {
-
-class Debug
-{
-// TODO: This needs to be split into Debug(), Info(), Warn(), Err().
-//       For now, we just print all Debug() even in Release mode.
-//#ifdef DEBUG
-#if 1
-public:
-    Debug() : _s() {}
-
-    template <typename T>
-    Debug &operator << (const T &x)
-    {
-        _s << x;
-        return *this;
-    }
-
-    ~Debug()
-    {
-#if ANDROID
-        __android_log_print(ANDROID_LOG_DEBUG, "DroneCore", "%s", _s.str().c_str());
-#else
-        std::cout << _s.str() << std::endl;
-#endif
-    }
-
-private:
-    std::stringstream _s;
-
-#else
-public:
-    template <typename T>
-    Debug &operator << (const T &x)
-    {
-        UNUSED(x);
-        return *this;
-    }
-#endif
-};
 
 typedef std::chrono::time_point<std::chrono::steady_clock> dl_time_t;
 

--- a/core/http_loader_test.cpp
+++ b/core/http_loader_test.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <vector>
 #include <numeric>
+#include <gtest/gtest.h>
 
 using namespace dronecore;
 

--- a/core/integration_test_helper.h
+++ b/core/integration_test_helper.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <iostream>
 #include <gtest/gtest.h>
 #include "global_include.h"
+#include "log.h"
 
 class SitlTest : public testing::Test
 {

--- a/core/log.h
+++ b/core/log.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <sstream>
+
+#if ANDROID
+#include <android/log.h>
+#else
+#include <iostream>
+#endif
+
+namespace dronecore {
+
+class Debug
+{
+// TODO: This needs to be split into Debug(), Info(), Warn(), Err().
+//       For now, we just print all Debug() even in Release mode.
+//#ifdef DEBUG
+#if 1
+public:
+    Debug() : _s() {}
+
+    template <typename T>
+    Debug &operator << (const T &x)
+    {
+        _s << x;
+        return *this;
+    }
+
+    ~Debug()
+    {
+#if ANDROID
+        __android_log_print(ANDROID_LOG_DEBUG, "DroneCore", "%s", _s.str().c_str());
+#else
+        std::cout << _s.str() << std::endl;
+#endif
+    }
+
+private:
+    std::stringstream _s;
+
+#else
+public:
+    template <typename T>
+    Debug &operator << (const T &x)
+    {
+        UNUSED(x);
+        return *this;
+    }
+#endif
+};
+
+} // namespace dronecore

--- a/core/log.h
+++ b/core/log.h
@@ -6,6 +6,8 @@
 #include <android/log.h>
 #else
 #include <iostream>
+#include <iomanip>
+#include <ctime>
 #endif
 
 #define ANSI_COLOR_RED     "\x1b[31m"
@@ -76,20 +78,27 @@ public:
                 break;
         }
 #else
+
+        // Time output taken from:
+        // https://stackoverflow.com/questions/16357999#answer-16358111
+        auto t = std::time(nullptr);
+        auto tm = *std::localtime(&t);
+        std::cout << "[" << std::put_time(&tm, "%H:%M:%S");
+
         switch (_log_level) {
             case LogLevel::Debug:
-                std::cout << "[Debug  ] ";
+                std::cout << " | Debug  ] ";
                 break;
             case LogLevel::Info:
-                std::cout << "[Info   ] ";
+                std::cout << " | Info   ] ";
                 break;
             case LogLevel::Warn:
                 std::cout << ANSI_COLOR_YELLOW;
-                std::cout << "[Warning] ";
+                std::cout << " | Warning] ";
                 break;
             case LogLevel::Err:
                 std::cout << ANSI_COLOR_RED;
-                std::cout << "[Error  ] ";
+                std::cout << " | Error  ] ";
                 break;
         }
 

--- a/core/log.h
+++ b/core/log.h
@@ -47,8 +47,8 @@ class LogDetailed
 {
 public:
     LogDetailed(const char *filename, int filenumber) : _s(),
-        _filename(filename),
-        _filenumber(filenumber)
+        _caller_filename(filename),
+        _caller_filenumber(filenumber)
     {}
 
     template <typename T>
@@ -94,7 +94,7 @@ public:
         }
 
         std::cout << _s.str();
-        std::cout << " (" << _filename << ":" << _filenumber << ")";
+        std::cout << " (" << _caller_filename << ":" << _caller_filenumber << ")";
 
         switch (_log_level) {
             case LogLevel::Info:
@@ -122,8 +122,8 @@ protected:
 
 private:
     std::stringstream _s;
-    const char *_filename;
-    int _filenumber;
+    const char *_caller_filename;
+    int _caller_filenumber;
 };
 
 class LogDebugDetailed : public LogDetailed

--- a/core/log.h
+++ b/core/log.h
@@ -95,18 +95,18 @@ public:
 
         switch (_log_level) {
             case LogLevel::Debug:
-                std::cout << " | Debug  ] ";
+                std::cout << "|Debug] ";
                 break;
             case LogLevel::Info:
-                std::cout << " | Info   ] ";
+                std::cout << "|Info ] ";
                 break;
             case LogLevel::Warn:
                 std::cout << ANSI_COLOR_YELLOW;
-                std::cout << " | Warning] ";
+                std::cout << "|Warn ] ";
                 break;
             case LogLevel::Err:
                 std::cout << ANSI_COLOR_RED;
-                std::cout << " | Error  ] ";
+                std::cout << "|Error] ";
                 break;
         }
 

--- a/core/log.h
+++ b/core/log.h
@@ -15,8 +15,12 @@
 #define ANSI_COLOR_GRAY    "\x1b[37m"
 #define ANSI_COLOR_RESET   "\x1b[0m"
 
+#ifndef WINDOWS
 // Remove path and extract only filename.
 #define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
+#else
+#define __FILENAME__  __FILE__
+#endif
 
 // For release builds, don't show debug printfs, and just discard it into the NullStream.
 class NullStream

--- a/core/log.h
+++ b/core/log.h
@@ -6,7 +6,6 @@
 #include <android/log.h>
 #else
 #include <iostream>
-#include <iomanip>
 #include <ctime>
 #endif
 
@@ -84,10 +83,15 @@ public:
 #else
 
         // Time output taken from:
-        // https://stackoverflow.com/questions/16357999#answer-16358111
-        auto t = std::time(nullptr);
-        auto tm = *std::localtime(&t);
-        std::cout << "[" << std::put_time(&tm, "%H:%M:%S");
+        // https://stackoverflow.com/questions/16357999#answer-16358264
+
+
+        time_t rawtime;
+        time(&rawtime);
+        struct tm *timeinfo = localtime(&rawtime);
+        char time_buffer[10] {}; // We need 8 characters + \0
+        strftime(time_buffer, sizeof(time_buffer), "%I:%M:%S", timeinfo);
+        std::cout << "[" << time_buffer;
 
         switch (_log_level) {
             case LogLevel::Debug:

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -30,13 +30,13 @@ void MavlinkParameters::set_param_async(const std::string &name,
                                         bool extended)
 {
     // if (value.is_float()) {
-    //     Debug() << "setting param " << name << " to " << value.get_float();
+    //     LogDebug() << "setting param " << name << " to " << value.get_float();
     // } else {
-    //     Debug() << "setting param " << name << " to " << value.get_int();
+    //     LogDebug() << "setting param " << name << " to " << value.get_int();
     // }
 
     if (name.size() > PARAM_ID_LEN) {
-        Debug() << "Error: param name too long";
+        LogErr() << "Error: param name too long";
         if (callback) {
             callback(false);
         }
@@ -58,10 +58,10 @@ void MavlinkParameters::get_param_async(const std::string &name,
                                         get_param_callback_t callback,
                                         bool extended)
 {
-    // Debug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
+    // LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
 
     if (name.size() > PARAM_ID_LEN) {
-        Debug() << "Error: param name too long";
+        LogErr() << "Error: param name too long";
         if (callback) {
             ParamValue empty_param;
             callback(false, empty_param);
@@ -130,7 +130,7 @@ void MavlinkParameters::do_work()
         }
 
         if (!_parent->send_message(message)) {
-            Debug() << "Error: Send message failed";
+            LogErr() << "Error: Send message failed";
             if (work.callback) {
                 work.callback(false);
             }
@@ -156,7 +156,7 @@ void MavlinkParameters::do_work()
         char param_id[PARAM_ID_LEN] = {};
         STRNCPY(param_id, work.param_name.c_str(), sizeof(param_id));
 
-        // Debug() << "now getting: " << work.param_name;
+        // LogDebug() << "now getting: " << work.param_name;
 
         mavlink_message_t message = {};
         if (work.extended) {
@@ -169,7 +169,7 @@ void MavlinkParameters::do_work()
                                                     -1);
 
         } else {
-            //Debug() << "request read: "
+            //LogDebug() << "request read: "
             //    << (int)_parent->get_own_system_id() << ":"
             //    << (int)_parent->get_own_component_id() <<
             //    " to "
@@ -186,7 +186,7 @@ void MavlinkParameters::do_work()
         }
 
         if (!_parent->send_message(message)) {
-            Debug() << "Error: Send message failed";
+            LogErr() << "Error: Send message failed";
             if (work.callback) {
                 ParamValue empty_param;
                 work.callback(false, empty_param);
@@ -206,7 +206,7 @@ void MavlinkParameters::do_work()
 
 void MavlinkParameters::process_param_value(const mavlink_message_t &message)
 {
-    // Debug() << "getting param value";
+    // LogDebug() << "getting param value";
 
     mavlink_param_value_t param_value;
     mavlink_msg_param_value_decode(&message, &param_value);
@@ -232,7 +232,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
                 }
                 _state = State::NONE;
                 _parent->unregister_timeout_handler(_timeout_cookie);
-                // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
+                // LogDebug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _get_param_queue.pop_front();
             }
         }
@@ -254,7 +254,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
 
                 _state = State::NONE;
                 _parent->unregister_timeout_handler(_timeout_cookie);
-                // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
+                // LogDebug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
         }
@@ -263,7 +263,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
 
 void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message)
 {
-    // Debug() << "getting param ext value";
+    // LogDebug() << "getting param ext value";
     mavlink_param_ext_value_t param_ext_value;
     mavlink_msg_param_ext_value_decode(&message, &param_ext_value);
 
@@ -288,7 +288,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
                 }
                 _state = State::NONE;
                 _parent->unregister_timeout_handler(_timeout_cookie);
-                // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
+                // LogDebug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _get_param_queue.pop_front();
             }
         }
@@ -311,7 +311,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
 
                 _state = State::NONE;
                 _parent->unregister_timeout_handler(_timeout_cookie);
-                // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
+                // LogDebug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
         }
@@ -321,7 +321,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
 
 void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
 {
-    // Debug() << "getting param ext ack";
+    // LogDebug() << "getting param ext ack";
 
     mavlink_param_ext_ack_t param_ext_ack;
     mavlink_msg_param_ext_ack_decode(&message, &param_ext_ack);
@@ -347,7 +347,7 @@ void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
 
                 _state = State::NONE;
                 _parent->unregister_timeout_handler(_timeout_cookie);
-                // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
+                // LogDebug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
 
             } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
@@ -365,7 +365,7 @@ void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
 
                 _state = State::NONE;
                 _parent->unregister_timeout_handler(_timeout_cookie);
-                // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
+                // LogDebug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
 
@@ -391,8 +391,8 @@ void MavlinkParameters::receive_timeout()
             if (work.callback) {
                 ParamValue empty_value;
                 // Notify about timeout
-                Debug() << "Error: get param busy timeout: " << work.param_name;
-                // Debug() << "Got it after: " << elapsed_since_s(_last_request_time);
+                LogErr() << "Error: get param busy timeout: " << work.param_name;
+                // LogDebug() << "Got it after: " << elapsed_since_s(_last_request_time);
                 work.callback(false, empty_value);
             }
             _state = State::NONE;
@@ -408,7 +408,7 @@ void MavlinkParameters::receive_timeout()
 
             if (work.callback) {
                 // Notify about timeout
-                Debug() << "Error: set param busy timeout: " << work.param_name;
+                LogErr() << "Error: set param busy timeout: " << work.param_name;
                 work.callback(false);
             }
             _state = State::NONE;

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "log.h"
 #include "global_include.h"
 #include "mavlink_include.h"
 #include "locked_queue.h"

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -56,7 +56,7 @@ public:
                     break;
                 default:
                     // This would be worrying
-                    Debug() << "Error: unknown mavlink param type";
+                    LogErr() << "Error: unknown mavlink param type";
                     break;
             }
         }
@@ -80,7 +80,7 @@ public:
                     break;
                 default:
                     // This would be worrying
-                    Debug() << "Error: unknown mavlink ext param type";
+                    LogErr() << "Error: unknown mavlink ext param type";
                     break;
             }
         }

--- a/core/mavlink_receiver.cpp
+++ b/core/mavlink_receiver.cpp
@@ -66,8 +66,8 @@ void MavlinkReceiver::debug_drop_rate()
 
         if (!_first) {
 
-            Debug() << "-------------------------------------------------------------------"
-                    << "-----------";
+            LogDebug() << "-------------------------------------------------------------------"
+                       << "-----------";
 
             if (_bytes_received <= sys_status.errors_comm &&
                 sys_status.errors_count2 <= sys_status.errors_comm) {
@@ -89,7 +89,7 @@ void MavlinkReceiver::debug_drop_rate()
                            _bytes_at_sdk_overall, _bytes_sent_overall);
 
             } else {
-                Debug() << "Missed SYS_STATUS";
+                LogDebug() << "Missed SYS_STATUS";
             }
         }
         _first = false;
@@ -104,30 +104,30 @@ void MavlinkReceiver::debug_drop_rate()
 void MavlinkReceiver::print_line(const char *index, unsigned count, unsigned count_total,
                                  unsigned overall_bytes, unsigned overall_bytes_total)
 {
-    Debug() << "count "
-            << index
-            << ": "
-            << std::setw(6)
-            << count
-            << ", loss: "
-            << std::setw(6)
-            << count_total -  count
-            << ",  "
-            << std::setw(6)
-            << std::setprecision(2)
-            << std::fixed
-            << 100.0 * float(count) / float(count_total)
-            << " %, overall: "
-            << std::setw(6)
-            << std::setprecision(2)
-            << std::fixed
-            << (100.0 * double(overall_bytes) / double(overall_bytes_total))
-            << " %, "
-            << std::setw(6)
-            << std::setprecision(2)
-            << std::fixed
-            << (double(overall_bytes) / _time_elapsed / 1024.0)
-            << " KiB/s";
+    LogDebug() << "count "
+               << index
+               << ": "
+               << std::setw(6)
+               << count
+               << ", loss: "
+               << std::setw(6)
+               << count_total -  count
+               << ",  "
+               << std::setw(6)
+               << std::setprecision(2)
+               << std::fixed
+               << 100.0 * float(count) / float(count_total)
+               << " %, overall: "
+               << std::setw(6)
+               << std::setprecision(2)
+               << std::fixed
+               << (100.0 * double(overall_bytes) / double(overall_bytes_total))
+               << " %, "
+               << std::setw(6)
+               << std::setprecision(2)
+               << std::fixed
+               << (double(overall_bytes) / _time_elapsed / 1024.0)
+               << " KiB/s";
 }
 #endif
 

--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -71,7 +71,7 @@ DroneCore::ConnectionResult SerialConnection::setup_port()
         return DroneCore::ConnectionResult::CONNECTION_ERROR;
     }
     if (ioctl(_fd, TCGETS2, &tc) == -1) {
-        Debug() << "Could not get termios2 " << GET_ERROR(errno);
+        LogErr() << "Could not get termios2 " << GET_ERROR(errno);
         close(_fd);
         return DroneCore::ConnectionResult::CONNECTION_ERROR;
     }
@@ -88,13 +88,13 @@ DroneCore::ConnectionResult SerialConnection::setup_port()
     tc.c_ospeed = _baudrate;
 
     if (ioctl(_fd, TCSETS2, &tc) == -1) {
-        Debug() << "Could not set terminal attributes " << GET_ERROR(errno);
+        LogErr() << "Could not set terminal attributes " << GET_ERROR(errno);
         close(_fd);
         return DroneCore::ConnectionResult::CONNECTION_ERROR;
     }
 
     if (ioctl(_fd, TCFLSH, TCIOFLUSH) == -1) {
-        Debug() << "Could not flush terminal " << GET_ERROR(errno);
+        LogErr() << "Could not flush terminal " << GET_ERROR(errno);
         close(_fd);
         return DroneCore::ConnectionResult::CONNECTION_ERROR;
     }
@@ -128,12 +128,12 @@ DroneCore::ConnectionResult SerialConnection::stop()
 bool SerialConnection::send_message(const mavlink_message_t &message)
 {
     if (_serial_node.empty()) {
-        Debug() << "Dev Path unknown";
+        LogErr() << "Dev Path unknown";
         return false;
     }
 
     if (_baudrate == 0) {
-        Debug() << "Baudrate unknown";
+        LogErr() << "Baudrate unknown";
         return false;
     }
 
@@ -143,7 +143,7 @@ bool SerialConnection::send_message(const mavlink_message_t &message)
     int send_len =  write(_fd, buffer, buffer_len);
 
     if (send_len != buffer_len) {
-        Debug() << "write failure: " << GET_ERROR(errno);
+        LogErr() << "write failure: " << GET_ERROR(errno);
         return false;
     }
 
@@ -158,7 +158,7 @@ void SerialConnection::receive(SerialConnection *parent)
     while (!parent->_should_exit) {
         int recv_len = read(parent->_fd, buffer, sizeof(buffer));
         if (recv_len < -1) {
-            Debug() << "read failure: " << GET_ERROR(errno);
+            LogErr() << "read failure: " << GET_ERROR(errno);
         }
         if (recv_len > (int)sizeof(buffer) || recv_len == 0) {
             continue;

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -67,7 +67,7 @@ DroneCore::ConnectionResult TcpConnection::setup_port()
 #ifdef WINDOWS
     WSADATA wsa;
     if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
-        Debug() << "Error: Winsock failed, error: %d", WSAGetLastError();
+        LogErr() << "Error: Winsock failed, error: %d", WSAGetLastError();
         return DroneCore::ConnectionResult::SOCKET_ERROR;
     }
 #endif
@@ -75,7 +75,7 @@ DroneCore::ConnectionResult TcpConnection::setup_port()
     _socket_fd = socket(AF_INET, SOCK_STREAM, 0);
 
     if (_socket_fd < 0) {
-        Debug() << "socket error" << GET_ERROR(errno);
+        LogErr() << "socket error" << GET_ERROR(errno);
         return DroneCore::ConnectionResult::SOCKET_ERROR;
     }
 
@@ -85,7 +85,7 @@ DroneCore::ConnectionResult TcpConnection::setup_port()
     remote_addr.sin_addr.s_addr = inet_addr(_remote_ip.c_str());
 
     if (connect(_socket_fd, (sockaddr *)&remote_addr, sizeof(struct sockaddr_in)) < 0) {
-        Debug() << "connect error: " << GET_ERROR(errno);
+        LogErr() << "connect error: " << GET_ERROR(errno);
         return DroneCore::ConnectionResult::SOCKET_CONNECTION_ERROR;
     }
 
@@ -131,12 +131,12 @@ DroneCore::ConnectionResult TcpConnection::stop()
 bool TcpConnection::send_message(const mavlink_message_t &message)
 {
     if (_remote_ip.empty()) {
-        Debug() << "Remote IP unknown";
+        LogErr() << "Remote IP unknown";
         return false;
     }
 
     if (_remote_port_number == 0) {
-        Debug() << "Remote port unknown";
+        LogErr() << "Remote port unknown";
         return false;
     }
 
@@ -158,7 +158,7 @@ bool TcpConnection::send_message(const mavlink_message_t &message)
                           (const sockaddr *)&dest_addr, sizeof(dest_addr));
 
     if (send_len != buffer_len) {
-        Debug() << "sendto failure: " << GET_ERROR(errno);
+        LogErr() << "sendto failure: " << GET_ERROR(errno);
         return false;
     }
     return true;
@@ -182,7 +182,7 @@ void TcpConnection::receive(TcpConnection *parent)
         if (recv_len < 0) {
             // This happens on desctruction when close(_socket_fd) is called,
             // therefore be quiet.
-            //Debug() << "recvfrom error: " << GET_ERROR(errno);
+            //LogErr() << "recvfrom error: " << GET_ERROR(errno);
             continue;
         }
 

--- a/core/udp_connection.cpp
+++ b/core/udp_connection.cpp
@@ -1,5 +1,6 @@
 #include "udp_connection.h"
 #include "global_include.h"
+#include "log.h"
 
 #ifndef WINDOWS
 #include <netinet/in.h>

--- a/integration_tests/async_hover.cpp
+++ b/integration_tests/async_hover.cpp
@@ -56,14 +56,14 @@ TEST_F(SitlTest, ActionAsyncHover)
 
 void receive_result(Action::Result result)
 {
-    std::cout << "got result: " << unsigned(result) << std::endl;
+    LogDebug() << "got result: " << unsigned(result);
     EXPECT_EQ(result, Action::Result::SUCCESS);
 }
 
 void receive_health_all_ok(bool all_ok)
 {
     if (all_ok && !_all_ok) {
-        std::cout << "we're ready, let's go" << std::endl;
+        LogDebug() << "we're ready, let's go";
         _all_ok = true;
     }
 }

--- a/integration_tests/curl.cpp
+++ b/integration_tests/curl.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <chrono>
 #include <thread>
+#include <gtest/gtest.h>
 
 using namespace dronecore;
 

--- a/integration_tests/mission_change_speed.cpp
+++ b/integration_tests/mission_change_speed.cpp
@@ -78,8 +78,8 @@ TEST_F(SitlTest, MissionChangeSpeed)
                 std::this_thread::sleep_for(std::chrono::seconds(6));
                 const float speed_correct = speeds[_current_item - 1];
                 const float speed_actual = current_speed(device);
-                Debug() << "speed check, should be: " << speed_correct << " m/s, "
-                        << "actually: " << speed_actual << " m/s";
+                LogWarn() << "speed check, should be: " << speed_correct << " m/s, "
+                          << "actually: " << speed_actual << " m/s";
                 EXPECT_GT(speed_actual, speed_correct - 1.0f);
                 EXPECT_LT(speed_actual, speed_correct + 1.0f);
             }
@@ -87,7 +87,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    Debug() << "mission done";
+    LogInfo() << "mission done";
 
     result = device.action().return_to_launch();
     ASSERT_EQ(result, Action::Result::SUCCESS);

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -407,7 +407,7 @@ void ActionImpl::set_max_speed(float speed_m_s)
 void ActionImpl::receive_max_speed_result(bool success, float new_speed_m_s)
 {
     if (!success) {
-        Debug() << "setting max speed param failed";
+        LogErr() << "setting max speed param failed";
         return;
     }
     _max_speed_m_s = new_speed_m_s;

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -81,12 +81,12 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
     if (mission_request_int.target_system != _parent->get_own_system_id() &&
         mission_request_int.target_component != _parent->get_own_component_id()) {
 
-        Debug() << "Ignore mission request int that is not for us";
+        LogWarn() << "Ignore mission request int that is not for us";
         return;
     }
 
     if (_activity != Activity::SET_MISSION) {
-        Debug() << "Ignoring mission request int, not active";
+        LogWarn() << "Ignoring mission request int, not active";
         return;
     }
 
@@ -100,7 +100,7 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
 void MissionImpl::process_mission_ack(const mavlink_message_t &message)
 {
     if (_activity != Activity::SET_MISSION) {
-        Debug() << "Error: not sure how to process Mission ack.";
+        LogWarn() << "Error: not sure how to process Mission ack.";
         return;
     }
 
@@ -110,7 +110,7 @@ void MissionImpl::process_mission_ack(const mavlink_message_t &message)
     if (mission_ack.target_system != _parent->get_own_system_id() &&
         mission_ack.target_component != _parent->get_own_component_id()) {
 
-        Debug() << "Ignore mission ack that is not for us";
+        LogWarn() << "Ignore mission ack that is not for us";
         return;
     }
 
@@ -125,13 +125,13 @@ void MissionImpl::process_mission_ack(const mavlink_message_t &message)
         _last_reached_mavlink_mission_item = -1;
 
         report_mission_result(_result_callback, Mission::Result::SUCCESS);
-        Debug() << "Sucess, done";
+        LogInfo() << "Sucess, done";
         _activity = Activity::NONE;
     } else if (mission_ack.type == MAV_MISSION_NO_SPACE) {
-        Debug() << "Error: too many waypoints: " << int(mission_ack.type);
+        LogErr() << "Error: too many waypoints: " << int(mission_ack.type);
         report_mission_result(_result_callback, Mission::Result::TOO_MANY_MISSION_ITEMS);
     } else {
-        Debug() << "Error: unknown mission ack: " << int(mission_ack.type);
+        LogErr() << "Error: unknown mission ack: " << int(mission_ack.type);
         report_mission_result(_result_callback, Mission::Result::ERROR);
     }
 
@@ -177,7 +177,7 @@ void MissionImpl::send_mission_async(const std::vector<std::shared_ptr<MissionIt
     }
 
     if (!_parent->target_supports_mission_int()) {
-        Debug() << "Mission int messages not supported";
+        LogWarn() << "Mission int messages not supported";
         report_mission_result(callback, Mission::Result::ERROR);
         return;
     }
@@ -367,7 +367,7 @@ void MissionImpl::assemble_mavlink_messages()
                     param1 = 0.0f; // all camera IDs
                     break;
                 default:
-                    Debug() << "Error: camera action not supported";
+                    LogErr() << "Error: camera action not supported";
                     break;
             }
 
@@ -406,7 +406,7 @@ void MissionImpl::assemble_mavlink_messages()
 
 void MissionImpl::timeout_happened()
 {
-    Debug() << "timeout happened";
+    LogErr() << "timeout happened";
     _activity = Activity::NONE;
 
     _last_set_current_mavlink_mission_item = -1;
@@ -523,9 +523,9 @@ void MissionImpl::set_current_mission_item_async(int current, Mission::result_ca
 
 void MissionImpl::send_mission_item(uint16_t seq)
 {
-    Debug() << "Send mission item " << int(seq);
+    LogDebug() << "Send mission item " << int(seq);
     if (seq >= _mavlink_mission_item_messages.size()) {
-        Debug() << "Mission item requested out of bounds.";
+        LogErr() << "Mission item requested out of bounds.";
         return;
     }
 
@@ -547,7 +547,7 @@ void MissionImpl::report_mission_result(const Mission::result_callback_t &callba
                                         Mission::Result result)
 {
     if (callback == nullptr) {
-        Debug() << "Callback is not set";
+        LogWarn() << "Callback is not set";
         return;
     }
 

--- a/plugins/mission/mission_item_impl.cpp
+++ b/plugins/mission/mission_item_impl.cpp
@@ -50,7 +50,7 @@ void MissionItemImpl::set_camera_photo_interval(double interval_s)
     if (interval_s > 0.0) {
         _camera_photo_interval_s = interval_s;
     } else {
-        Debug() << "Invalid interval argument";
+        LogWarn() << "Invalid interval argument";
     }
 }
 

--- a/plugins/mission/mission_item_impl.cpp
+++ b/plugins/mission/mission_item_impl.cpp
@@ -1,5 +1,6 @@
 #include "mission_item_impl.h"
 #include "global_include.h"
+#include "log.h"
 #include <cmath>
 
 namespace dronecore {

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -142,7 +142,7 @@ void OffboardImpl::report_offboard_result(const Offboard::result_callback_t &cal
                                           Offboard::Result result)
 {
     if (callback == nullptr) {
-        Debug() << "Callback is not set";
+        LogWarn() << "Callback is not set";
         return;
     }
 

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -520,7 +520,7 @@ Telemetry::FlightMode TelemetryImpl::to_flight_mode_from_custom_mode(uint32_t cu
 void TelemetryImpl::receive_param_cal_gyro(bool success, int value)
 {
     if (!success) {
-        Debug() << "Error: Param for gyro cal failed.";
+        LogErr() << "Error: Param for gyro cal failed.";
         return;
     }
 
@@ -531,7 +531,7 @@ void TelemetryImpl::receive_param_cal_gyro(bool success, int value)
 void TelemetryImpl::receive_param_cal_accel(bool success, int value)
 {
     if (!success) {
-        Debug() << "Error: Param for accel cal failed.";
+        LogErr() << "Error: Param for accel cal failed.";
         return;
     }
 
@@ -542,7 +542,7 @@ void TelemetryImpl::receive_param_cal_accel(bool success, int value)
 void TelemetryImpl::receive_param_cal_mag(bool success, int value)
 {
     if (!success) {
-        Debug() << "Error: Param for mag cal failed.";
+        LogErr() << "Error: Param for mag cal failed.";
         return;
     }
 
@@ -554,7 +554,7 @@ void TelemetryImpl::receive_param_cal_mag(bool success, int value)
 void TelemetryImpl::receive_param_cal_level(bool success, float value)
 {
     if (!success) {
-        Debug() << "Error: Param for level cal failed.";
+        LogErr() << "Error: Param for level cal failed.";
         return;
     }
 


### PR DESCRIPTION
This improves the log output. Instead of only one `Debug()` printf for everything, there are now proper log levels: `LogDebug()`, `LogInfo()`, `LogWarn()`, `LogErr()`.

It also adds file name and file number to the printfs which should help to figure out where stuff went wrong.