### PR TITLE
cmake: ignore our warnings for additional includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ include_directories(
     ${external_plugins}
     ${CMAKE_CURRENT_BINARY_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/core
-    ${EXTERNAL_DIR}/${additional_includes}
+    SYSTEM ${EXTERNAL_DIR}/${additional_includes}
 )
 
 if (ANDROID)


### PR DESCRIPTION
By adding SYSTEM before including the additional_includes, we ignore our
cmake warnings which would often break the build.