### PR TITLE
Fallback to mavlink system ID if no UUID available

### DIFF
--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -196,6 +196,11 @@ bool DeviceImpl::send_message(const mavlink_message_t &message)
 
 void DeviceImpl::request_autopilot_version()
 {
+    if (_target_uuid_initialized) {
+        // Already initialized, we can exit.
+        return;
+    }
+
     if (!_autopilot_version_pending && _target_uuid_retries >= 3) {
         // We give up getting a UUID and use the system ID.
 

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -367,7 +367,8 @@ void DeviceImpl::send_command_with_ack_async(uint16_t command,
                                   callback);
 }
 
-MavlinkCommands::Result DeviceImpl::set_msg_rate(uint16_t message_id, double rate_hz)
+MavlinkCommands::Result DeviceImpl::set_msg_rate(uint16_t message_id, double rate_hz,
+                                                 uint8_t component_id)
 {
     // If left at -1 it will stop the message stream.
     float interval_us = -1.0f;
@@ -375,13 +376,20 @@ MavlinkCommands::Result DeviceImpl::set_msg_rate(uint16_t message_id, double rat
         interval_us = 1e6f / (float)rate_hz;
     }
 
-    return send_command_with_ack(
-               MAV_CMD_SET_MESSAGE_INTERVAL,
-               MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN});
+    if (component_id != 0) {
+        return send_command_with_ack(
+                   MAV_CMD_SET_MESSAGE_INTERVAL,
+                   MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
+                   component_id);
+    } else {
+        return send_command_with_ack(
+                   MAV_CMD_SET_MESSAGE_INTERVAL,
+                   MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN});
+    }
 }
 
 void DeviceImpl::set_msg_rate_async(uint16_t message_id, double rate_hz,
-                                    command_result_callback_t callback)
+                                    command_result_callback_t callback, uint8_t component_id)
 {
     // If left at -1 it will stop the message stream.
     float interval_us = -1.0f;
@@ -389,10 +397,18 @@ void DeviceImpl::set_msg_rate_async(uint16_t message_id, double rate_hz,
         interval_us = 1e6f / (float)rate_hz;
     }
 
-    send_command_with_ack_async(
-        MAV_CMD_SET_MESSAGE_INTERVAL,
-        MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
-        callback);
+    if (component_id != 0) {
+        send_command_with_ack_async(
+            MAV_CMD_SET_MESSAGE_INTERVAL,
+            MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
+            callback,
+            component_id);
+    } else {
+        send_command_with_ack_async(
+            MAV_CMD_SET_MESSAGE_INTERVAL,
+            MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
+            callback);
+    }
 }
 
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -95,11 +95,12 @@ private:
 
     void process_heartbeat(const mavlink_message_t &message);
     void process_autopilot_version(const mavlink_message_t &message);
+    void heartbeats_timed_out();
+    void set_connected();
+    void set_disconnected();
 
     static void device_thread(DeviceImpl *self);
     static void send_heartbeat(DeviceImpl *self);
-    static void check_timeouts(DeviceImpl *self);
-    static void check_heartbeat_timeout(DeviceImpl *self);
 
     static void receive_float_param(bool success, MavlinkParameters::ParamValue value,
                                     get_param_float_callback_t callback);
@@ -120,6 +121,10 @@ private:
     // The component ID is hardcoded for now.
     uint8_t _target_component_id = MAV_COMP_ID_AUTOPILOT1;
     uint64_t _target_uuid {0};
+
+    int _target_uuid_retries = 0;
+    std::atomic<bool> _target_uuid_initialized {false};
+
     bool _target_supports_mission_int {false};
     bool _armed {false};
 
@@ -128,18 +133,17 @@ private:
     command_result_callback_t _command_result_callback {nullptr};
 
     std::thread *_device_thread {nullptr};
-    std::atomic_bool _should_exit {false};
+    std::atomic<bool> _should_exit {false};
 
     // TODO: should our own system ID have some value?
     static constexpr uint8_t _own_system_id = 0;
     static constexpr uint8_t _own_component_id = MAV_COMP_ID_SYSTEM_CONTROL;
 
-    static std::mutex _last_heartbeat_reiceved_time_mutex;
-    static dl_time_t _last_heartbeat_received_time;
-
     static constexpr double _HEARTBEAT_TIMEOUT_S = 3.0;
 
-    std::atomic<bool> _heartbeats_arriving {false};
+    std::mutex _connection_mutex {};
+    bool _connected {false};
+    void *_heartbeat_timeout_cookie = nullptr;
 
     static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -145,6 +145,9 @@ private:
     bool _connected {false};
     void *_heartbeat_timeout_cookie = nullptr;
 
+    std::atomic<bool> _autopilot_version_pending {false};
+    void *_autopilot_version_timed_out_cookie = nullptr;
+
     static constexpr double _HEARTBEAT_SEND_INTERVAL_S = 1.0;
 
     MavlinkParameters _params;

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -53,10 +53,10 @@ public:
                                      command_result_callback_t callback,
                                      uint8_t component_id = 0);
 
-    MavlinkCommands::Result set_msg_rate(uint16_t message_id, double rate_hz);
+    MavlinkCommands::Result set_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id = 0);
 
     void set_msg_rate_async(uint16_t message_id, double rate_hz,
-                            command_result_callback_t callback);
+                            command_result_callback_t callback, uint8_t component_id = 0);
 
     void request_autopilot_version();
 

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -209,6 +209,7 @@ void DroneCoreImpl::create_device_if_not_existing(uint8_t system_id)
 
 void DroneCoreImpl::notify_on_discover(uint64_t uuid)
 {
+    Debug() << "Discovered " << uuid;
     if (_on_discover_callback != nullptr) {
         _on_discover_callback(uuid);
     }
@@ -216,6 +217,7 @@ void DroneCoreImpl::notify_on_discover(uint64_t uuid)
 
 void DroneCoreImpl::notify_on_timeout(uint64_t uuid)
 {
+    Debug() << "Lost " << uuid;
     if (_on_timeout_callback != nullptr) {
         _on_timeout_callback(uuid);
     }

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -115,6 +115,7 @@ public:
      * @brief Get vector of device UUIDs.
      *
      * This returns a vector of the UUIDs of all devices that have been discovered.
+     * Devices without UUIDs will just use the mavlink system IDs ranging from (0..255).
      *
      * @return A reference to the vector containing the UUIDs.
      */
@@ -143,7 +144,7 @@ public:
     /**
      * @brief Callback type for discover and timeout notifications.
      *
-     * @param uuid UUID of device.
+     * @param uuid UUID of device (or mavlink system ID if UUID is not supported by the device)
      */
     typedef std::function<void(uint64_t uuid)> event_callback_t;
 

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -30,7 +30,8 @@ void ActionImpl::init()
     // We use the async call here because we should not block in the init call because
     // we won't receive an answer anyway in init because the receive loop is not
     // called while we are being created here.
-    _parent->set_msg_rate_async(MAVLINK_MSG_ID_EXTENDED_SYS_STATE, 1.0, nullptr);
+    _parent->set_msg_rate_async(MAVLINK_MSG_ID_EXTENDED_SYS_STATE, 1.0, nullptr,
+                                MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
 void ActionImpl::deinit()


### PR DESCRIPTION
This changes the logic so that you the UUID is used if available but the
mavlink system ID is used as a fallback option. The fallback happens if
3 requests for the autopilot_version are unsuccessful or if the
AUTOPILOT_VERSION.uid field is 0.

This replaces #77.