### PR TITLE
Android: link to LLVM stl instead of GNU stl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,12 +107,6 @@ add_library(dronecore STATIC
 # other applications.
 if(ANDROID)
     set(lib_path "lib/android/${ANDROID_ABI}")
-
-    # The old armeabi arch doesn't support promises yet with gcc 4.9.
-    if (ANDROID_ABI STREQUAL "armeabi")
-        add_definitions(-DNO_PROMISES)
-    endif()
-
 elseif(IOS)
     set(lib_path "lib/ios")
 else()

--- a/Makefile
+++ b/Makefile
@@ -91,37 +91,44 @@ ios_simulator: ios_curl
 
 android_x86: android_curl
 	$(call cmake-build, \
-    -DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=x86)
 
 android_x86_64: android_curl
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=x86_64)
 
 android_mips: android_curl
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=mips)
 
 android_mips64: android_curl
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=mips64)
 
 android_armeabi: android_curl
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=armeabi)
 
 android_armeabi-v7a: android_curl
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=armeabi-v7a)
 
 android_arm64-v8a: android_curl
 	$(call cmake-build, \
-        -DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_TOOLCHAIN_CMAKE) \
+		-DANDROID_STL:STRING=c++_static \
 		-DANDROID_ABI=arm64-v8a)
 
 android_curl: android_env_check

--- a/core/log.h
+++ b/core/log.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sstream>
+#include "global_include.h"
 
 #if ANDROID
 #include <android/log.h>
@@ -80,6 +81,8 @@ public:
                 __android_log_print(ANDROID_LOG_ERROR, "DroneCore", "%s", _s.str().c_str());
                 break;
         }
+        UNUSED(_caller_filename);
+        UNUSED(_caller_filenumber);
 #else
 
         // Time output taken from:

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -36,33 +36,6 @@ MavlinkCommands::Result MavlinkCommands::send_command(uint16_t command,
                                                       uint8_t target_system_id,
                                                       uint8_t target_component_id)
 {
-    // Some architectures sadly don't have the promises (yet). Therefore, we have this crude
-    // while loop to wait until the async task is done.
-#ifdef NO_PROMISES
-    {
-        std::lock_guard<std::mutex> lock(_promise_mutex);
-        // We can't buffer with this implementation.
-        if (_promise_state != PromiseState::IDLE) {
-            return Result::BUSY;
-        }
-
-        _promise_state = PromiseState::BUSY;
-        queue_command_async(command, params, target_system_id, target_component_id,
-                            std::bind(&MavlinkCommands::_promise_receive_command_result,
-                                      this, std::placeholders::_1, std::placeholders::_2));
-    }
-    while (true) {
-        {
-            std::lock_guard<std::mutex> lock(_promise_mutex);
-            if (_promise_state == PromiseState::DONE) {
-                _promise_state = PromiseState::IDLE;
-                return _promise_last_result;
-            }
-        }
-        // Check at 100 Hz.
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-#else
     struct PromiseResult {
         Result result;
         float progress;
@@ -94,23 +67,8 @@ MavlinkCommands::Result MavlinkCommands::send_command(uint16_t command,
         }
         return promise_result.result;
     }
-#endif
 }
 
-#ifdef NO_PROMISES
-void MavlinkCommands::_promise_receive_command_result(Result result, float progress)
-{
-    std::lock_guard<std::mutex> lock(_promise_mutex);
-    if (_promise_state == PromiseState::BUSY) {
-        if (result != Result::IN_PROGRESS) {
-            _promise_state = PromiseState::DONE;
-            _promise_last_result = result;
-        } else {
-            LogInfo() << "In progress: " << progress;
-        }
-    }
-}
-#endif
 
 void MavlinkCommands::queue_command_async(uint16_t command,
                                           const MavlinkCommands::Params params,

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -77,17 +77,6 @@ private:
     LockedQueue<Work> _work_queue {};
 
     void *_timeout_cookie = nullptr;
-
-#ifdef NO_PROMISES
-    std::mutex _promise_mutex {};
-    enum class PromiseState {
-        IDLE,
-        BUSY,
-        DONE
-    } _promise_state {PromiseState::IDLE};
-    Result _promise_last_result {};
-    void _promise_receive_command_result(Result result, float progress);
-#endif
 };
 
 } // namespace dronecore


### PR DESCRIPTION
The reason for the switch is that LLVM supports futures and promises for the architecture armeabi.

This means we can get rid of some (mostly untested) promise code specifically writtern for the armeabi architecture.