### PR TITLE
integration_tests: add checks to takeoff/land test

### DIFF
--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -40,6 +40,11 @@ DeviceImpl::~DeviceImpl()
     }
 }
 
+bool DeviceImpl::is_connected() const
+{
+    return _heartbeats_arriving;
+}
+
 void DeviceImpl::register_mavlink_message_handler(uint16_t msg_id,
                                                   mavlink_message_handler_t callback,
                                                   const void *cookie)

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -87,6 +87,8 @@ public:
     static uint8_t get_own_system_id() { return _own_system_id; }
     static uint8_t get_own_component_id() { return _own_component_id; }
 
+    bool is_connected() const;
+
     // Non-copyable
     DeviceImpl(const DeviceImpl &) = delete;
     const DeviceImpl &operator=(const DeviceImpl &) = delete;

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -107,6 +107,16 @@ Device &DroneCore::device(uint64_t uuid) const
     return _impl->get_device(uuid);
 }
 
+bool DroneCore::is_connected() const
+{
+    return _impl->is_connected();
+}
+
+bool DroneCore::is_connected(uint64_t uuid) const
+{
+    return _impl->is_connected(uuid);
+}
+
 void DroneCore::register_on_discover(event_callback_t callback)
 {
     _impl->register_on_discover(callback);

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -184,6 +184,28 @@ Device &DroneCoreImpl::get_device(uint64_t uuid)
     return *_devices[system_id];
 }
 
+bool DroneCoreImpl::is_connected() const
+{
+    std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
+
+    if (_device_impls.size() == 1) {
+        return _device_impls.begin()->second->is_connected();
+    }
+    return false;
+}
+
+bool DroneCoreImpl::is_connected(uint64_t uuid) const
+{
+    std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
+
+    for (auto it = _device_impls.begin(); it != _device_impls.end(); ++it) {
+        if (it->second->get_target_uuid() == uuid) {
+            return it->second->is_connected();
+        }
+    }
+    return false;
+}
+
 void DroneCoreImpl::create_device_if_not_existing(uint8_t system_id)
 {
     std::lock_guard<std::recursive_mutex> lock(_devices_mutex);

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -26,6 +26,9 @@ public:
     Device &get_device();
     Device &get_device(uint64_t uuid);
 
+    bool is_connected() const;
+    bool is_connected(uint64_t uuid) const;
+
     void register_on_discover(DroneCore::event_callback_t callback);
     void register_on_timeout(DroneCore::event_callback_t callback);
 
@@ -38,7 +41,7 @@ private:
     std::mutex _connections_mutex;
     std::vector<Connection *> _connections;
 
-    std::recursive_mutex _devices_mutex;
+    mutable std::recursive_mutex _devices_mutex;
     std::map<uint8_t, Device *> _devices;
     std::map<uint8_t, DeviceImpl *> _device_impls;
 

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -143,7 +143,6 @@ int main(int /*argc*/, char ** /*argv*/)
     std::cout << "Armed." << std::endl;
 
     // Before starting the mission, we want to be sure to subscribe to the mission progress.
-    // We pass on device to receive_mission_progress because we need it in the callback.
     device.mission().subscribe_progress(std::bind(&receive_mission_progress, _1, _2));
 
     {

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -24,10 +24,6 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                                      float gimbal_yaw_deg,
                                                      MissionItem::CameraAction camera_action);
 
-static void receive_mission_progress(int current, int total);
-
-static std::atomic<bool> _want_to_pause {false};
-
 int main(int /*argc*/, char ** /*argv*/)
 {
     DroneCore dc;
@@ -142,8 +138,18 @@ int main(int /*argc*/, char ** /*argv*/)
 
     std::cout << "Armed." << std::endl;
 
+    std::atomic<bool> want_to_pause {false};
     // Before starting the mission, we want to be sure to subscribe to the mission progress.
-    device.mission().subscribe_progress(std::bind(&receive_mission_progress, _1, _2));
+    device.mission().subscribe_progress(
+    [&want_to_pause](int current, int total) {
+        std::cout << "Mission status update: " << current << " / " << total << std::endl;
+
+        if (current >= 2) {
+            // We can only set a flag here. If we do more request inside the callback,
+            // we risk blocking the system.
+            want_to_pause = true;
+        }
+    });
 
     {
         std::cout << "Starting mission." << std::endl;
@@ -162,7 +168,7 @@ int main(int /*argc*/, char ** /*argv*/)
         }
     }
 
-    while (!_want_to_pause) {
+    while (!want_to_pause) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
@@ -249,15 +255,3 @@ std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
     new_item->set_camera_action(camera_action);
     return new_item;
 }
-
-void receive_mission_progress(int current, int total)
-{
-    std::cout << "Mission status update: " << current << " / " << total << std::endl;
-
-    if (current >= 2) {
-        // We can only set a flag here. If we do more request inside the callback,
-        // we risk blocking the system.
-        _want_to_pause = true;
-    }
-}
-

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -148,6 +148,29 @@ public:
     typedef std::function<void(uint64_t uuid)> event_callback_t;
 
     /**
+     * @brief Returns true if exactly one device is currently connected.
+     *
+     * Connected means we are receiving heartbeats from this device.
+     * It means the same as "discovered" and "not timed out".
+     *
+     * If multiple devices have connected, this will return false.
+     *
+     * @return true if exactly one device is connected.
+     */
+    bool is_connected() const;
+
+    /**
+     * @brief Returns true if a device is currently connected.
+     *
+     * Connected means we are receiving heartbeats from this device.
+     * It means the same as "discovered" and "not timed out".
+     *
+     * @param uuid UUID of device to check.
+     * @return true if device is connected.
+     */
+    bool is_connected(uint64_t uuid) const;
+
+    /**
      * @brief Register callback for device discovery.
      *
      * This sets a callback that will be notified if a new device is discovered.

--- a/integration_tests/simple_hover.cpp
+++ b/integration_tests/simple_hover.cpp
@@ -4,7 +4,27 @@
 
 using namespace dronecore;
 
-TEST_F(SitlTest, ActionSimpleHover)
+
+static void takeoff_and_hover_at_altitude(float altitude_m = NAN);
+
+
+TEST_F(SitlTest, ActionSimpleHoverDefault)
+{
+    takeoff_and_hover_at_altitude();
+}
+
+TEST_F(SitlTest, ActionSimpleHoverHigher)
+{
+    takeoff_and_hover_at_altitude(5.0f);
+}
+
+TEST_F(SitlTest, ActionSimpleHoverLower)
+{
+    takeoff_and_hover_at_altitude(1.0f);
+}
+
+
+void takeoff_and_hover_at_altitude(float altitude_m)
 {
     DroneCore dc;
 
@@ -13,31 +33,55 @@ TEST_F(SitlTest, ActionSimpleHover)
 
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_TRUE(dc.is_connected());
 
     Device &device = dc.device();
 
-    while (!device.telemetry().health_all_ok()) {
+    for (int i = 0; ; ++i) {
+        if (device.telemetry().health_all_ok()) {
+            break;
+        }
         std::cout << "waiting for device to be ready" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        ASSERT_LT(i, 10);
     }
 
     Action::Result action_ret = device.action().arm();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
+    if (std::isfinite(altitude_m)) {
+        device.action().set_takeoff_altitude(altitude_m);
+    } else {
+        // The default should be 2.5 m, so we check against that.
+        altitude_m = 2.5f;
+    }
+
     action_ret = device.action().takeoff();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    // We wait 1.5s / m plus a margin of 3s.
+    const int wait_time_s = (int)(altitude_m * 1.5f + 3.0f);
+    std::this_thread::sleep_for(std::chrono::seconds(wait_time_s));
+
+
+    EXPECT_GT(device.telemetry().position().relative_altitude_m, altitude_m - 0.25f);
+    EXPECT_LT(device.telemetry().position().relative_altitude_m, altitude_m + 0.25f);
 
     action_ret = device.action().land();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
 
-    while (device.telemetry().in_air()) {
+    for (int i = 0; ; ++i) {
+        if (!device.telemetry().in_air()) {
+            break;
+        }
         std::cout << "waiting for device to be landed" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // TODO: currently we need to wait a long time until landed is detected.
+        ASSERT_LT(i, wait_time_s + 5);
     }
 
     action_ret = device.action().disarm();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
 }
-

--- a/integration_tests/simple_hover.cpp
+++ b/integration_tests/simple_hover.cpp
@@ -37,14 +37,12 @@ void takeoff_and_hover_at_altitude(float altitude_m)
 
     Device &device = dc.device();
 
-    for (int i = 0; ; ++i) {
-        if (device.telemetry().health_all_ok()) {
-            break;
-        }
+    int iteration = 0;
+    while (!device.telemetry().health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(1));
 
-        ASSERT_LT(i, 10);
+        ASSERT_LT(++iteration, 10);
     }
 
     Action::Result action_ret = device.action().arm();
@@ -71,15 +69,13 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     action_ret = device.action().land();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
 
-    for (int i = 0; ; ++i) {
-        if (!device.telemetry().in_air()) {
-            break;
-        }
+    iteration = 0;
+    while (device.telemetry().in_air()) {
         std::cout << "waiting for device to be landed" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(1));
 
         // TODO: currently we need to wait a long time until landed is detected.
-        ASSERT_LT(i, wait_time_s + 5);
+        ASSERT_LT(++iteration, 10);
     }
 
     action_ret = device.action().disarm();

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -125,7 +125,7 @@ void MissionImpl::process_mission_ack(const mavlink_message_t &message)
         _last_reached_mavlink_mission_item = -1;
 
         report_mission_result(_result_callback, Mission::Result::SUCCESS);
-        LogInfo() << "Sucess, done";
+        LogInfo() << "Mission accepted";
         _activity = Activity::NONE;
     } else if (mission_ack.type == MAV_MISSION_NO_SPACE) {
         LogErr() << "Error: too many waypoints: " << int(mission_ack.type);


### PR DESCRIPTION
This adds some checks to the ActionSimpleHover tests to actually check
what PX4 SITL is executing rather than just checking if we get the
correct responses.

This could be an example for CI tests for PX4 using DroneCore.

@dagar have a look

To test this:
- Start PX4 SITL
- Then start the test:
    ```
    make && build/default/integration_tests_runner --gtest_filter="SitlTest.ActionSimpleHover*"
    ```
    
Or if you have Firmware and DroneCore next to each other in a folder:

```
make && AUTOSTART_SITL=1 build/default/integration_tests_runner --gtest_filter="SitlTest.ActionSimpleHover*"
```