### PR TITLE
mavlink system_id instead of UUID for devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ add_library(dronecore STATIC
     core/plugin_impl_base.cpp
     core/curl_wrapper.cpp
     core/http_loader.cpp
+    core/timeout_handler.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/core/device_plugin_container.cpp
     ${plugin_source_files}
 )
@@ -151,6 +152,7 @@ if(NOT IOS AND NOT ANDROID)
         core/mavlink_channels_test.cpp
         core/unittests_main.cpp
         core/http_loader_test.cpp
+        core/timeout_handler_test.cpp
         ${plugin_unittest_source_files}
         ${unit_tests_src}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
 if(NOT MSVC)
     # Clang and GCC
     # We are not using exceptions to make it easier to write wrappers.
-    add_definitions("-std=c++11 -Wall -Wextra -Werror -fno-exceptions")
+    add_definitions("-std=c++11 -Wall -Wextra -Werror -fno-exceptions -Wshadow")
     set(platform_libs "pthread")
     set(curl_lib "curl")
 else()

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -7,8 +7,6 @@
 namespace dronecore {
 
 using namespace std::placeholders; // for `_1`
-std::mutex DeviceImpl::_last_heartbeat_reiceved_time_mutex;
-dl_time_t DeviceImpl::_last_heartbeat_received_time;
 
 DeviceImpl::DeviceImpl(DroneCoreImpl *parent,
                        uint8_t target_system_id) :
@@ -100,18 +98,21 @@ void DeviceImpl::process_heartbeat(const mavlink_message_t &message)
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
 
-    /* If we don't know the UUID yet, or we had a timeout, we want to check that the
-     * UUID is still the same. */
-    if (_target_uuid == 0 || !_heartbeats_arriving) {
-        request_autopilot_version();
-    }
-
     _armed = ((heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED) ? true : false);
 
-    _heartbeats_arriving = true;
+    if (!_connected) {
+        _connected = true;
+        _parent->notify_on_discover(_target_system_id);
 
-    std::lock_guard<std::mutex> lock(_last_heartbeat_reiceved_time_mutex);
-    _last_heartbeat_received_time = steady_time();
+        // Let's check some flags on reconnect.
+        request_autopilot_version();
+
+        register_timeout_handler(std::bind(&DeviceImpl::heartbeats_timed_out, this),
+                                 _HEARTBEAT_TIMEOUT_S,
+                                 &_heartbeat_timeout_cookie);
+    } else {
+        refresh_timeout_handler(_heartbeat_timeout_cookie);
+    }
 }
 
 void DeviceImpl::process_autopilot_version(const mavlink_message_t &message)
@@ -127,23 +128,13 @@ void DeviceImpl::process_autopilot_version(const mavlink_message_t &message)
     _target_supports_mission_int =
         ((autopilot_version.capabilities & MAV_PROTOCOL_CAPABILITY_MISSION_INT) ? true : false);
 
-    if (_target_uuid == 0) {
-        _target_uuid = autopilot_version.uid;
-        _parent->notify_on_discover(_target_uuid);
+    // TODO: check UUID for conflict.
+}
 
-    } else if (_target_uuid == autopilot_version.uid) {
-        if (!_heartbeats_arriving) {
-            // It looks like the vehicle has reconnected, let's accept it again.
-            _parent->notify_on_discover(_target_uuid);
-        } else {
-            // This means we just got a autopilot version message but we don't need it
-            // or didn't request it.
-        }
-
-    } else {
-        // TODO: this is bad, we should raise a flag to invalidate device.
-        Debug() << "Error: UUID changed";
-    }
+void DeviceImpl::heartbeats_timed_out()
+{
+    _connected = false;
+    _parent->notify_on_timeout(_target_system_id);
 }
 
 void DeviceImpl::device_thread(DeviceImpl *self)
@@ -156,16 +147,17 @@ void DeviceImpl::device_thread(DeviceImpl *self)
             send_heartbeat(self);
             last_time = steady_time();
         }
-        check_timeouts(self);
-        check_heartbeat_timeout(self);
+
+        self->_timeout_handler.run_once();
         self->_params.do_work();
         self->_commands.do_work();
-        if (self->_heartbeats_arriving) {
+
+        if (self->_connected) {
             // Work fairly fast if we're connected.
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         } else {
             // Be less aggressive when unconnected.
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }
 }
@@ -178,26 +170,6 @@ void DeviceImpl::send_heartbeat(DeviceImpl *self)
     self->send_message(message);
 }
 
-void DeviceImpl::check_timeouts(DeviceImpl *self)
-{
-    self->_timeout_handler.run_once();
-}
-
-void DeviceImpl::check_heartbeat_timeout(DeviceImpl *self)
-{
-    std::lock_guard<std::mutex> lock(_last_heartbeat_reiceved_time_mutex);
-    if (elapsed_since_s(self->_last_heartbeat_received_time) > DeviceImpl::_HEARTBEAT_TIMEOUT_S) {
-        if (self->_heartbeats_arriving) {
-            self->_parent->notify_on_timeout(self->_target_uuid);
-            self->_heartbeats_arriving = false;
-        }
-    } else {
-        if (!self->_heartbeats_arriving) {
-            self->_heartbeats_arriving = true;
-        }
-    }
-}
-
 bool DeviceImpl::send_message(const mavlink_message_t &message)
 {
     return _parent->send_message(message);
@@ -205,16 +177,13 @@ bool DeviceImpl::send_message(const mavlink_message_t &message)
 
 void DeviceImpl::request_autopilot_version()
 {
+    // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
     send_command_with_ack_async(
         MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
         MavlinkCommands::Params {1.0f, NAN, NAN, NAN, NAN, NAN, NAN},
         nullptr,
-        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
-}
-
-uint64_t DeviceImpl::get_target_uuid() const
-{
-    return _target_uuid;
+        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT
+    );
 }
 
 uint8_t DeviceImpl::get_target_system_id() const

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -60,7 +60,6 @@ public:
 
     void request_autopilot_version();
 
-    uint64_t get_target_uuid() const;
     uint8_t get_target_system_id() const;
     uint8_t get_target_component_id() const;
 
@@ -95,11 +94,10 @@ private:
 
     void process_heartbeat(const mavlink_message_t &message);
     void process_autopilot_version(const mavlink_message_t &message);
+    void heartbeats_timed_out();
 
     static void device_thread(DeviceImpl *self);
     static void send_heartbeat(DeviceImpl *self);
-    static void check_timeouts(DeviceImpl *self);
-    static void check_heartbeat_timeout(DeviceImpl *self);
 
     static void receive_float_param(bool success, MavlinkParameters::ParamValue value,
                                     get_param_float_callback_t callback);
@@ -119,7 +117,7 @@ private:
 
     // The component ID is hardcoded for now.
     uint8_t _target_component_id = MAV_COMP_ID_AUTOPILOT1;
-    uint64_t _target_uuid {0};
+
     bool _target_supports_mission_int {false};
     bool _armed {false};
 
@@ -134,12 +132,10 @@ private:
     static constexpr uint8_t _own_system_id = 0;
     static constexpr uint8_t _own_component_id = MAV_COMP_ID_SYSTEM_CONTROL;
 
-    static std::mutex _last_heartbeat_reiceved_time_mutex;
-    static dl_time_t _last_heartbeat_received_time;
-
     static constexpr double _HEARTBEAT_TIMEOUT_S = 3.0;
 
-    std::atomic<bool> _heartbeats_arriving {false};
+    std::atomic<bool> _connected {false};
+    void *_heartbeat_timeout_cookie = nullptr;
 
     static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
 

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -92,9 +92,9 @@ DroneCore::ConnectionResult DroneCore::add_serial_connection(std::string dev_pat
 #endif
 }
 
-const std::vector<uint64_t> &DroneCore::device_uuids() const
+const std::vector<uint8_t> &DroneCore::device_system_ids() const
 {
-    return _impl->get_device_uuids();
+    return _impl->get_device_system_ids();
 }
 
 Device &DroneCore::device() const
@@ -102,9 +102,9 @@ Device &DroneCore::device() const
     return _impl->get_device();
 }
 
-Device &DroneCore::device(uint64_t uuid) const
+Device &DroneCore::device(uint8_t system_id) const
 {
-    return _impl->get_device(uuid);
+    return _impl->get_device(system_id);
 }
 
 void DroneCore::register_on_discover(event_callback_t callback)

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -115,27 +115,27 @@ void DroneCoreImpl::add_connection(Connection *new_connection)
     _connections.push_back(new_connection);
 }
 
-const std::vector<uint64_t> &DroneCoreImpl::get_device_uuids() const
+const std::vector<uint8_t> &DroneCoreImpl::get_device_system_ids() const
 {
     // This needs to survive the scope but we need to clean it up.
-    static std::vector<uint64_t> uuids = {};
-    uuids.clear();
+    static std::vector<uint8_t> system_ids = {};
+    system_ids.clear();
 
     for (auto it = _device_impls.begin(); it != _device_impls.end(); ++it) {
-        uint64_t uuid = it->second->get_target_uuid();
-        if (uuid != 0) {
-            uuids.push_back(uuid);
+        uint8_t system_id = it->second->get_target_system_id();
+        if (system_id != 0) {
+            system_ids.push_back(system_id);
         }
     }
 
-    return uuids;
+    return system_ids;
 }
 
 Device &DroneCoreImpl::get_device()
 {
     {
         std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
-        // In get_device withoiut uuid, we expect to have only
+        // In get_device without system ID, we expect to have only
         // one device conneted.
         if (_device_impls.size() == 1) {
             return *(_devices.at(_device_impls.begin()->first));
@@ -161,27 +161,27 @@ Device &DroneCoreImpl::get_device()
     }
 }
 
-Device &DroneCoreImpl::get_device(uint64_t uuid)
+Device &DroneCoreImpl::get_device(uint8_t system_id)
 {
     {
         std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
         // TODO: make a cache map for this.
         for (auto it = _device_impls.begin(); it != _device_impls.end(); ++it) {
-            if (it->second->get_target_uuid() == uuid) {
+            if (it->second->get_target_system_id() == system_id) {
                 return *(_devices.at(it->first));
             }
         }
     }
 
-    // We have not found a device with this UUID.
+    // We have not found a device with this system ID.
     // TODO: this is an error condition that we ought to handle properly.
-    Debug() << "device with UUID: " << uuid << " not found";
+    Debug() << "device with system ID: " << system_id << " not found";
 
     // Create a dummy
-    uint8_t system_id = 0;
-    create_device_if_not_existing(system_id);
+    uint8_t dummy_system_id = 0;
+    create_device_if_not_existing(dummy_system_id);
 
-    return *_devices[system_id];
+    return *_devices[dummy_system_id];
 }
 
 void DroneCoreImpl::create_device_if_not_existing(uint8_t system_id)
@@ -207,17 +207,19 @@ void DroneCoreImpl::create_device_if_not_existing(uint8_t system_id)
     _devices.insert(std::pair<uint8_t, Device *>(system_id, new_device));
 }
 
-void DroneCoreImpl::notify_on_discover(uint64_t uuid)
+void DroneCoreImpl::notify_on_discover(uint8_t system_id)
 {
+    Debug() << "Discovered " << (int)system_id;
     if (_on_discover_callback != nullptr) {
-        _on_discover_callback(uuid);
+        _on_discover_callback(system_id);
     }
 }
 
-void DroneCoreImpl::notify_on_timeout(uint64_t uuid)
+void DroneCoreImpl::notify_on_timeout(uint8_t system_id)
 {
+    Debug() << "Lost " << (int)system_id;
     if (_on_timeout_callback != nullptr) {
-        _on_timeout_callback(uuid);
+        _on_timeout_callback(system_id);
     }
 }
 

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -136,7 +136,7 @@ Device &DroneCoreImpl::get_device()
     {
         std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
         // In get_device without system ID, we expect to have only
-        // one device conneted.
+        // one device connected.
         if (_device_impls.size() == 1) {
             return *(_devices.at(_device_impls.begin()->first));
         }

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -22,15 +22,15 @@ public:
     bool send_message(const mavlink_message_t &message);
     void add_connection(Connection *connection);
 
-    const std::vector<uint64_t> &get_device_uuids() const;
+    const std::vector<uint8_t> &get_device_system_ids() const;
     Device &get_device();
-    Device &get_device(uint64_t uuid);
+    Device &get_device(uint8_t system_id);
 
     void register_on_discover(DroneCore::event_callback_t callback);
     void register_on_timeout(DroneCore::event_callback_t callback);
 
-    void notify_on_discover(uint64_t uuid);
-    void notify_on_timeout(uint64_t uuid);
+    void notify_on_discover(uint8_t system_id);
+    void notify_on_timeout(uint8_t system_id);
 
 private:
     void create_device_if_not_existing(uint8_t system_id);

--- a/core/http_loader_test.cpp
+++ b/core/http_loader_test.cpp
@@ -86,7 +86,7 @@ protected:
                                                   const std::string &url, const std::string &path)
     {
         EXPECT_CALL(*curl_wrapper, download_file_to_path(url, path, _))
-        .WillOnce(Invoke([&](const std::string &/*url*/, const std::string & path,
+        .WillOnce(Invoke([&](const std::string &/*url*/, const std::string & got_path,
         const progress_callback_t &progress_callback) {
             for (size_t i = 0; i <= 100; i++) {
                 if (progress_callback != nullptr) {
@@ -94,7 +94,7 @@ protected:
                 }
             }
 
-            write_file(path, "downloaded file content\n");
+            write_file(got_path, "downloaded file content\n");
 
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
@@ -120,10 +120,10 @@ TEST_F(HttpLoaderTest, HttpLoader_DownloadAsync_OneBad)
     progress_callback_t progress = [&callback_results_progress,
                                     &callback_finished_counter,
                                     &callback_error_counter]
-    (int progress, Status status, CURLcode curl_code) -> int {
+    (int got_progress, Status status, CURLcode curl_code) -> int {
         if (status == Status::Downloading)
         {
-            callback_results_progress.push_back(progress);
+            callback_results_progress.push_back(got_progress);
         } else if (status == Status::Error && curl_code == CURLcode::CURLE_COULDNT_RESOLVE_HOST)
         {
             callback_error_counter++;
@@ -168,10 +168,10 @@ TEST_F(HttpLoaderTest, HttpLoader_DownloadAsync_AllGood)
     progress_callback_t progress = [&callback_results_progress,
                                     &callback_finished_counter,
                                     &callback_error_counter]
-    (int progress, Status status, CURLcode curl_code) -> int {
+    (int got_progress, Status status, CURLcode curl_code) -> int {
         if (status == Status::Downloading)
         {
-            callback_results_progress.push_back(progress);
+            callback_results_progress.push_back(got_progress);
         } else if (status == Status::Error && curl_code == CURLcode::CURLE_COULDNT_RESOLVE_HOST)
         {
             callback_error_counter++;

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -76,6 +76,8 @@ private:
     DeviceImpl *_parent;
     LockedQueue<Work> _work_queue {};
 
+    void *_timeout_cookie = nullptr;
+
 #ifdef NO_PROMISES
     std::mutex _promise_mutex {};
     enum class PromiseState {

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -29,7 +29,11 @@ void MavlinkParameters::set_param_async(const std::string &name,
                                         set_param_callback_t callback,
                                         bool extended)
 {
-    // Debug() << "setting param " << name << " to " << value.get_int();
+    // if (value.is_float()) {
+    //     Debug() << "setting param " << name << " to " << value.get_float();
+    // } else {
+    //     Debug() << "setting param " << name << " to " << value.get_int();
+    // }
 
     if (name.size() > PARAM_ID_LEN) {
         Debug() << "Error: param name too long";

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -119,7 +119,6 @@ void MavlinkParameters::do_work()
                                            param_value_buf,
                                            work.param_value.get_mav_param_type());
         } else {
-            mavlink_message_t message = {};
             mavlink_msg_param_set_pack(_parent->get_own_system_id(),
                                        _parent->get_own_component_id(),
                                        &message,

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -140,7 +140,7 @@ void MavlinkParameters::do_work()
         // We want to get notified if a timeout happens
         _parent->register_timeout_handler(std::bind(&MavlinkParameters::receive_timeout, this),
                                           0.5,
-                                          this);
+                                          &_timeout_cookie);
 
     } else if (_get_param_queue.size() > 0) {
 
@@ -197,7 +197,7 @@ void MavlinkParameters::do_work()
         // We want to get notified if a timeout happens
         _parent->register_timeout_handler(std::bind(&MavlinkParameters::receive_timeout, this),
                                           0.5,
-                                          this);
+                                          &_timeout_cookie);
     }
 }
 
@@ -228,7 +228,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
                     work.callback(true, value);
                 }
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _get_param_queue.pop_front();
             }
@@ -250,7 +250,7 @@ void MavlinkParameters::process_param_value(const mavlink_message_t &message)
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
@@ -284,7 +284,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
                     work.callback(true, value);
                 }
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _get_param_queue.pop_front();
             }
@@ -307,7 +307,7 @@ void MavlinkParameters::process_param_ext_value(const mavlink_message_t &message
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }
@@ -343,14 +343,14 @@ void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
 
             } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
 
                 // Reset timeout and wait again.
-                _parent->refresh_timeout_handler(this);
+                _parent->refresh_timeout_handler(_timeout_cookie);
 
             } else {
 
@@ -361,7 +361,7 @@ void MavlinkParameters::process_param_ext_ack(const mavlink_message_t &message)
                 }
 
                 _state = State::NONE;
-                _parent->unregister_timeout_handler(this);
+                _parent->unregister_timeout_handler(_timeout_cookie);
                 // Debug() << "time taken: " << elapsed_since_s(_last_request_time);
                 _set_param_queue.pop_front();
             }

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -118,6 +118,11 @@ public:
             return _int_value;
         }
 
+        bool is_float() const
+        {
+            return (_type == Type::FLOAT);
+        }
+
     private:
         float _float_value = NAN;
         int32_t _int_value = 0;

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -174,6 +174,8 @@ private:
     };
     LockedQueue<GetParamWork> _get_param_queue {};
 
+    void *_timeout_cookie = nullptr;
+
     // dl_time_t _last_request_time = {};
 };
 

--- a/core/timeout_handler.cpp
+++ b/core/timeout_handler.cpp
@@ -1,0 +1,83 @@
+#include "timeout_handler.h"
+
+namespace dronecore {
+
+TimeoutHandler::TimeoutHandler()
+{
+}
+
+TimeoutHandler::~TimeoutHandler()
+{
+}
+
+void TimeoutHandler::add(std::function<void()> callback, double duration_s, void **cookie)
+{
+    auto new_timeout = std::make_shared<Timeout>();
+    new_timeout->callback = callback;
+    new_timeout->time = steady_time_in_future(duration_s);
+    new_timeout->duration_s = duration_s;
+
+    void *new_cookie = static_cast<void *>(new_timeout.get());
+
+    {
+        std::lock_guard<std::mutex> lock(_timeouts_mutex);
+        _timeouts.insert(std::pair<void *, std::shared_ptr<Timeout>>(new_cookie, new_timeout));
+    }
+
+    if (cookie != nullptr) {
+        *cookie = new_cookie;
+    }
+}
+
+void TimeoutHandler::refresh(const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
+
+    auto it = _timeouts.find((void *)(cookie));
+    if (it != _timeouts.end()) {
+        dl_time_t future_time = steady_time_in_future(it->second->duration_s);
+        it->second->time = future_time;
+    }
+}
+
+void TimeoutHandler::remove(const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
+
+    auto it = _timeouts.find((void *)cookie);
+    if (it != _timeouts.end()) {
+        _timeouts.erase((void *)cookie);
+    }
+}
+
+void TimeoutHandler::run_once()
+{
+    _timeouts_mutex.lock();
+
+    dl_time_t now = steady_time();
+
+    for (auto it = _timeouts.begin(); it != _timeouts.end(); /* no ++it */) {
+
+        // If time is passed, call timeout callback.
+        if (it->second->time < now) {
+
+            if (it->second->callback) {
+
+                // Unlock while we callback because it might in turn want to add timeouts.
+                std::function<void()> callback = it->second->callback;
+                _timeouts_mutex.unlock();
+                callback();
+                _timeouts_mutex.lock();
+            }
+
+            // Self-destruct before calling to avoid locking issues.
+            _timeouts.erase(it++);
+
+        } else {
+            ++it;
+        }
+    }
+    _timeouts_mutex.unlock();
+}
+
+} // namespace dronecore

--- a/core/timeout_handler.h
+++ b/core/timeout_handler.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <mutex>
+#include <memory>
+#include <functional>
+#include <map>
+#include "global_include.h"
+
+namespace dronecore {
+
+class TimeoutHandler
+{
+public:
+    TimeoutHandler();
+    ~TimeoutHandler();
+
+    // delete copy and move constructors and assign operators
+    TimeoutHandler(TimeoutHandler const &) = delete;            // Copy construct
+    TimeoutHandler(TimeoutHandler &&) = delete;                 // Move construct
+    TimeoutHandler &operator=(TimeoutHandler const &) = delete; // Copy assign
+    TimeoutHandler &operator=(TimeoutHandler &&) = delete;      // Move assign
+
+    void add(std::function<void()> callback, double duration_s, void **cookie);
+    void refresh(const void *cookie);
+    void remove(const void *cookie);
+
+    void run_once();
+
+private:
+    struct Timeout {
+        std::function<void()> callback;
+        dl_time_t time;
+        double duration_s;
+    };
+
+    std::map<void *, std::shared_ptr<Timeout>> _timeouts {};
+    std::mutex _timeouts_mutex {};
+};
+
+} // namespace dronecore

--- a/core/timeout_handler_test.cpp
+++ b/core/timeout_handler_test.cpp
@@ -1,0 +1,118 @@
+#include "timeout_handler.h"
+#include <gtest/gtest.h>
+#include <atomic>
+
+using namespace dronecore;
+
+TEST(TimeoutHandler, Timeout)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+
+    UNUSED(cookie);
+}
+
+TEST(TimeoutHandler, TimeoutNoCookie)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    // This time we supply nullptr and don't want a cookie.
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, nullptr);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+}
+
+TEST(TimeoutHandler, CallTimeoutInTimeoutCallback)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie1 = nullptr;
+    void *cookie2 = nullptr;
+    th.add([&th, &timeout_happened, &cookie2]() {
+        timeout_happened = true;
+        // This tests the case where we want to set yet another timeout when we
+        // are called because of a timeout. This tests if there are no locking
+        // issues.
+        th.add([]() {
+        }, 5.0, &cookie2);
+    }, 0.5, &cookie1);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+
+    UNUSED(cookie1);
+    UNUSED(cookie2);
+}
+
+TEST(TimeoutHandler, TimeoutRefreshed)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(400));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    th.refresh(cookie);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+
+    UNUSED(cookie);
+}
+
+TEST(TimeoutHandler, TimeoutRemoved)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+    th.remove(cookie);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+}

--- a/example/fly_mission/fly_mission_dronecore.cpp
+++ b/example/fly_mission/fly_mission_dronecore.cpp
@@ -73,8 +73,8 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     std::cout << DRONECORE << "Waiting to discover device..." << std::endl;
-    dc.register_on_discover([&discovered_device](uint64_t uuid) {
-        std::cout << DRONECORE << "Discovered device with UUID: " << uuid << std::endl;
+    dc.register_on_discover([&discovered_device](uint8_t system_id) {
+        std::cout << DRONECORE << "Discovered device with system ID: " << (int)system_id << std::endl;
         discovered_device = true;
     });
 
@@ -85,9 +85,9 @@ int main(int /*argc*/, char ** /*argv*/)
         return 1;
     }
 
-    // We don't need to specifiy the UUID if it's only one device anyway.
+    // We don't need to specifiy the system ID if it's only one device anyway.
     // If there were multiple, we could specify it with:
-    // dc.device(uint64_t uuid);
+    // dc.device(uint8_t system_id);
     Device &device = dc.device();
     std::vector<std::shared_ptr<MissionItem>> mission_items;
 

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -31,8 +31,8 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     std::cout << "Waiting to discover device..." << std::endl;
-    dc.register_on_discover([&discovered_device](uint64_t uuid) {
-        std::cout << "Discovered device with UUID: " << uuid << std::endl;
+    dc.register_on_discover([&discovered_device](uint8_t system_id) {
+        std::cout << "Discovered device with system ID: " << (int)(system_id) << std::endl;
         discovered_device = true;
     });
 
@@ -44,9 +44,9 @@ int main(int /*argc*/, char ** /*argv*/)
         return 1;
     }
 
-    // We don't need to specify the UUID if it's only one device anyway.
+    // We don't need to specify the system ID if it's only one device anyway.
     // If there were multiple, we could specify it with:
-    // dc.device(uint64_t uuid);
+    // dc.device(uint8_t uuid);
     Device &device = dc.device();
 
     // We want to listen to the altitude of the drone at 1 Hz.

--- a/external_example/integration_tests/hello_world.cpp
+++ b/external_example/integration_tests/hello_world.cpp
@@ -16,8 +16,8 @@ TEST_F(SitlTest, ExternalExampleHello)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // One vehicle should have connected.
-    std::vector<uint64_t> uuids = dc.device_uuids();
-    EXPECT_EQ(uuids.size(), 1);
+    std::vector<uint8_t> system_ids = dc.device_system_ids();
+    EXPECT_EQ(system_ids.size(), 1);
 
     // Apparently it can say hello.
     dc.device().example().say_hello();

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -112,13 +112,13 @@ public:
     ConnectionResult add_serial_connection(std::string dev_path, int baudrate);
 
     /**
-     * @brief Get vector of device UUIDs.
+     * @brief Get vector of device system IDs.
      *
-     * This returns a vector of the UUIDs of all devices that have been discovered.
+     * This returns a vector of the system IDs of all devices that have been discovered.
      *
-     * @return A reference to the vector containing the UUIDs.
+     * @return A reference to the vector containing the system IDs.
      */
-    const std::vector<uint64_t> &device_uuids() const;
+    const std::vector<uint8_t> &device_system_ids() const;
 
     /**
      * @brief Get the first discovered device.
@@ -130,22 +130,32 @@ public:
     Device &device() const;
 
     /**
-     * @brief Get the device with the specified UUID.
+     * @brief Get the device with the specified system ID.
      *
-     * This returns a device for a given UUID if such a device has been discovered and a null
+     * This returns a device for a given system ID if such a device has been discovered and a null
      * device otherwise.
      *
-     * @param uuid UUID of device to get.
+     * @param system_id mavlink system ID of device to get.
      * @return A reference to the specified device.
      */
-    Device &device(uint64_t uuid) const;
+    Device &device(uint8_t system_id) const;
+
+
+    /**
+     * @brief Return true if a device is connected.
+     *
+     * This returns true if we have received heartbeats in the last 3 seconds.
+     * This interface presents the same information that you receive using the
+     * callbacks `register_on_discover` and `register_on_timeout`.
+     */
+    bool is_connected(uint8_t system_id) const;
 
     /**
      * @brief Callback type for discover and timeout notifications.
      *
-     * @param uuid UUID of device.
+     * @param system_id mavlink system ID of device.
      */
-    typedef std::function<void(uint64_t uuid)> event_callback_t;
+    typedef std::function<void(uint8_t system_id)> event_callback_t;
 
     /**
      * @brief Register callback for device discovery.

--- a/integration_tests/async_connect.cpp
+++ b/integration_tests/async_connect.cpp
@@ -8,10 +8,10 @@ using namespace std::placeholders; // for _1
 
 static bool _discovered_device = false;
 static bool _timeouted_device = false;
-static uint64_t _uuid = 0;
+static uint8_t _system_id = 0;
 
-void on_discover(uint64_t uuid);
-void on_timeout(uint64_t uuid);
+void on_discover(uint8_t system_id);
+void on_timeout(uint8_t system_id);
 
 TEST_F(SitlTest, AsyncConnect)
 {
@@ -39,20 +39,20 @@ TEST_F(SitlTest, AsyncConnect)
     }
 }
 
-void on_discover(uint64_t uuid)
+void on_discover(uint8_t system_id)
 {
-    std::cout << "Found device with UUID: " << uuid << std::endl;
+    std::cout << "Found device with system ID: " << (int)system_id << std::endl;
     _discovered_device = true;
-    _uuid = uuid;
-    // The UUID should not be 0.
-    EXPECT_NE(_uuid, 0);
+    _system_id = system_id;
+    // The system ID should not be 0.
+    EXPECT_NE(_system_id, 0);
 }
 
-void on_timeout(uint64_t uuid)
+void on_timeout(uint8_t system_id)
 {
-    std::cout << "Lost device with UUID: " << uuid << std::endl;
+    std::cout << "Lost device with system ID: " << (int)system_id << std::endl;
     _timeouted_device = true;
 
-    // The UUID should still be the same.
-    EXPECT_EQ(_uuid, uuid);
+    // The system ID should still be the same.
+    EXPECT_EQ(_system_id, system_id);
 }

--- a/integration_tests/curl.cpp
+++ b/integration_tests/curl.cpp
@@ -106,8 +106,8 @@ TEST_F(CurlTest, Curl_DownloadFile_ProgressFeedback_Success)
     CURLcode last_curl_code;
 
     auto progress = [&last_progress, &last_status, &last_curl_code]
-    (int progress, Status status, CURLcode curl_code) -> int {
-        last_progress = progress;
+    (int got_progress, Status status, CURLcode curl_code) -> int {
+        last_progress = got_progress;
         last_status = status;
         last_curl_code = curl_code;
         return 0;
@@ -132,8 +132,8 @@ TEST_F(CurlTest, Curl_DownloadFile_ProgressFeedback_COULDNT_RESOLVE_HOST)
     CURLcode last_curl_code;
 
     auto progress = [&last_progress, &last_status, &last_curl_code]
-    (int progress, Status status, CURLcode curl_code) -> int {
-        last_progress = progress;
+    (int got_progress, Status status, CURLcode curl_code) -> int {
+        last_progress = got_progress;
         last_status = status;
         last_curl_code = curl_code;
         return 0;

--- a/integration_tests/info.cpp
+++ b/integration_tests/info.cpp
@@ -4,7 +4,7 @@
 
 using namespace dronecore;
 
-static void on_discover(uint64_t uuid);
+static void on_discover(uint8_t system_id);
 static bool _discovered_device = false;
 
 TEST_F(SitlTest, Info)
@@ -48,8 +48,8 @@ TEST_F(SitlTest, Info)
     }
 }
 
-void on_discover(uint64_t uuid)
+void on_discover(uint8_t system_id)
 {
-    std::cout << "Found device with UUID: " << uuid << std::endl;
+    std::cout << "Found device with system ID: " << system_id << std::endl;
     _discovered_device = true;
 }

--- a/integration_tests/simple_connect.cpp
+++ b/integration_tests/simple_connect.cpp
@@ -17,14 +17,14 @@ TEST_F(SitlTest, TwoConnections)
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
-    std::vector<uint64_t> uuids = dc->device_uuids();
+    std::vector<uint8_t> system_ids = dc->device_system_ids();
 
-    for (auto it = uuids.begin(); it != uuids.end(); ++it) {
-        std::cout << "found device with UUID: " << *it << std::endl;
+    for (auto it = system_ids.begin(); it != system_ids.end(); ++it) {
+        std::cout << "found device with system ID: " << (int)(*it) << std::endl;
     }
 
-    ASSERT_EQ(uuids.size(), 1);
-    uint64_t uuid = uuids[0];
+    ASSERT_EQ(system_ids.size(), 1);
+    uint64_t system_id = system_ids[0];
 
     std::cout << "deleting it" << std::endl;
     delete dc;
@@ -36,10 +36,10 @@ TEST_F(SitlTest, TwoConnections)
     ASSERT_EQ(dc->add_udp_connection(14540), DroneCore::ConnectionResult::SUCCESS);
 
     std::this_thread::sleep_for(std::chrono::seconds(3));
-    uuids = dc->device_uuids();
+    system_ids = dc->device_system_ids();
 
-    ASSERT_EQ(uuids.size(), 1);
-    EXPECT_EQ(uuid, uuids[0]);
+    ASSERT_EQ(system_ids.size(), 1);
+    EXPECT_EQ(system_id, system_ids[0]);
 
     std::cout << "created and started yet again" << std::endl;
     std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/integration_tests/takeoff_and_kill.cpp
+++ b/integration_tests/takeoff_and_kill.cpp
@@ -6,8 +6,8 @@ using namespace std::placeholders; // for _1
 using namespace dronecore;
 
 static bool _discovered_device = false;
-static uint64_t _uuid = 0;
-static void on_discover(uint64_t uuid);
+static uint8_t _system_id = 0;
+static void on_discover(uint64_t system_id);
 
 static bool _received_arm_result = false;
 static bool _received_takeoff_result = false;
@@ -36,10 +36,10 @@ void receive_kill_result(Action::Result result)
 }
 
 
-void on_discover(uint64_t uuid)
+void on_discover(uint64_t system_id)
 {
-    std::cout << "Found device with UUID: " << uuid << std::endl;
-    _uuid = uuid;
+    std::cout << "Found device with system ID: " << system_id << std::endl;
+    _system_id = system_id;
     _discovered_device = true;
 }
 
@@ -52,25 +52,25 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
     std::this_thread::sleep_for(std::chrono::seconds(5));
     ASSERT_TRUE(_discovered_device);
 
-    while (!dc.device(_uuid).telemetry().health_all_ok()) {
+    while (!dc.device(_system_id).telemetry().health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    dc.device(_uuid).action().set_takeoff_altitude(0.5f);
+    dc.device(_system_id).action().set_takeoff_altitude(0.5f);
 
-    dc.device(_uuid).action().arm_async(std::bind(&receive_arm_result, _1));
+    dc.device(_system_id).action().arm_async(std::bind(&receive_arm_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_TRUE(_received_arm_result);
 
-    dc.device(_uuid).action().takeoff_async(std::bind(&receive_takeoff_result, _1));
+    dc.device(_system_id).action().takeoff_async(std::bind(&receive_takeoff_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_TRUE(_received_takeoff_result);
 
     bool reached_alt = false;
     // Wait up to 2.0s (combined 3s) to reach 0.3m.
     for (unsigned i = 0; i < 1000; ++i) {
-        if (dc.device(_uuid).telemetry().position().relative_altitude_m > 0.3f) {
+        if (dc.device(_system_id).telemetry().position().relative_altitude_m > 0.3f) {
             reached_alt = true;
             break;
         }
@@ -79,14 +79,14 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
     ASSERT_TRUE(reached_alt);
 
     // Kill it and hope it doesn't come down upside down, ready to fly again :)
-    dc.device(_uuid).action().kill_async(std::bind(&receive_kill_result, _1));
+    dc.device(_system_id).action().kill_async(std::bind(&receive_kill_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_TRUE(_received_kill_result);
 
     // It should be below 0.5m after having been killed
-    ASSERT_FALSE(dc.device(_uuid).telemetry().armed());
+    ASSERT_FALSE(dc.device(_system_id).telemetry().armed());
 
     // The land detector takes some time.
     std::this_thread::sleep_for(std::chrono::seconds(2));
-    ASSERT_FALSE(dc.device(_uuid).telemetry().in_air());
+    ASSERT_FALSE(dc.device(_system_id).telemetry().in_air());
 }

--- a/integration_tests/telemetry_async.cpp
+++ b/integration_tests/telemetry_async.cpp
@@ -47,19 +47,19 @@ TEST_F(SitlTest, TelemetryAsync)
 
     std::this_thread::sleep_for(std::chrono::seconds(3));
 
-    std::vector<uint64_t> uuids = dc.device_uuids();
+    std::vector<uint8_t> system_ids = dc.device_system_ids();
 
-    for (auto it = uuids.begin(); it != uuids.end(); ++it) {
-        std::cout << "found device with UUID: " << *it << std::endl;
+    for (auto it = system_ids.begin(); it != system_ids.end(); ++it) {
+        std::cout << "found device with system ID: " << *it << std::endl;
     }
 
-    ASSERT_EQ(uuids.size(), 1);
+    ASSERT_EQ(system_ids.size(), 1);
 
-    uint64_t uuid = uuids.at(0);
+    uint64_t system_id = system_ids.at(0);
 
     ASSERT_EQ(ret, DroneCore::ConnectionResult::SUCCESS);
 
-    Device &device = dc.device(uuid);
+    Device &device = dc.device(system_id);
 
     device.telemetry().set_rate_position_async(10.0, std::bind(&receive_result, _1));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -52,6 +52,8 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
 
     mavlink_msg_autopilot_version_decode(&message, &autopilot_version);
 
+    set_uuid(autopilot_version.uid);
+
     Info::Version version = {};
 
     version.flight_sw_major = (autopilot_version.flight_sw_version >> (8 * 3)) & 0xFF;
@@ -108,8 +110,16 @@ void InfoImpl::translate_binary_to_str(uint8_t *binary, unsigned binary_len,
 
 uint64_t InfoImpl::get_uuid() const
 {
-    return _parent->get_target_uuid();
+    std::lock_guard<std::mutex> lock(_uuid_mutex);
+    return _uuid;
 }
+
+void InfoImpl::set_uuid(uint64_t uuid)
+{
+    std::lock_guard<std::mutex> lock(_uuid_mutex);
+    _uuid = uuid;
+}
+
 
 bool InfoImpl::is_complete() const
 {

--- a/plugins/info/info_impl.h
+++ b/plugins/info/info_impl.h
@@ -22,15 +22,19 @@ public:
 
 private:
     void set_version(Info::Version version);
+    void set_uuid(uint64_t uuid);
 
     void process_heartbeat(const mavlink_message_t &message);
     void process_autopilot_version(const mavlink_message_t &message);
 
-    mutable std::mutex _version_mutex;
-    Info::Version _version = {};
+    mutable std::mutex _version_mutex {};
+    Info::Version _version {};
 
     static void translate_binary_to_str(uint8_t *binary, unsigned binary_len,
                                         char *str, unsigned str_len);
+
+    mutable std::mutex _uuid_mutex {};
+    uint64_t _uuid = 0;
 };
 
 } // namespace dronecore

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -88,6 +88,8 @@ private:
     static constexpr uint8_t PX4_CUSTOM_MAIN_MODE_AUTO = 4;
     static constexpr uint8_t PX4_CUSTOM_SUB_MODE_AUTO_LOITER = 3;
     static constexpr uint8_t PX4_CUSTOM_SUB_MODE_AUTO_MISSION = 4;
+
+    void *_timeout_cookie = nullptr;
 };
 
 //static std::function<void(MavlinkCommands::Result)> empty_callback;

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -92,7 +92,8 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
 
     _result_callback = callback;
 
-    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0, this);
+    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0,
+                                      &_timeout_cookie);
 }
 
 void OffboardImpl::stop_async(Offboard::result_callback_t callback)
@@ -117,14 +118,15 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
 
     _result_callback = callback;
 
-    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0, this);
+    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0,
+                                      &_timeout_cookie);
 }
 
 void OffboardImpl::receive_command_result(MavlinkCommands::Result result,
                                           const Offboard::result_callback_t &callback)
 {
     // We got a command back, so we can get rid of the timeout handler.
-    _parent->unregister_timeout_handler(this);
+    _parent->unregister_timeout_handler(_timeout_cookie);
 
     Offboard::Result offboard_result = offboard_result_from_command_result(result);
 

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -36,11 +36,12 @@ private:
     static Offboard::Result offboard_result_from_command_result(
         MavlinkCommands::Result result);
 
-
     void timeout_happened();
 
     bool _offboard_mode_active;
     Offboard::result_callback_t _result_callback;
+
+    void *_timeout_cookie = nullptr;
 };
 
 } // namespace dronecore

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -603,14 +603,14 @@ bool TelemetryImpl::armed() const
     return _armed;
 }
 
-void TelemetryImpl::set_in_air(bool in_air)
+void TelemetryImpl::set_in_air(bool in_air_new)
 {
-    _in_air = in_air;
+    _in_air = in_air_new;
 }
 
-void TelemetryImpl::set_armed(bool armed)
+void TelemetryImpl::set_armed(bool armed_new)
 {
-    _armed = armed;
+    _armed = armed_new;
 }
 
 Telemetry::Quaternion TelemetryImpl::get_attitude_quaternion() const

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -96,7 +96,7 @@ void TelemetryImpl::init()
         std::bind(&TelemetryImpl::process_rc_channels, this, _1), (void *)this);
 
     _parent->register_timeout_handler(
-        std::bind(&TelemetryImpl::receive_rc_channels_timeout, this), 1.0, (const void *)this);
+        std::bind(&TelemetryImpl::receive_rc_channels_timeout, this), 1.0, &_timeout_cookie);
 
     // FIXME: The calibration check should eventually be better than this.
     //        For now, we just do the same as QGC does.
@@ -484,7 +484,7 @@ void TelemetryImpl::process_rc_channels(const mavlink_message_t &message)
     bool rc_ok = (rc_channels.chancount > 0);
     set_rc_status(rc_ok, rc_channels.rssi);
 
-    _parent->refresh_timeout_handler(this);
+    _parent->refresh_timeout_handler(_timeout_cookie);
 }
 
 Telemetry::FlightMode TelemetryImpl::to_flight_mode_from_custom_mode(uint32_t custom_mode)

--- a/plugins/telemetry/telemetry_impl.h
+++ b/plugins/telemetry/telemetry_impl.h
@@ -181,6 +181,8 @@ private:
     // the faster between the two.
     double _ground_speed_ned_rate_hz;
     double _position_rate_hz;
+
+    void *_timeout_cookie = nullptr;
 };
 
 } // namespace dronecore


### PR DESCRIPTION
The problem is that not all mavlink devices support the
AUTOPILOT_VERSION.uid field and therefore won't connect and be
addressable properly unless we switch from UUIDs to the mavlink system
ID.

Also, the UUID in fact gave us a wrong sense of security because when
communicating with a device we still use the system ID and not the UUID
anyway.