### PR TITLE
mission: add delay before camera action

### DIFF
--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -289,4 +289,9 @@ void compare_mission_items(const std::shared_ptr<MissionItem> original,
         EXPECT_DOUBLE_EQ(original->get_camera_photo_interval_s(),
                          downloaded->get_camera_photo_interval_s());
     }
+
+    if (std::isfinite(original->get_camera_action_delay_s())) {
+        EXPECT_FLOAT_EQ(original->get_camera_action_delay_s(),
+                        downloaded->get_camera_action_delay_s());
+    }
 }

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -17,6 +17,7 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                                      bool is_fly_through,
                                                      float gimbal_pitch_deg,
                                                      float gimbal_yaw_deg,
+                                                     float camera_action_delay_s,
                                                      MissionItem::CameraAction camera_action);
 
 static void compare_mission_items(const std::shared_ptr<MissionItem> original,
@@ -61,6 +62,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
                          8.5456490218639658,
                          10.0f, 5.0f, false,
                          20.0f, 60.0f,
+                         NAN,
                          MissionItem::CameraAction::NONE));
 
     mission_items.push_back(
@@ -68,12 +70,14 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
                          8.5455360114574432,
                          10.0f, 2.0f, true,
                          0.0f, -60.0f,
+                         5.0f,
                          MissionItem::CameraAction::TAKE_PHOTO));
 
     mission_items.push_back(
         add_mission_item(47.398139363821485, 8.5453846156597137,
                          10.0f, 5.0f, true,
                          -46.0f, 0.0f,
+                         NAN,
                          MissionItem::CameraAction::START_VIDEO));
 
     mission_items.push_back(
@@ -81,6 +85,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
                          8.5454618036746979,
                          10.0f, 2.0f, false,
                          -90.0f, 30.0f,
+                         NAN,
                          MissionItem::CameraAction::STOP_VIDEO));
 
     mission_items.push_back(
@@ -88,6 +93,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
                          8.5456969141960144,
                          10.0f, 5.0f, false,
                          -45.0f, -30.0f,
+                         NAN,
                          MissionItem::CameraAction::START_PHOTO_INTERVAL));
 
     mission_items.push_back(
@@ -95,6 +101,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
                          8.5455576181411743,
                          10.0f, 5.0f, false,
                          0.0f, 0.0f,
+                         NAN,
                          MissionItem::CameraAction::STOP_PHOTO_INTERVAL));
 
     {
@@ -240,6 +247,7 @@ std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                               bool is_fly_through,
                                               float gimbal_pitch_deg,
                                               float gimbal_yaw_deg,
+                                              float camera_action_delay_s,
                                               MissionItem::CameraAction camera_action)
 {
     auto new_item = std::make_shared<MissionItem>();
@@ -248,6 +256,7 @@ std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
     new_item->set_speed(speed_m_s);
     new_item->set_fly_through(is_fly_through);
     new_item->set_gimbal_pitch_and_yaw(gimbal_pitch_deg, gimbal_yaw_deg);
+    new_item->set_camera_action_delay(camera_action_delay_s);
     new_item->set_camera_action(camera_action);
 
     // In order to test setting the interval, add it here.

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -625,6 +625,9 @@ void MissionImpl::assemble_mission_items()
                 result = Mission::Result::UNSUPPORTED;
             }
 
+        } else if (it->command == MAV_CMD_NAV_LOITER_TIME) {
+            new_mission_item->set_camera_action_delay(it->param1);
+
         } else {
             LogErr() << "UNSUPPORTED mission item command (" << it->command << ")";
             result = Mission::Result::UNSUPPORTED;

--- a/plugins/mission/mission_item.cpp
+++ b/plugins/mission/mission_item.cpp
@@ -40,6 +40,11 @@ void MissionItem::set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg)
     _impl->set_gimbal_pitch_and_yaw(pitch_deg, yaw_deg);
 }
 
+void MissionItem::set_camera_action_delay(float delay_s)
+{
+    _impl->set_camera_action_delay(delay_s);
+}
+
 void MissionItem::set_camera_action(CameraAction action)
 {
     _impl->set_camera_action(action);
@@ -73,6 +78,11 @@ bool MissionItem::get_fly_through() const
 float MissionItem::get_speed_m_s() const
 {
     return _impl->get_speed_m_s();
+}
+
+float MissionItem::get_camera_action_delay_s() const
+{
+    return _impl->get_camera_action_delay_s();
 }
 
 MissionItem::CameraAction MissionItem::get_camera_action() const

--- a/plugins/mission/mission_item.h
+++ b/plugins/mission/mission_item.h
@@ -66,6 +66,16 @@ public:
     void set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg);
 
     /**
+     * @brief Set a delay before executing camera action.
+     *
+     * This can be used to wait for vehicle to slow down or a gimbal to arrive at the set
+     * orientation.
+     *
+     * @param delay_s The time to wait for in seconds.
+     */
+    void set_camera_action_delay(float delay_s);
+
+    /**
      * @brief Possible camera actions at a mission item.
      */
     enum class CameraAction {
@@ -128,6 +138,13 @@ public:
      * @return Speed in metres/second.
      */
     float get_speed_m_s() const;
+
+    /**
+     * @brief Get the delay before executing camera action.
+     *
+     * @return The delay in seconds.
+     */
+    float get_camera_action_delay_s() const;
 
     /**
      * @brief Get the camera action set for this mission item.

--- a/plugins/mission/mission_item_impl.cpp
+++ b/plugins/mission/mission_item_impl.cpp
@@ -40,6 +40,11 @@ void MissionItemImpl::set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg)
     _gimbal_yaw_deg = yaw_deg;
 }
 
+void MissionItemImpl::set_camera_action_delay(float delay_s)
+{
+    _camera_action_delay_s = delay_s;
+}
+
 void MissionItemImpl::set_camera_action(MissionItem::CameraAction action)
 {
     _camera_action = action;

--- a/plugins/mission/mission_item_impl.h
+++ b/plugins/mission/mission_item_impl.h
@@ -16,6 +16,7 @@ public:
     void set_speed(float speed_m_s);
     void set_fly_through(bool fly_through);
     void set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg);
+    void set_camera_action_delay(float delay_s);
     void set_camera_action(MissionItem::CameraAction action);
     void set_camera_photo_interval(double interval_s);
 
@@ -26,6 +27,7 @@ public:
     bool get_fly_through() const { return _fly_through; };
     float get_gimbal_pitch_deg() const { return _gimbal_pitch_deg; }
     float get_gimbal_yaw_deg() const { return _gimbal_yaw_deg; }
+    float get_camera_action_delay_s() const { return _camera_action_delay_s; }
     MissionItem::CameraAction get_camera_action() const { return _camera_action; }
     double get_camera_photo_interval_s() const { return _camera_photo_interval_s; }
 
@@ -49,6 +51,7 @@ private:
     bool _fly_through = false;
     float _gimbal_pitch_deg = NAN;
     float _gimbal_yaw_deg = NAN;
+    float _camera_action_delay_s = NAN;
     MissionItem::CameraAction _camera_action {MissionItem::CameraAction::NONE};
     double _camera_photo_interval_s = 1.0;
 };


### PR DESCRIPTION
This adds the possibility to add a delay before taking a picture or
starting a video. This is used to wait for a gimbal to reach its
orientation, or a vehicle to slow down.

The current implementation is not optimal because it is based on the
`LOITER_TIME` waypoint instead of the `NAV_DELAY` command which would be
more appropriate but is not supported (yet).