### PR TITLE
core: make Info printfs blue

### DIFF
--- a/core/log.h
+++ b/core/log.h
@@ -12,6 +12,7 @@
 
 #define ANSI_COLOR_RED     "\x1b[31m"
 #define ANSI_COLOR_YELLOW  "\x1b[33m"
+#define ANSI_COLOR_BLUE    "\x1b[34m"
 #define ANSI_COLOR_GRAY    "\x1b[37m"
 #define ANSI_COLOR_RESET   "\x1b[0m"
 
@@ -85,10 +86,22 @@ public:
         UNUSED(_caller_filenumber);
 #else
 
+        switch (_log_level) {
+            case LogLevel::Debug:
+                break;
+            case LogLevel::Info:
+                std::cout << ANSI_COLOR_BLUE;
+                break;
+            case LogLevel::Warn:
+                std::cout << ANSI_COLOR_YELLOW;
+                break;
+            case LogLevel::Err:
+                std::cout << ANSI_COLOR_RED;
+                break;
+        }
+
         // Time output taken from:
         // https://stackoverflow.com/questions/16357999#answer-16358264
-
-
         time_t rawtime;
         time(&rawtime);
         struct tm *timeinfo = localtime(&rawtime);
@@ -104,11 +117,9 @@ public:
                 std::cout << "|Info ] ";
                 break;
             case LogLevel::Warn:
-                std::cout << ANSI_COLOR_YELLOW;
                 std::cout << "|Warn ] ";
                 break;
             case LogLevel::Err:
-                std::cout << ANSI_COLOR_RED;
                 std::cout << "|Error] ";
                 break;
         }
@@ -117,9 +128,9 @@ public:
         std::cout << " (" << _caller_filename << ":" << _caller_filenumber << ")";
 
         switch (_log_level) {
-            case LogLevel::Info:
-                break;
             case LogLevel::Debug:
+                break;
+            case LogLevel::Info:
             // FALLTHROUGH
             case LogLevel::Warn:
             // FALLTHROUGH


### PR DESCRIPTION
In order to distinguish Info and Debug, Info is now made blue.

Also, the color is now properly set at the beginning of the line instead
of after the time.