### PR TITLE
Support for commands in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # build folders
-**/build
-**/install
-**/logs
+build/*
+install/*
+logs/*

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -1,0 +1,206 @@
+# This file is NOT licensed under the GPLv3, which is the license for the rest
+# of YouCompleteMe.
+#
+# Here's the license text for this file:
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org/>
+
+import os
+import ycm_core
+
+# These are the compilation flags that will be used in case there's no
+# compilation database set (by default, one is not set).
+# CHANGE THIS LIST OF FLAGS. YES, THIS IS THE DROID YOU HAVE BEEN LOOKING FOR.
+flags = [
+'-Wall',
+'-Wextra',
+'-Werror',
+'-fno-exceptions',
+'-Wshadow',
+'-Wno-strict-aliasing',
+# You 100% do NOT need -DUSE_CLANG_COMPLETER in your flags; only the YCM
+# source code needs it.
+'-DUSE_CLANG_COMPLETER',
+# THIS IS IMPORTANT! Without a "-std=<something>" flag, clang won't know which
+# language to use when compiling headers. So it will guess. Badly. So C++
+# headers will be compiled as C headers. You don't want that so ALWAYS specify
+# a "-std=<something>".
+# For a C project, you would set this to something like 'c99' instead of
+# 'c++11'.
+'-std=c++11',
+# ...and the same thing goes for the magic -x option which specifies the
+# language that the files to be compiled are written in. This is mostly
+# relevant for c++ headers.
+# For a C project, you would set this to 'c' instead of 'c++'.
+'-x',
+'c++',
+'-isystem',
+# This path will only work on OS X, but extra paths that don't exist are not
+# harmful
+'/System/Library/Frameworks/Python.framework/Headers',
+'-isystem',
+'../llvm/include',
+'-isystem',
+'../llvm/tools/clang/include',
+'-I',
+'.',
+'-I',
+'core',
+'-I',
+'include',
+'-I',
+'libs/include',
+'-I',
+'build/default/include',
+'-I',
+'build/default/core',
+'-I',
+'plugins/action',
+'-I',
+'plugins/info',
+'-I',
+'plugins/logging',
+'-I',
+'plugins/mission',
+'-I',
+'plugins/offboard',
+'-I',
+'plugins/telemetry',
+'-I',
+'./ClangCompleter',
+'-isystem',
+'./tests/gmock/gtest',
+'-isystem',
+'./tests/gmock/gtest/include',
+'-isystem',
+'./tests/gmock',
+'-isystem',
+'./tests/gmock/include',
+]
+
+
+# Set this to the absolute path to the folder (NOT the file!) containing the
+# compile_commands.json file to use that instead of 'flags'. See here for
+# more details: http://clang.llvm.org/docs/JSONCompilationDatabase.html
+#
+# You can get CMake to generate this file for you by adding:
+#   set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )
+# to your CMakeLists.txt file.
+#
+# Most projects will NOT need to set this to anything; you can just change the
+# 'flags' list of compilation flags. Notice that YCM itself uses that approach.
+compilation_database_folder = ''
+
+if os.path.exists( compilation_database_folder ):
+  database = ycm_core.CompilationDatabase( compilation_database_folder )
+else:
+  database = None
+
+SOURCE_EXTENSIONS = [ '.cpp', '.cxx', '.cc', '.c', '.m', '.mm' ]
+
+def DirectoryOfThisScript():
+  return os.path.dirname( os.path.abspath( __file__ ) )
+
+
+def MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
+  if not working_directory:
+    return list( flags )
+  new_flags = []
+  make_next_absolute = False
+  path_flags = [ '-isystem', '-I', '-iquote', '--sysroot=' ]
+  for flag in flags:
+    new_flag = flag
+
+    if make_next_absolute:
+      make_next_absolute = False
+      if not flag.startswith( '/' ):
+        new_flag = os.path.join( working_directory, flag )
+
+    for path_flag in path_flags:
+      if flag == path_flag:
+        make_next_absolute = True
+        break
+
+      if flag.startswith( path_flag ):
+        path = flag[ len( path_flag ): ]
+        new_flag = path_flag + os.path.join( working_directory, path )
+        break
+
+    if new_flag:
+      new_flags.append( new_flag )
+  return new_flags
+
+
+def IsHeaderFile( filename ):
+  extension = os.path.splitext( filename )[ 1 ]
+  return extension in [ '.h', '.hxx', '.hpp', '.hh' ]
+
+
+def GetCompilationInfoForFile( filename ):
+  # The compilation_commands.json file generated by CMake does not have entries
+  # for header files. So we do our best by asking the db for flags for a
+  # corresponding source file, if any. If one exists, the flags for that file
+  # should be good enough.
+  if IsHeaderFile( filename ):
+    basename = os.path.splitext( filename )[ 0 ]
+    for extension in SOURCE_EXTENSIONS:
+      replacement_file = basename + extension
+      if os.path.exists( replacement_file ):
+        compilation_info = database.GetCompilationInfoForFile(
+          replacement_file )
+        if compilation_info.compiler_flags_:
+          return compilation_info
+    return None
+  return database.GetCompilationInfoForFile( filename )
+
+
+def FlagsForFile( filename, **kwargs ):
+  if database:
+    # Bear in mind that compilation_info.compiler_flags_ does NOT return a
+    # python list, but a "list-like" StringVec object
+    compilation_info = GetCompilationInfoForFile( filename )
+    if not compilation_info:
+      return None
+
+    final_flags = MakeRelativePathsInFlagsAbsolute(
+      compilation_info.compiler_flags_,
+      compilation_info.compiler_working_dir_ )
+
+    # NOTE: This is just for YouCompleteMe; it's highly likely that your project
+    # does NOT need to remove the stdlib flag. DO NOT USE THIS IN YOUR
+    # ycm_extra_conf IF YOU'RE NOT 100% SURE YOU NEED IT.
+    try:
+      final_flags.remove( '-stdlib=libc++' )
+    except ValueError:
+      pass
+  else:
+    relative_to = DirectoryOfThisScript()
+    final_flags = MakeRelativePathsInFlagsAbsolute( flags, relative_to )
+
+  return {
+    'flags': final_flags,
+    'do_cache': True
+  }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ if(NOT IOS AND NOT ANDROID)
         core/unittests_main.cpp
         core/http_loader_test.cpp
         core/timeout_handler_test.cpp
+        core/locked_list_test.cpp
         ${plugin_unittest_source_files}
         ${unit_tests_src}
     )

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -79,6 +79,11 @@ void DeviceImpl::refresh_timeout_handler(const void *cookie)
     _timeout_handler.refresh(cookie);
 }
 
+void DeviceImpl::update_timeout_handler(double new_duration_s, const void *cookie)
+{
+    _timeout_handler.update(new_duration_s, cookie);
+}
+
 void DeviceImpl::unregister_timeout_handler(const void *cookie)
 {
     _timeout_handler.remove(cookie);

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -40,6 +40,8 @@ public:
 
     void refresh_timeout_handler(const void *cookie);
 
+    void update_timeout_handler(double new_duration_s, const void *cookie);
+
     void unregister_timeout_handler(const void *cookie);
 
     bool send_message(const mavlink_message_t &message);

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -62,6 +62,8 @@ void DroneCoreImpl::receive_message(const mavlink_message_t &message)
         return;
     }
 
+    // LogDebug() << "Received " << (int)message.msgid;
+
     std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
 
     // Change system id of null device

--- a/core/locked_list.h
+++ b/core/locked_list.h
@@ -20,8 +20,8 @@ public:
     class iterator: public std::list<T>::iterator
     {
     public:
-        iterator(typename std::list<T>::iterator c, std::mutex &mutex) :
-            std::list<T>::iterator(c),
+        iterator(typename std::list<T>::iterator iter, std::mutex &mutex) :
+            std::list<T>::iterator(iter),
             _mutex(&mutex)
         {}
 

--- a/core/locked_list.h
+++ b/core/locked_list.h
@@ -5,6 +5,9 @@
 
 namespace dronecore {
 
+// Note: this wrapper around list was developed for `MavlinkCommands` but was not used
+// eventually. Instead, `std::list` was used directly and protected with a `std::mutex`.
+
 template <class T>
 class LockedList
 {

--- a/core/locked_list.h
+++ b/core/locked_list.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <list>
+#include <mutex>
+
+namespace dronecore {
+
+template <class T>
+class LockedList
+{
+public:
+    LockedList() :
+        _list(),
+        _mutex()
+    {};
+
+    class iterator: public std::list<T>::iterator
+    {
+    public:
+        iterator(typename std::list<T>::iterator c, std::mutex &mutex) :
+            std::list<T>::iterator(c),
+            _mutex(&mutex)
+        {}
+
+        T &operator*()
+        {
+            std::lock_guard<std::mutex> lock(*_mutex);
+            return std::list<T>::iterator::operator *();
+        }
+    private:
+        std::mutex *_mutex;
+    };
+
+    iterator begin()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return iterator(_list.begin(), _mutex);
+    }
+
+    iterator end()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return iterator(_list.end(), _mutex);
+    }
+
+    iterator erase(iterator it)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return iterator(_list.erase(it), _mutex);
+    }
+
+    void push_back(T item)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        _list.push_back(item);
+    }
+
+    T &front()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        return _list.front();
+    }
+
+    void pop_front()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        _list.pop_front();
+    }
+
+    size_t size()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        return _list.size();
+    }
+
+private:
+    std::list<T> _list;
+    std::mutex _mutex;
+};
+
+} // namespace dronecore

--- a/core/locked_list_test.cpp
+++ b/core/locked_list_test.cpp
@@ -1,0 +1,98 @@
+#include "locked_list.h"
+#include <gtest/gtest.h>
+
+using namespace dronecore;
+
+static const int LEN = 10;
+
+
+TEST(LockedList, CreateAndDelete)
+{
+    LockedList<int> locked_list;
+    EXPECT_EQ(locked_list.size(), 0);
+
+    locked_list.push_back(1);
+    EXPECT_EQ(locked_list.size(), 1);
+
+    locked_list.push_back(2);
+    EXPECT_EQ(locked_list.size(), 2);
+
+    locked_list.pop_front();
+    EXPECT_EQ(locked_list.size(), 1);
+
+    locked_list.pop_front();
+    EXPECT_EQ(locked_list.size(), 0);
+}
+
+TEST(LockedList, Iterate)
+{
+    LockedList<int> locked_list;
+    EXPECT_EQ(locked_list.size(), 0);
+
+    for (int i = 0; i < LEN; ++i) {
+        locked_list.push_back(i);
+    }
+    EXPECT_EQ(locked_list.size(), LEN);
+
+    int count = 0;
+    for (auto it = locked_list.begin(); it != locked_list.end(); ++it) {
+        ++count;
+    }
+    EXPECT_EQ(count, LEN);
+}
+
+TEST(LockedList, RemoveInBetween)
+{
+    LockedList<int> locked_list;
+    EXPECT_EQ(locked_list.size(), 0);
+
+    for (int i = 0; i < LEN; ++i) {
+        locked_list.push_back(i);
+        EXPECT_EQ(locked_list.size(), i + 1);
+    }
+
+    int count = 0;
+    for (auto it = locked_list.begin(); it != locked_list.end(); /*++it*/) {
+        if (*it == 5) {
+            it = locked_list.erase(it);
+        } else {
+            ++it;
+        }
+        ++count;
+    }
+
+    EXPECT_EQ(locked_list.size(), LEN - 1);
+    EXPECT_EQ(count, LEN);
+}
+
+TEST(LockedList, RemoveInBetweenAndAddAgain)
+{
+    LockedList<int> locked_list;
+    EXPECT_EQ(locked_list.size(), 0);
+
+    for (int i = 0; i < LEN; ++i) {
+        locked_list.push_back(i);
+        EXPECT_EQ(locked_list.size(), i + 1);
+    }
+
+    int count = 0;
+    for (auto it = locked_list.begin(); it != locked_list.end(); /*++it*/) {
+        if (*it == 5) {
+            it = locked_list.erase(it);
+            locked_list.push_back(42);
+        } else {
+            ++it;
+        }
+        ++count;
+    }
+
+    EXPECT_EQ(locked_list.size(), LEN);
+    EXPECT_EQ(count, LEN + 1);
+
+    int last_one = 0;
+    for (auto it = locked_list.begin(); it != locked_list.end(); ++it) {
+        EXPECT_NE(*it, 5);
+        last_one = *it;
+    }
+    EXPECT_EQ(last_one, 42);
+}

--- a/core/log.h
+++ b/core/log.h
@@ -12,6 +12,7 @@
 
 #define ANSI_COLOR_RED     "\x1b[31m"
 #define ANSI_COLOR_YELLOW  "\x1b[33m"
+#define ANSI_COLOR_BLUE    "\x1b[34m"
 #define ANSI_COLOR_GRAY    "\x1b[37m"
 #define ANSI_COLOR_RESET   "\x1b[0m"
 
@@ -101,6 +102,7 @@ public:
                 std::cout << "|Debug] ";
                 break;
             case LogLevel::Info:
+                std::cout << ANSI_COLOR_BLUE;
                 std::cout << "|Info ] ";
                 break;
             case LogLevel::Warn:
@@ -117,9 +119,9 @@ public:
         std::cout << " (" << _caller_filename << ":" << _caller_filenumber << ")";
 
         switch (_log_level) {
-            case LogLevel::Info:
-                break;
             case LogLevel::Debug:
+                break;
+            case LogLevel::Info:
             // FALLTHROUGH
             case LogLevel::Warn:
             // FALLTHROUGH

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -203,7 +203,7 @@ void MavlinkCommands::do_work()
     for (auto it = _work_list.begin(); it != _work_list.end(); /* ++it */) {
 
         // We ignore what has already been sent and is not timed out yet.
-        if ((*it)->num_sent != 0 && !(*it)->timed_out) {
+        if ((*it)->num_command_sent != 0 && !(*it)->timed_out) {
             // Mark it as active.
             active_command_ids.push_back((*it)->mavlink_command);
 
@@ -212,7 +212,7 @@ void MavlinkCommands::do_work()
         }
 
         // We remove what has already been resent a few times.
-        if ((*it)->timed_out && (*it)->num_sent >= RETRIES) {
+        if ((*it)->timed_out && (*it)->num_command_sent >= RETRIES) {
             if ((*it)->callback) {
                 auto callback_tmp = (*it)->callback;
                 _mutex.unlock();
@@ -235,7 +235,7 @@ void MavlinkCommands::do_work()
         }
 
         // Now we can actually send it.
-        LogDebug() << "Sending command " << (*it)->num_sent
+        LogDebug() << "Sending command " << (*it)->num_command_sent
                    << " time (" << (int)(*it)->mavlink_command << ")";
 
         // Reset timeout flag for next re-send.
@@ -254,7 +254,7 @@ void MavlinkCommands::do_work()
             continue;
         }
 
-        ++((*it)->num_sent);
+        ++((*it)->num_command_sent);
 
         std::shared_ptr<Work> work_ptr = *it;
         // Let's set a timer for retransmission if needed.

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -57,21 +57,19 @@ MavlinkCommands::Result MavlinkCommands::send_command(uint16_t command,
                        );
 
     std::future<PromiseResult> res = prom->get_future();
-    while (true) {
-        // Block now to wait for result.
-        res.wait();
+    // Block now to wait for result.
+    res.wait();
 
-        PromiseResult promise_result = res.get();
+    PromiseResult promise_result = res.get();
 
-        // We should not get notified for progress because `std::future` does not support
-        // being called multiple times.
+    // We should not get notified for progress because `std::future` does not support
+    // being called multiple times.
 
-        //if (promise_result.result == Result::IN_PROGRESS) {
-        //    LogInfo() << "In progress: " << promise_result.progress;
-        //    continue;
-        //}
-        return promise_result.result;
-    }
+    //if (promise_result.result == Result::IN_PROGRESS) {
+    //    LogInfo() << "In progress: " << promise_result.progress;
+    //    continue;
+    //}
+    return promise_result.result;
 }
 
 

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -229,7 +229,7 @@ void MavlinkCommands::do_work()
              != active_command_ids.end());
 
         if (found_command_id) {
-            LogDebug() << "We need to wait to send " << (int)(*it)->mavlink_command;
+            // LogDebug() << "We need to wait to send " << (int)(*it)->mavlink_command;
             ++it;
             continue;
         }

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -238,6 +238,8 @@ void MavlinkCommands::do_work()
         LogDebug() << "Sending command " << (*it)->num_sent
                    << " time (" << (int)(*it)->mavlink_command << ")";
 
+        // Reset timeout flag for next re-send.
+        (*it)->timed_out = false;
         if (!_parent->send_message((*it)->mavlink_message)) {
             LogErr() << "connection send error (" << (*it)->mavlink_command << ")";
             if ((*it)->callback) {

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -59,7 +59,7 @@ private:
     static constexpr int RETRIES = 3;
 
     struct Work {
-        int num_sent = 0;
+        int num_command_sent = 0;
         bool timed_out = true;
         double timeout_s = DEFAULT_TIMEOUT_NORMAL_S;
         uint16_t mavlink_command = 0;

--- a/core/timeout_handler.cpp
+++ b/core/timeout_handler.cpp
@@ -39,13 +39,13 @@ void TimeoutHandler::refresh(const void *cookie)
     }
 }
 
-void TimeoutHandler::update(double new_duration_s, const void *cookie)
+void TimeoutHandler::update(double updated_duration_s, const void *cookie)
 {
     std::lock_guard<std::mutex> lock(_timeouts_mutex);
 
     auto it = _timeouts.find((void *)(cookie));
     if (it != _timeouts.end()) {
-        it->second->duration_s = new_duration_s;
+        it->second->duration_s = updated_duration_s;
     }
 }
 

--- a/core/timeout_handler.h
+++ b/core/timeout_handler.h
@@ -22,7 +22,7 @@ public:
 
     void add(std::function<void()> callback, double duration_s, void **cookie);
     void refresh(const void *cookie);
-    void update(double new_duration_s, const void *cookie);
+    void update(double updated_duration_s, const void *cookie);
     void remove(const void *cookie);
 
     void run_once();

--- a/core/timeout_handler.h
+++ b/core/timeout_handler.h
@@ -22,6 +22,7 @@ public:
 
     void add(std::function<void()> callback, double duration_s, void **cookie);
     void refresh(const void *cookie);
+    void update(double new_duration_s, const void *cookie);
     void remove(const void *cookie);
 
     void run_once();
@@ -29,7 +30,7 @@ public:
 private:
     struct Timeout {
         std::function<void()> callback;
-        dl_time_t time;
+        dl_time_t start_time;
         double duration_s;
     };
 

--- a/core/timeout_handler_test.cpp
+++ b/core/timeout_handler_test.cpp
@@ -138,3 +138,28 @@ TEST(TimeoutHandler, TimeoutRemovedDuringCallback)
     th.run_once();
     EXPECT_TRUE(timeout_happened);
 }
+
+TEST(TimeoutHandler, TimeoutUpdate)
+{
+    TimeoutHandler th;
+
+    bool timeout_happened = false;
+
+    void *cookie = nullptr;
+    th.add([&timeout_happened]() {
+        timeout_happened = true;
+    }, 0.5, &cookie);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+
+    th.update(1.0, cookie);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_FALSE(timeout_happened);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    th.run_once();
+    EXPECT_TRUE(timeout_happened);
+}

--- a/integration_tests/async_hover.cpp
+++ b/integration_tests/async_hover.cpp
@@ -30,22 +30,26 @@ TEST_F(SitlTest, ActionAsyncHover)
     device.telemetry().in_air_async(std::bind(&receive_in_air, _1));
 
     while (!_all_ok) {
-        std::cout << "Waiting to be ready..." << std::endl;
+        LogInfo() << "Waiting to be ready...";
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
+    LogInfo() << "Arming...";
     device.action().arm_async(std::bind(&receive_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
+    LogInfo() << "Setting takeoff altitude...";
     device.action().set_takeoff_altitude(5.0f);
 
+    LogInfo() << "Taking off...";
     device.action().takeoff_async(std::bind(&receive_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
+    LogInfo() << "Landing...";
     device.action().land_async(std::bind(&receive_result, _1));
 
     while (_in_air) {
-        std::cout << "Waiting to be landed..." << std::endl;
+        LogInfo() << "Waiting to be landed...";
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 


### PR DESCRIPTION
This is a big refactor of the MavlinkCommands class in order to support
multiple commands in parallel. It won't do multiple commands with the
same command ID at the same time in order to prevent conflicts/races
with acks that can't be assigned uniquely.