### PR TITLE
fix comment, use lambdas for mission progress

### DIFF
--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -143,7 +143,6 @@ int main(int /*argc*/, char ** /*argv*/)
     std::cout << "Armed." << std::endl;
 
     // Before starting the mission, we want to be sure to subscribe to the mission progress.
-    // We pass on device to receive_mission_progress because we need it in the callback.
     device.mission().subscribe_progress(std::bind(&receive_mission_progress, _1, _2));
 
     {

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -24,10 +24,6 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                                      float gimbal_yaw_deg,
                                                      MissionItem::CameraAction camera_action);
 
-static void receive_mission_progress(int current, int total);
-
-static std::atomic<bool> _want_to_pause {false};
-
 int main(int /*argc*/, char ** /*argv*/)
 {
     DroneCore dc;
@@ -142,8 +138,18 @@ int main(int /*argc*/, char ** /*argv*/)
 
     std::cout << "Armed." << std::endl;
 
+    std::atomic<bool> want_to_pause {false};
     // Before starting the mission, we want to be sure to subscribe to the mission progress.
-    device.mission().subscribe_progress(std::bind(&receive_mission_progress, _1, _2));
+    device.mission().subscribe_progress(
+    [&want_to_pause](int current, int total) {
+        std::cout << "Mission status update: " << current << " / " << total << std::endl;
+
+        if (current >= 2) {
+            // We can only set a flag here. If we do more request inside the callback,
+            // we risk blocking the system.
+            want_to_pause = true;
+        }
+    });
 
     {
         std::cout << "Starting mission." << std::endl;
@@ -162,7 +168,7 @@ int main(int /*argc*/, char ** /*argv*/)
         }
     }
 
-    while (!_want_to_pause) {
+    while (!want_to_pause) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
@@ -249,15 +255,3 @@ std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
     new_item->set_camera_action(camera_action);
     return new_item;
 }
-
-void receive_mission_progress(int current, int total)
-{
-    std::cout << "Mission status update: " << current << " / " << total << std::endl;
-
-    if (current >= 2) {
-        // We can only set a flag here. If we do more request inside the callback,
-        // we risk blocking the system.
-        _want_to_pause = true;
-    }
-}
-


### PR DESCRIPTION
Thanks for spotting this @hamishwillee.

- Fixed a wrong comment.
- Changed mission progress handling into lambda because it is more readable.