### PR TITLE
Improve debug printfs

### DIFF
--- a/core/log.h
+++ b/core/log.h
@@ -10,6 +10,7 @@
 #endif
 
 #define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
 #define ANSI_COLOR_YELLOW  "\x1b[33m"
 #define ANSI_COLOR_BLUE    "\x1b[34m"
 #define ANSI_COLOR_GRAY    "\x1b[37m"
@@ -88,6 +89,7 @@ public:
 
         switch (_log_level) {
             case LogLevel::Debug:
+                std::cout << ANSI_COLOR_GREEN;
                 break;
             case LogLevel::Info:
                 std::cout << ANSI_COLOR_BLUE;
@@ -129,7 +131,7 @@ public:
 
         switch (_log_level) {
             case LogLevel::Debug:
-                break;
+            // FALLTHROUGH
             case LogLevel::Info:
             // FALLTHROUGH
             case LogLevel::Warn:

--- a/core/log.h
+++ b/core/log.h
@@ -126,10 +126,10 @@ public:
                 break;
         }
 
+        std::cout << ANSI_COLOR_RESET;
+
         std::cout << _s.str();
         std::cout << " (" << _caller_filename << ":" << _caller_filenumber << ")";
-
-        std::cout << ANSI_COLOR_RESET;
 
         std::cout << std::endl;
 #endif

--- a/core/log.h
+++ b/core/log.h
@@ -129,17 +129,7 @@ public:
         std::cout << _s.str();
         std::cout << " (" << _caller_filename << ":" << _caller_filenumber << ")";
 
-        switch (_log_level) {
-            case LogLevel::Debug:
-            // FALLTHROUGH
-            case LogLevel::Info:
-            // FALLTHROUGH
-            case LogLevel::Warn:
-            // FALLTHROUGH
-            case LogLevel::Err:
-                std::cout << ANSI_COLOR_RESET;
-                break;
-        }
+        std::cout << ANSI_COLOR_RESET;
 
         std::cout << std::endl;
 #endif


### PR DESCRIPTION
This makes debug printfs green as requested in #103 (closes #103).
Also, the color is now only applied for `[time|type]` instead of the whole line as agreed upon in #86.