### PR TITLE
Added gimbal plugin

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND integration_tests
 	mission
     mission_change_speed
 	mission_survey
+    gimbal
     curl
 )
 

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <functional>
+#include <memory>
+#include <atomic>
+#include <cmath>
+#include "integration_test_helper.h"
+#include "dronecore.h"
+
+using namespace std::placeholders; // for `_1`
+using namespace dronecore;
+
+
+void send_new_gimbal_command(Device &device, int i);
+void receive_gimbal_result(Gimbal::Result result);
+void receive_gimbal_attitude_euler_angles(Telemetry::EulerAngle euler_angle);
+
+
+TEST_F(SitlTest, GimbalMove)
+{
+    DroneCore dc;
+
+    DroneCore::ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, DroneCore::ConnectionResult::SUCCESS);
+
+    // Wait for device to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    Device &device = dc.device();
+
+    device.telemetry().set_rate_camera_attitude(10.0);
+
+    device.telemetry().camera_attitude_euler_angle_async(
+        std::bind(&receive_gimbal_attitude_euler_angles, _1));
+
+    for (int i = 0; i < 500; i += 1) {
+
+        send_new_gimbal_command(device, i);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+TEST_F(SitlTest, GimbalTakeoffAndMove)
+{
+    DroneCore dc;
+
+    DroneCore::ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, DroneCore::ConnectionResult::SUCCESS);
+
+    // Wait for device to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    Device &device = dc.device();
+
+    while (!device.telemetry().health_all_ok()) {
+        LogInfo() << "waiting for device to be ready";
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    device.action().arm();
+    device.action().takeoff();
+
+    device.telemetry().set_rate_camera_attitude(10.0);
+
+    device.telemetry().camera_attitude_euler_angle_async(
+        std::bind(&receive_gimbal_attitude_euler_angles, _1));
+
+    for (int i = 0; i < 500; i += 1) {
+
+        send_new_gimbal_command(device, i);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    device.action().land();
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
+void send_new_gimbal_command(Device &device, int i)
+{
+    float pitch_deg = 30.0f * cosf(i / 360.0f * 2 * M_PI_F);
+    float yaw_deg = 45.0f * sinf(i / 360.0f * 2 * M_PI_F);
+
+    device.gimbal().set_pitch_and_yaw_async(pitch_deg, yaw_deg,
+                                            std::bind(&receive_gimbal_result, _1));
+}
+
+void receive_gimbal_result(Gimbal::Result result)
+{
+    EXPECT_EQ(result, Gimbal::Result::SUCCESS);
+}
+
+void receive_gimbal_attitude_euler_angles(Telemetry::EulerAngle euler_angle)
+{
+    LogInfo() << "Received gimbal attitude: "
+              << euler_angle.roll_deg << ", "
+              << euler_angle.pitch_deg << ", "
+              << euler_angle.yaw_deg;
+}
+

--- a/plugins/gimbal/CMakeLists.txt
+++ b/plugins/gimbal/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(class_name
+    Gimbal
+    PARENT_SCOPE
+)
+
+set(source_files
+    gimbal.cpp
+    gimbal_impl.cpp
+    PARENT_SCOPE
+)
+
+set(header_files
+    gimbal.h
+    PARENT_SCOPE
+)
+
+set(impl_header_files
+    gimbal_impl.h
+    PARENT_SCOPE
+)
+

--- a/plugins/gimbal/gimbal.cpp
+++ b/plugins/gimbal/gimbal.cpp
@@ -1,0 +1,40 @@
+#include "gimbal.h"
+#include "gimbal_impl.h"
+
+namespace dronecore {
+
+Gimbal::Gimbal(GimbalImpl *impl) :
+    _impl(impl)
+{
+}
+
+Gimbal::~Gimbal()
+{
+}
+
+Gimbal::Result Gimbal::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
+{
+    return _impl->set_pitch_and_yaw(pitch_deg, yaw_deg);
+}
+
+void Gimbal::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, result_callback_t callback)
+{
+    _impl->set_pitch_and_yaw_async(pitch_deg, yaw_deg, callback);
+}
+
+const char *Gimbal::result_str(Result result)
+{
+    switch (result) {
+        case Result::SUCCESS:
+            return "Success";
+        case Result::ERROR:
+            return "Error";
+        case Result::TIMEOUT:
+            return "Timeout";
+        case Result::UNKNOWN:
+        default:
+            return "Unknown";
+    }
+}
+
+} // namespace dronecore

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -6,33 +6,87 @@ namespace dronecore {
 
 class GimbalImpl;
 
+/**
+ * @brief The Gimbal class enables to control a gimbal.
+ *
+ * Synchronous and asynchronous variants of the gimbal methods are supplied.
+ */
 class Gimbal
 {
 public:
+    /**
+     * @brief Constructor (internal use only).
+     *
+     * @param impl Private internal implementation.
+     */
     explicit Gimbal(GimbalImpl *impl);
+
+    /**
+     * @brief Destructor (internal use only).
+     */
     ~Gimbal();
 
+    /**
+     * @brief Possible results returned for gimbal commands.
+     */
     enum class Result {
-        SUCCESS = 0,
-        ERROR,
-        TIMEOUT,
-        UNKNOWN
+        SUCCESS = 0, /**< @brief Success. The gimbal command was accepted. */
+        ERROR, /**< @brief Error. An error occured sending the command. */
+        TIMEOUT, /**< @brief Timeout. A timeout occured sending the command. */
+        UNKNOWN /**< @brief Unspecified error. */
     };
 
+    /**
+     * @brief Returns a human-readable English string for Gimbal::Result.
+     *
+     * @param Result The enum value for which a human readable string is required.
+     * @return Human readable string for the Gimbal::Result.
+     */
     static const char *result_str(Result result);
 
+    /**
+     * @brief Callback type for asynchronous Gimbal calls.
+     */
     typedef std::function<void(Result)> result_callback_t;
 
+    /**
+     * @brief Set gimbal pitch and yaw angles (synchronous).
+     *
+     * This sets the desired pitch and yaw angles of a gimbal.
+     * The function will return when the command is accepted, however, it might
+     * take the gimbal longer to actually be set to the new angles.
+     *
+     * @param pitch_deg The pitch angle in degrees. Negative to point down.
+     * @param yaw_deg The yaw angle in degrees. Positive for clock-wise, range -180..180 or 0..360.
+     * @return Result of request.
+     */
     Result set_pitch_and_yaw(float pitch_deg, float yaw_deg);
 
+    /**
+     * @brief Set gimbal pitch and yaw angles (asynchronous).
+     *
+     * This sets the desired pitch and yaw angles of a gimbal.
+     * The callback will be called when the command is accepted, however, it might
+     * take the gimbal longer to actually be set to the new angles.
+     *
+     * @param pitch_deg The pitch angle in degrees. Negative to point down.
+     * @param yaw_deg The yaw angle in degrees. Positive for clock-wise, range -180..180 or 0..360.
+     * @param callback Function to call with result of request.
+     */
     void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, result_callback_t callback);
 
-    // Non-copyable
+    /**
+     * @brief Copy constructor (object is not copyable).
+     */
     Gimbal(const Gimbal &) = delete;
+
+    /**
+     * @brief Equality operator (object is not copyable).
+     */
     const Gimbal &operator=(const Gimbal &) = delete;
 
 private:
-    // Underlying implementation, set at instantiation
+    /** @private Underlying implementation, set at instantiation */
     GimbalImpl *_impl;
 };
 

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <functional>
+
+namespace dronecore {
+
+class GimbalImpl;
+
+class Gimbal
+{
+public:
+    explicit Gimbal(GimbalImpl *impl);
+    ~Gimbal();
+
+    enum class Result {
+        SUCCESS = 0,
+        ERROR,
+        TIMEOUT,
+        UNKNOWN
+    };
+
+    static const char *result_str(Result result);
+
+    typedef std::function<void(Result)> result_callback_t;
+
+    Result set_pitch_and_yaw(float pitch_deg, float yaw_deg);
+
+    void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, result_callback_t callback);
+
+    // Non-copyable
+    Gimbal(const Gimbal &) = delete;
+    const Gimbal &operator=(const Gimbal &) = delete;
+
+private:
+    // Underlying implementation, set at instantiation
+    GimbalImpl *_impl;
+};
+
+} // namespace dronecore

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -1,0 +1,79 @@
+#include "gimbal_impl.h"
+#include "device_impl.h"
+#include "global_include.h"
+#include "mavlink_include.h"
+#include <functional>
+
+namespace dronecore {
+
+GimbalImpl::GimbalImpl() :
+    PluginImplBase()
+{
+}
+
+GimbalImpl::~GimbalImpl()
+{
+}
+
+void GimbalImpl::init()
+{
+}
+
+void GimbalImpl::deinit()
+{
+}
+
+Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
+{
+    const float roll_deg = 0.0f;
+
+    return gimbal_result_from_command_result(
+               _parent->send_command_with_ack(
+                   MAV_CMD_DO_MOUNT_CONTROL,
+                   MavlinkCommands::Params {pitch_deg, roll_deg, yaw_deg, NAN, NAN, NAN,
+                                            MAV_MOUNT_MODE_MAVLINK_TARGETING},
+                   MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+}
+
+void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
+                                         Gimbal::result_callback_t callback)
+{
+    const float roll_deg = 0.0f;
+    _parent->send_command_with_ack_async(
+        MAV_CMD_DO_MOUNT_CONTROL,
+        MavlinkCommands::Params {pitch_deg, roll_deg, yaw_deg, NAN, NAN, NAN,
+                                 MAV_MOUNT_MODE_MAVLINK_TARGETING},
+        std::bind(&GimbalImpl::receive_command_result, std::placeholders::_1, callback),
+        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+}
+
+void GimbalImpl::receive_command_result(MavlinkCommands::Result command_result,
+                                        const Gimbal::result_callback_t &callback)
+{
+    Gimbal::Result gimbal_result = gimbal_result_from_command_result(command_result);
+
+    if (callback) {
+        callback(gimbal_result);
+    }
+}
+
+
+Gimbal::Result GimbalImpl::gimbal_result_from_command_result(MavlinkCommands::Result
+                                                             command_result)
+{
+    switch (command_result) {
+        case MavlinkCommands::Result::SUCCESS:
+            return Gimbal::Result::SUCCESS;
+        case MavlinkCommands::Result::TIMEOUT:
+            return Gimbal::Result::TIMEOUT;
+        case MavlinkCommands::Result::NO_DEVICE:
+        case MavlinkCommands::Result::CONNECTION_ERROR:
+        case MavlinkCommands::Result::BUSY:
+        case MavlinkCommands::Result::COMMAND_DENIED:
+        default:
+            return Gimbal::Result::ERROR;
+    }
+}
+
+
+} // namespace dronecore

--- a/plugins/gimbal/gimbal_impl.h
+++ b/plugins/gimbal/gimbal_impl.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "device_impl.h"
+#include "gimbal.h"
+#include "plugin_impl_base.h"
+
+namespace dronecore {
+
+class GimbalImpl : public PluginImplBase
+{
+public:
+    GimbalImpl();
+    ~GimbalImpl();
+
+    void init() override;
+    void deinit() override;
+
+    Gimbal::Result set_pitch_and_yaw(float pitch_deg, float yaw_deg);
+
+    void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
+                                 Gimbal::result_callback_t callback);
+
+    // Non-copyable
+    GimbalImpl(const GimbalImpl &) = delete;
+    const GimbalImpl &operator=(const GimbalImpl &) = delete;
+
+private:
+    static Gimbal::Result gimbal_result_from_command_result(MavlinkCommands::Result
+                                                            command_result);
+
+    static void receive_command_result(MavlinkCommands::Result command_result,
+                                       const Gimbal::result_callback_t &callback);
+};
+
+
+} // namespace dronecore


### PR DESCRIPTION
This adds a plugin which can set pitch and yaw angle of a gimbal.
Currently, the commands are sent to component ID 1, so the assumption is
that the gimbal is connected to the autopilot and not talking mavlink
itself. This could change or be made adaptable in the future.