### PR TITLE
telemetry: use available instead of lost for RC

### DIFF
--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -134,7 +134,7 @@ public:
      */
     struct RCStatus {
         bool available_once; /**< @brief true if an RC signal has been available once. */
-        bool lost; /**< @brief true if the RC signal is lost. */
+        bool available; /**< @brief true if the RC signal is available now. */
         float signal_strength_percent; /**< @brief Signal strength as a percentage (range: 0 to 100). */
     };
 

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -784,7 +784,7 @@ void TelemetryImpl::set_rc_status(bool available, float signal_strength_percent)
         _rc_status.signal_strength_percent = 0.0f;
     }
 
-    _rc_status.lost = !available;
+    _rc_status.available = available;
 
 }
 


### PR DESCRIPTION
It is more intuitive to have the flag `available` signalling connected
then `not lost` like previously. Also, the initialization with `false`
makes more sense this way.