### PR TITLE
core: add mavlink statustexts as debug printfs

### DIFF
--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -97,6 +97,7 @@ private:
 
     void process_heartbeat(const mavlink_message_t &message);
     void process_autopilot_version(const mavlink_message_t &message);
+    void process_statustext(const mavlink_message_t &message);
     void heartbeats_timed_out();
     void set_connected();
     void set_disconnected();


### PR DESCRIPTION
By printing all mavlink statustexts we should get a bit more context
when something goes wrong on the firmware side.

@bkueng do you have a better suggestion how to make sure the `statustext.text` string is null terminated