### PR TITLE
offboard: automatically send setpoins at set rate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library(dronecore STATIC
     core/curl_wrapper.cpp
     core/http_loader.cpp
     core/timeout_handler.cpp
+    core/call_every_handler.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/core/device_plugin_container.cpp
     ${plugin_source_files}
 )
@@ -185,6 +186,7 @@ if(NOT IOS AND NOT ANDROID)
         core/unittests_main.cpp
         core/http_loader_test.cpp
         core/timeout_handler_test.cpp
+        core/call_every_handler_test.cpp
         ${plugin_unittest_source_files}
         ${unit_tests_src}
     )

--- a/core/call_every_handler.cpp
+++ b/core/call_every_handler.cpp
@@ -1,0 +1,77 @@
+#include "call_every_handler.h"
+
+namespace dronecore {
+
+CallEveryHandler::CallEveryHandler()
+{
+}
+
+CallEveryHandler::~CallEveryHandler()
+{
+}
+
+void CallEveryHandler::add(std::function<void()> callback, float interval_s, void **cookie)
+{
+    auto new_entry = std::make_shared<Entry>();
+    new_entry->callback = callback;
+    new_entry->last_time = steady_time();
+    new_entry->interval_s = interval_s;
+
+    void *new_cookie = static_cast<void *>(new_entry.get());
+
+    {
+        std::lock_guard<std::mutex> lock(_entries_mutex);
+        _entries.insert(std::pair<void *, std::shared_ptr<Entry>>(new_cookie, new_entry));
+    }
+
+    if (cookie != nullptr) {
+        *cookie = new_cookie;
+    }
+}
+
+void CallEveryHandler::change(float interval_s, const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_entries_mutex);
+
+    auto it = _entries.find(const_cast<void *>(cookie));
+    if (it != _entries.end()) {
+        it->second->interval_s = interval_s;
+    }
+}
+
+void CallEveryHandler::remove(const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_entries_mutex);
+
+    auto it = _entries.find(const_cast<void *>(cookie));
+    if (it != _entries.end()) {
+        _entries.erase(const_cast<void *>(cookie));
+    }
+}
+
+void CallEveryHandler::run_once()
+{
+    _entries_mutex.lock();
+
+    for (auto it = _entries.begin(); it != _entries.end(); ++it ) {
+
+        if (elapsed_since_s(it->second->last_time) > double(it->second->interval_s)) {
+
+            shift_steady_time_by(it->second->last_time, double(it->second->interval_s));
+
+            if (it->second->callback) {
+
+                // Get a copy for the callback because we unlock.
+                std::function<void()> callback = it->second->callback;
+
+                // Unlock while we callback because it might in turn want to add timeouts.
+                _entries_mutex.unlock();
+                callback();
+                _entries_mutex.lock();
+            }
+        }
+    }
+    _entries_mutex.unlock();
+}
+
+} // namespace dronecore

--- a/core/call_every_handler.cpp
+++ b/core/call_every_handler.cpp
@@ -39,6 +39,16 @@ void CallEveryHandler::change(float interval_s, const void *cookie)
     }
 }
 
+void CallEveryHandler::reset(const void *cookie)
+{
+    std::lock_guard<std::mutex> lock(_entries_mutex);
+
+    auto it = _entries.find(const_cast<void *>(cookie));
+    if (it != _entries.end()) {
+        it->second->last_time = steady_time();
+    }
+}
+
 void CallEveryHandler::remove(const void *cookie)
 {
     std::lock_guard<std::mutex> lock(_entries_mutex);
@@ -53,7 +63,7 @@ void CallEveryHandler::run_once()
 {
     _entries_mutex.lock();
 
-    for (auto it = _entries.begin(); it != _entries.end(); ++it ) {
+    for (auto it = _entries.begin(); it != _entries.end(); ++it) {
 
         if (elapsed_since_s(it->second->last_time) > double(it->second->interval_s)) {
 

--- a/core/call_every_handler.h
+++ b/core/call_every_handler.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <mutex>
+#include <memory>
+#include <functional>
+#include <map>
+#include "global_include.h"
+
+namespace dronecore {
+
+class CallEveryHandler
+{
+public:
+    CallEveryHandler();
+    ~CallEveryHandler();
+
+    // delete copy and move constructors and assign operators
+    CallEveryHandler(CallEveryHandler const &) = delete;            // Copy construct
+    CallEveryHandler(CallEveryHandler &&) = delete;                 // Move construct
+    CallEveryHandler &operator=(CallEveryHandler const &) = delete; // Copy assign
+    CallEveryHandler &operator=(CallEveryHandler &&) = delete;      // Move assign
+
+    void add(std::function<void()> callback, float interval_s, void **cookie);
+    void change(float interval_s, const void *cookie);
+    void remove(const void *cookie);
+
+    void run_once();
+
+private:
+    struct Entry {
+        std::function<void()> callback;
+        dl_time_t last_time;
+        float interval_s;
+    };
+
+    std::map<void *, std::shared_ptr<Entry>> _entries {};
+    std::mutex _entries_mutex {};
+};
+
+} // namespace dronecore

--- a/core/call_every_handler.h
+++ b/core/call_every_handler.h
@@ -22,6 +22,7 @@ public:
 
     void add(std::function<void()> callback, float interval_s, void **cookie);
     void change(float interval_s, const void *cookie);
+    void reset(const void *cookie);
     void remove(const void *cookie);
 
     void run_once();

--- a/core/call_every_handler_test.cpp
+++ b/core/call_every_handler_test.cpp
@@ -1,0 +1,91 @@
+#include "call_every_handler.h"
+#include <gtest/gtest.h>
+#include <atomic>
+#include "log.h"
+
+using namespace dronecore;
+
+TEST(CallEveryHandler, Single)
+{
+    CallEveryHandler ceh;
+
+    int num_called = 0;
+
+    void *cookie = nullptr;
+    ceh.add([&num_called]() { ++num_called; }, 0.1, &cookie);
+
+    for (int i = 0; i < 11; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        ceh.run_once();
+    }
+    EXPECT_EQ(num_called, 1);
+
+    UNUSED(cookie);
+}
+
+TEST(CallEveryHandler, Multiple)
+{
+    CallEveryHandler ceh;
+
+    int num_called = 0;
+
+    void *cookie = nullptr;
+    ceh.add([&num_called]() { ++num_called; }, 0.1, &cookie);
+
+    for (int i = 0; i < 10; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ceh.run_once();
+    }
+    EXPECT_EQ(num_called, 10);
+
+    num_called = 0;
+    ceh.change(0.2, cookie);
+
+    for (int i = 0; i < 20; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ceh.run_once();
+    }
+
+    EXPECT_EQ(num_called, 10);
+
+    num_called = 0;
+    ceh.remove(cookie);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ceh.run_once();
+    EXPECT_EQ(num_called, 0);
+}
+
+TEST(CallEveryHandler, InParallel)
+{
+    CallEveryHandler ceh;
+
+    int num_called1 = 0;
+    int num_called2 = 0;
+
+    void *cookie1 = nullptr;
+    void *cookie2 = nullptr;
+    ceh.add([&num_called1]() { ++num_called1; }, 0.1, &cookie1);
+    ceh.add([&num_called2]() { ++num_called2; }, 0.2, &cookie2);
+
+    for (int i = 0; i < 10; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ceh.run_once();
+    }
+
+    EXPECT_EQ(num_called1, 10);
+    EXPECT_EQ(num_called2, 5);
+
+    num_called1 = 0;
+    num_called2 = 0;
+
+    ceh.change(0.4, cookie1);
+    ceh.change(0.1, cookie2);
+
+    for (int i = 0; i < 10; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ceh.run_once();
+    }
+
+    EXPECT_EQ(num_called1, 2);
+    EXPECT_EQ(num_called2, 10);
+}

--- a/core/call_every_handler_test.cpp
+++ b/core/call_every_handler_test.cpp
@@ -12,7 +12,7 @@ TEST(CallEveryHandler, Single)
     int num_called = 0;
 
     void *cookie = nullptr;
-    ceh.add([&num_called]() { ++num_called; }, 0.1, &cookie);
+    ceh.add([&num_called]() { ++num_called; }, 0.1f, &cookie);
 
     for (int i = 0; i < 11; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -30,7 +30,7 @@ TEST(CallEveryHandler, Multiple)
     int num_called = 0;
 
     void *cookie = nullptr;
-    ceh.add([&num_called]() { ++num_called; }, 0.1, &cookie);
+    ceh.add([&num_called]() { ++num_called; }, 0.1f, &cookie);
 
     for (int i = 0; i < 10; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -39,7 +39,7 @@ TEST(CallEveryHandler, Multiple)
     EXPECT_EQ(num_called, 10);
 
     num_called = 0;
-    ceh.change(0.2, cookie);
+    ceh.change(0.2f, cookie);
 
     for (int i = 0; i < 20; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -64,8 +64,8 @@ TEST(CallEveryHandler, InParallel)
 
     void *cookie1 = nullptr;
     void *cookie2 = nullptr;
-    ceh.add([&num_called1]() { ++num_called1; }, 0.1, &cookie1);
-    ceh.add([&num_called2]() { ++num_called2; }, 0.2, &cookie2);
+    ceh.add([&num_called1]() { ++num_called1; }, 0.1f, &cookie1);
+    ceh.add([&num_called2]() { ++num_called2; }, 0.2f, &cookie2);
 
     for (int i = 0; i < 10; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -78,8 +78,8 @@ TEST(CallEveryHandler, InParallel)
     num_called1 = 0;
     num_called2 = 0;
 
-    ceh.change(0.4, cookie1);
-    ceh.change(0.1, cookie2);
+    ceh.change(0.4f, cookie1);
+    ceh.change(0.1f, cookie2);
 
     for (int i = 0; i < 10; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -97,7 +97,7 @@ TEST(CallEveryHandler, Reset)
     int num_called = 0;
 
     void *cookie = nullptr;
-    ceh.add([&num_called]() { ++num_called; }, 0.1, &cookie);
+    ceh.add([&num_called]() { ++num_called; }, 0.1f, &cookie);
 
     for (int i = 0; i < 8; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/core/call_every_handler_test.cpp
+++ b/core/call_every_handler_test.cpp
@@ -89,3 +89,35 @@ TEST(CallEveryHandler, InParallel)
     EXPECT_EQ(num_called1, 2);
     EXPECT_EQ(num_called2, 10);
 }
+
+TEST(CallEveryHandler, Reset)
+{
+    CallEveryHandler ceh;
+
+    int num_called = 0;
+
+    void *cookie = nullptr;
+    ceh.add([&num_called]() { ++num_called; }, 0.1, &cookie);
+
+    for (int i = 0; i < 8; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        ceh.run_once();
+        if (i == 8) {
+        }
+    }
+    EXPECT_EQ(num_called, 0);
+
+    ceh.reset(cookie);
+
+    for (int i = 0; i < 8; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        ceh.run_once();
+    }
+    EXPECT_EQ(num_called, 0);
+
+    for (int i = 0; i < 3; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        ceh.run_once();
+    }
+    EXPECT_EQ(num_called, 1);
+}

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -105,6 +105,21 @@ void DeviceImpl::process_mavlink_message(const mavlink_message_t &message)
     }
 }
 
+void DeviceImpl::add_call_every(std::function<void()> callback, float interval_s, void **cookie)
+{
+    _call_every_handler.add(callback, interval_s, cookie);
+}
+
+void DeviceImpl::change_call_every(float interval_s, const void *cookie)
+{
+    _call_every_handler.change(interval_s, cookie);
+}
+
+void DeviceImpl::remove_call_every(const void *cookie)
+{
+    _call_every_handler.remove(cookie);
+}
+
 void DeviceImpl::process_heartbeat(const mavlink_message_t &message)
 {
     mavlink_heartbeat_t heartbeat;
@@ -220,6 +235,7 @@ void DeviceImpl::device_thread(DeviceImpl *self)
             last_time = steady_time();
         }
 
+        self->_call_every_handler.run_once();
         self->_timeout_handler.run_once();
         self->_params.do_work();
         self->_commands.do_work();

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -115,6 +115,11 @@ void DeviceImpl::change_call_every(float interval_s, const void *cookie)
     _call_every_handler.change(interval_s, cookie);
 }
 
+void DeviceImpl::reset_call_every(const void *cookie)
+{
+    _call_every_handler.reset(cookie);
+}
+
 void DeviceImpl::remove_call_every(const void *cookie)
 {
     _call_every_handler.remove(cookie);

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -5,6 +5,7 @@
 #include "mavlink_parameters.h"
 #include "mavlink_commands.h"
 #include "timeout_handler.h"
+#include "call_every_handler.h"
 #include <cstdint>
 #include <functional>
 #include <atomic>
@@ -37,10 +38,12 @@ public:
     void register_timeout_handler(std::function<void()> callback,
                                   double duration_s,
                                   void **cookie);
-
     void refresh_timeout_handler(const void *cookie);
-
     void unregister_timeout_handler(const void *cookie);
+
+    void add_call_every(std::function<void()> callback, float interval_s, void **cookie);
+    void change_call_every(float interval_s, const void *cookie);
+    void remove_call_every(const void *cookie);
 
     bool send_message(const mavlink_message_t &message);
 
@@ -158,6 +161,7 @@ private:
     MavlinkCommands _commands;
 
     TimeoutHandler _timeout_handler {};
+    CallEveryHandler _call_every_handler {};
 };
 
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -43,6 +43,7 @@ public:
 
     void add_call_every(std::function<void()> callback, float interval_s, void **cookie);
     void change_call_every(float interval_s, const void *cookie);
+    void reset_call_every(const void *cookie);
     void remove_call_every(const void *cookie);
 
     bool send_message(const mavlink_message_t &message);

--- a/core/global_include.cpp
+++ b/core/global_include.cpp
@@ -39,6 +39,10 @@ dl_time_t steady_time_in_future(double duration_s)
     return now + std::chrono::milliseconds(int64_t(duration_s * 1e3));
 }
 
+void shift_steady_time_by(dl_time_t &time, double offset_s)
+{
+    time += std::chrono::milliseconds(int64_t(offset_s * 1e3));
+}
 
 double to_rad_from_deg(double deg)
 {

--- a/core/global_include.h
+++ b/core/global_include.h
@@ -35,6 +35,7 @@ typedef std::chrono::time_point<std::chrono::steady_clock> dl_time_t;
 
 dl_time_t steady_time();
 dl_time_t steady_time_in_future(double duration_s);
+void shift_steady_time_by(dl_time_t &time, double offset_s);
 
 double elapsed_s();
 double elapsed_since_s(const dl_time_t &since);

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -56,7 +56,7 @@ inline void connection_error_exit(DroneCore::ConnectionResult result, const std:
 // Logs during Offboard control
 inline void offboard_log(const std::string &offb_mode, const std::string msg)
 {
-    std::cout << "[" << offb_mode << "]" << msg << std::endl;
+    std::cout << "[" << offb_mode << "] " << msg << std::endl;
 }
 
 /**
@@ -69,59 +69,45 @@ bool offb_ctrl_ned(Device &device)
     const std::string offb_mode = "NED";
     // Send it once before starting offboard, otherwise it will be rejected.
     device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 0.0f});
-    offboard_log(offb_mode, " Sent Null velocity command once before starting OFFBOARD");
 
     Offboard::Result offboard_result = device.offboard().start();
     offboard_error_exit(offboard_result, "Offboard start failed");
-    offboard_log(offb_mode, " OFFBOARD started");
-    sleep_for(seconds(1));
+    offboard_log(offb_mode, "Offboard started");
 
-    // Let yaw settle.
-    offboard_log(offb_mode, " Let yaw settle...");
+    offboard_log(offb_mode,  "Turn to face East");
     device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
-    sleep_for(seconds(1));
-    offboard_log(offb_mode, " Done...");
+    sleep_for(seconds(1)); // Let yaw settle.
 
     {
         const float step_size = 0.01f;
         const float one_cycle = 2.0f * (float)M_PI;
-        const unsigned steps = (unsigned)(one_cycle / step_size);
+        const unsigned steps = 2 * unsigned(one_cycle / step_size);
 
-        offboard_log(offb_mode,  " Go right & oscillate");
+        offboard_log(offb_mode,  "Go North and back South");
         for (unsigned i = 0; i < steps; ++i) {
             float vx = 5.0f * sinf(i * step_size);
             device.offboard().set_velocity_ned({vx, 0.0f, 0.0f, 90.0f});
             sleep_for(milliseconds(10));
         }
     }
-    offboard_log(offb_mode, " Done...");
-    // NOTE: Use sleep_for() after each velocity-ned command to closely monitor their behaviour.
 
-    offboard_log(offb_mode,  " Turn clock-wise 270 deg");
+    offboard_log(offb_mode,  "Turn to face West");
     device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
     sleep_for(seconds(2));
 
-    offboard_log(offb_mode, " Done");
 
-    offboard_log(offb_mode, " Go UP 2 m/s, Turn clock-wise 180 deg");
+    offboard_log(offb_mode, "Go up 2 m/s, turn to face South");
     device.offboard().set_velocity_ned({0.0f, 0.0f, -2.0f, 180.0f});
     sleep_for(seconds(4));
-    offboard_log(offb_mode, " Done...");
 
-    offboard_log(offb_mode,  " Turn clock-wise 90 deg");
-    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
-    sleep_for(seconds(4));
-    offboard_log(offb_mode, " Done...");
-
-    offboard_log(offb_mode,  " Go DOWN 1.0 m/s");
+    offboard_log(offb_mode,  "Go down 1 m/s, turn to face North");
     device.offboard().set_velocity_ned({0.0f, 0.0f, 1.0f, 0.0f});
     sleep_for(seconds(4));
-    offboard_log(offb_mode, " Done...");
 
     // Now, stop offboard mode.
     offboard_result = device.offboard().stop();
     offboard_error_exit(offboard_result, "Offboard stop failed: ");
-    offboard_log(offb_mode, " OFFBOARD stopped");
+    offboard_log(offb_mode, "Offboard stopped");
 
     return true;
 }
@@ -135,53 +121,44 @@ bool offb_ctrl_body(Device &device)
 {
     const std::string offb_mode = "BODY";
 
+    // Send it once before starting offboard, otherwise it will be rejected.
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-    offboard_log(offb_mode,  " Sent once before starting OFFBOARD");
 
     Offboard::Result offboard_result = device.offboard().start();
     offboard_error_exit(offboard_result, "Offboard start failed: ");
-    offboard_log(offb_mode, " OFFBOARD started");
+    offboard_log(offb_mode, "Offboard started");
 
-    // Turn around yaw and climb
-    offboard_log(offb_mode, " Turn around yaw & climb");
+    offboard_log(offb_mode, "Turn clock-wise and climb");
     device.offboard().set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
-    sleep_for(seconds(2));
+    sleep_for(seconds(5));
 
-    // Turn back
-    offboard_log(offb_mode, " Turn back");
+    offboard_log(offb_mode, "Turn back anti-clockwise");
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
-    sleep_for(seconds(2));
+    sleep_for(seconds(5));
 
-    // Wait for a bit
-    offboard_log(offb_mode, " Wait for a bit");
+    offboard_log(offb_mode, "Wait for a bit");
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
     sleep_for(seconds(2));
-    // NOTE: Use sleep_for() after each velocity-ned command to closely monitor their behaviour.
 
-    // Fly a circle
-    offboard_log(offb_mode, " Fly a circle");
-    device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 60.0f});
-    sleep_for(seconds(5));
+    offboard_log(offb_mode, "Fly a circle");
+    device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 30.0f});
+    sleep_for(seconds(15));
 
-    // Wait for a bit
-    offboard_log(offb_mode, " Wait for a bit");
+    offboard_log(offb_mode, "Wait for a bit");
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
     sleep_for(seconds(5));
 
-    // Fly a circle sideways
-    offboard_log(offb_mode, " Fly a circle sideways...");
-    device.offboard().set_velocity_body({0.0f, -5.0f, 0.0f, 60.0f});
-    sleep_for(seconds(5));
+    offboard_log(offb_mode, "Fly a circle sideways");
+    device.offboard().set_velocity_body({0.0f, -5.0f, 0.0f, 30.0f});
+    sleep_for(seconds(15));
 
-    // Wait for a bit
-    offboard_log(offb_mode, " Wait for a bit");
+    offboard_log(offb_mode, "Wait for a bit");
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-    sleep_for(seconds(5));
+    sleep_for(seconds(8));
 
-    // Now, stop offboard mode.
     offboard_result = device.offboard().stop();
     offboard_error_exit(offboard_result, "Offboard stop failed: ");
-    offboard_log(offb_mode, " OFFBOARD stopped");
+    offboard_log(offb_mode, "Offboard stopped");
 
     return true;
 }
@@ -190,7 +167,6 @@ int main(int, char **)
 {
     DroneCore dc;
 
-    // add udp connection
     DroneCore::ConnectionResult conn_result = dc.add_udp_connection();
     connection_error_exit(conn_result, "Connection failed");
 
@@ -200,7 +176,7 @@ int main(int, char **)
         sleep_for(seconds(1));
     }
 
-    // Device got connected...
+    // Device got discovered.
     Device &device = dc.device();
 
     while (!device.telemetry().health_all_ok()) {
@@ -209,25 +185,22 @@ int main(int, char **)
     }
     std::cout << "Device is ready" << std::endl;
 
-    // Arm
     Action::Result arm_result = device.action().arm();
     action_error_exit(arm_result, "Arming failed");
     std::cout << "Armed" << std::endl;
 
-    // Takeoff
     Action::Result takeoff_result = device.action().takeoff();
     action_error_exit(takeoff_result, "Takeoff failed");
     std::cout << "In Air..." << std::endl;
     sleep_for(seconds(5));
 
-    //  using LOCAL NED co-ordinates
+    //  using local NED co-ordinates
     bool ret = offb_ctrl_ned(device);
     if (ret == false) {
         return EXIT_FAILURE;
     }
-    std::cout << "---------------------------" << std::endl;
 
-    //  using BODY NED co-ordinates
+    //  using body co-ordinates
     ret = offb_ctrl_body(device);
     if (ret == false) {
         return EXIT_FAILURE;

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -1,7 +1,9 @@
 /**
 * @file offboard_velocity.cpp
 * @brief Example that demonstrates offboard velocity control in local NED and body coordinates
-* @author Author: Julian Oes <julian@oes.ch>, Shakthi Prashanth <shakthi.prashanth.m@intel.com>
+*
+* @authors Author: Julian Oes <julian@oes.ch>,
+*                  Shakthi Prashanth <shakthi.prashanth.m@intel.com>
 * @date 2017-10-17
 */
 
@@ -76,12 +78,9 @@ bool offb_ctrl_ned(Device &device)
 
     // Let yaw settle.
     offboard_log(offb_mode, " Let yaw settle...");
-    for (unsigned i = 0; i < 100; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
+    sleep_for(seconds(1));
     offboard_log(offb_mode, " Done...");
-    sleep_for(seconds(5));
 
     {
         const float step_size = 0.01f;
@@ -99,31 +98,24 @@ bool offb_ctrl_ned(Device &device)
     // NOTE: Use sleep_for() after each velocity-ned command to closely monitor their behaviour.
 
     offboard_log(offb_mode,  " Turn clock-wise 270 deg");
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
+    sleep_for(seconds(2));
+
     offboard_log(offb_mode, " Done");
 
     offboard_log(offb_mode, " Go UP 2 m/s, Turn clock-wise 180 deg");
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, -2.0f, 180.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, -2.0f, 180.0f});
+    sleep_for(seconds(4));
     offboard_log(offb_mode, " Done...");
 
     offboard_log(offb_mode,  " Turn clock-wise 90 deg");
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
+    sleep_for(seconds(4));
     offboard_log(offb_mode, " Done...");
 
     offboard_log(offb_mode,  " Go DOWN 1.0 m/s");
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 1.0f, 0.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 1.0f, 0.0f});
+    sleep_for(seconds(4));
     offboard_log(offb_mode, " Done...");
 
     // Now, stop offboard mode.
@@ -152,53 +144,39 @@ bool offb_ctrl_body(Device &device)
 
     // Turn around yaw and climb
     offboard_log(offb_mode, " Turn around yaw & climb");
-    for (unsigned i = 0; i < 200; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
+    sleep_for(seconds(2));
 
     // Turn back
     offboard_log(offb_mode, " Turn back");
-    for (unsigned i = 0; i < 200; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
+    sleep_for(seconds(2));
 
     // Wait for a bit
     offboard_log(offb_mode, " Wait for a bit");
-    for (unsigned i = 0; i < 200; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    sleep_for(seconds(2));
     // NOTE: Use sleep_for() after each velocity-ned command to closely monitor their behaviour.
 
     // Fly a circle
     offboard_log(offb_mode, " Fly a circle");
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 60.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 60.0f});
+    sleep_for(seconds(5));
 
     // Wait for a bit
     offboard_log(offb_mode, " Wait for a bit");
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    sleep_for(seconds(5));
 
     // Fly a circle sideways
     offboard_log(offb_mode, " Fly a circle sideways...");
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({0.0f, -5.0f, 0.0f, 60.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, -5.0f, 0.0f, 60.0f});
+    sleep_for(seconds(5));
 
     // Wait for a bit
     offboard_log(offb_mode, " Wait for a bit");
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-        sleep_for(milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    sleep_for(seconds(5));
 
     // Now, stop offboard mode.
     offboard_result = device.offboard().stop();

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -1,11 +1,11 @@
 /**
-* @file offboard_velocity.cpp
-* @brief Example that demonstrates offboard velocity control in local NED and body coordinates
-*
-* @authors Author: Julian Oes <julian@oes.ch>,
-*                  Shakthi Prashanth <shakthi.prashanth.m@intel.com>
-* @date 2017-10-17
-*/
+ * @file offboard_velocity.cpp
+ * @brief Example that demonstrates offboard velocity control in local NED and body coordinates
+ *
+ * @authors Author: Julian Oes <julian@oes.ch>,
+ *                  Shakthi Prashanth <shakthi.prashanth.m@intel.com>
+ * @date 2017-10-17
+ */
 
 #include <iostream>
 #include <cmath>
@@ -60,10 +60,10 @@ inline void offboard_log(const std::string &offb_mode, const std::string msg)
 }
 
 /**
-* @name connected device
-* @brief Does Offboard control using NED co-ordinates
-* returns true if everything went well in Offboard control, exits with a log otherwise.
-**/
+ * Does Offboard control using NED co-ordinates.
+ *
+ * returns true if everything went well in Offboard control, exits with a log otherwise.
+ */
 bool offb_ctrl_ned(Device &device)
 {
     const std::string offb_mode = "NED";
@@ -127,10 +127,10 @@ bool offb_ctrl_ned(Device &device)
 }
 
 /**
-* @name connected device
-* @brief Does Offboard control using BODY co-ordinates
-* returns true if everything went well in Offboard control, exits with a log otherwise.
-*/
+ * Does Offboard control using body co-ordinates.
+ *
+ * returns true if everything went well in Offboard control, exits with a log otherwise.
+ */
 bool offb_ctrl_body(Device &device)
 {
     const std::string offb_mode = "BODY";

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -53,6 +53,31 @@ TEST_F(SitlTest, OffboardVelocityNED)
         }
     }
 
+    // Let's make sure that offboard knows it is active.
+    EXPECT_TRUE(device.offboard().is_active());
+
+    // Then randomly, we just interfere with a mission command to pause it.
+    device.mission().pause_mission_async(nullptr);
+    // This needs some time to propagate.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    // Now it should be inactive.
+    EXPECT_TRUE(device.offboard().is_active());
+
+    // So we start it yet again.
+    offboard_result = device.offboard().start();
+
+    // It should complain because no setpoint is set.
+    EXPECT_EQ(offboard_result, Offboard::Result::NO_SETPOINT_SET);
+
+    // Alright, set one then.
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
+    // And start again.
+    offboard_result = device.offboard().start();
+    // Now it should work.
+    EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
+    EXPECT_TRUE(device.offboard().is_active());
+
+    // Ok let's carry on.
     device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
     std::this_thread::sleep_for(std::chrono::seconds(2));
 

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -43,7 +43,7 @@ TEST_F(SitlTest, OffboardVelocityNED)
     {
         const float step_size = 0.01f;
         const float one_cycle = 2.0f * M_PI_F;
-        const unsigned steps = static_cast<unsigned>(one_cycle / step_size);
+        const unsigned steps = 2 * unsigned(one_cycle / step_size);
 
         for (unsigned i = 0; i < steps; ++i) {
             float vx = 5.0f * sinf(i * step_size);
@@ -104,14 +104,15 @@ TEST_F(SitlTest, OffboardVelocityBody)
 
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
-    // Turn around yaw and climb
+    // Yaw clockwise and climb
     device.offboard().set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
-    // Turn back
+    // Yaw anti-clockwise
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
+    // Wait for a bit
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
@@ -119,6 +120,7 @@ TEST_F(SitlTest, OffboardVelocityBody)
     device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 60.0f});
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
+    // Wait for a bit
     device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
     std::this_thread::sleep_for(std::chrono::seconds(5));
 

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -37,11 +37,8 @@ TEST_F(SitlTest, OffboardVelocityNED)
 
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
-    // Let yaw settle.
-    for (unsigned i = 0; i < 100; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     {
         const float step_size = 0.01f;
@@ -56,35 +53,22 @@ TEST_F(SitlTest, OffboardVelocityNED)
         }
     }
 
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, -2.0f, 180.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, -2.0f, 180.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
-    for (unsigned i = 0; i < 400; ++i) {
-        device.offboard().set_velocity_ned({0.0f, 0.0f, 1.0f, 0.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_ned({0.0f, 0.0f, 1.0f, 0.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
     offboard_result = device.offboard().stop();
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = device.action().land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
-
-    std::this_thread::sleep_for(std::chrono::seconds(10));
-
-    action_ret = device.action().disarm();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
 }
 
@@ -121,55 +105,34 @@ TEST_F(SitlTest, OffboardVelocityBody)
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     // Turn around yaw and climb
-    for (unsigned i = 0; i < 200; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Turn back
-    for (unsigned i = 0; i < 200; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    // Wait for a bit
-    for (unsigned i = 0; i < 200; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Fly a circle
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 60.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({5.0f, 0.0f, 0.0f, 60.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
-    // Wait for a bit
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     // Fly a circle sideways
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({0.0f, -5.0f, 0.0f, 60.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, -5.0f, 0.0f, 60.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     // Wait for a bit
-    for (unsigned i = 0; i < 500; ++i) {
-        device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    device.offboard().set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     offboard_result = device.offboard().stop();
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = device.action().land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
-
-    std::this_thread::sleep_for(std::chrono::seconds(10));
-
-    action_ret = device.action().disarm();
     EXPECT_EQ(action_ret, Action::Result::SUCCESS);
 }

--- a/plugins/offboard/offboard.cpp
+++ b/plugins/offboard/offboard.cpp
@@ -12,12 +12,12 @@ Offboard::~Offboard()
 {
 }
 
-Offboard::Result Offboard::start() const
+Offboard::Result Offboard::start()
 {
     return _impl->start();
 }
 
-Offboard::Result Offboard::stop() const
+Offboard::Result Offboard::stop()
 {
     return _impl->stop();
 }
@@ -30,6 +30,11 @@ void Offboard::start_async(result_callback_t callback)
 void Offboard::stop_async(result_callback_t callback)
 {
     _impl->stop_async(callback);
+}
+
+bool Offboard::is_active() const
+{
+    return _impl->is_active();
 }
 
 void Offboard::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -6,14 +6,21 @@ namespace dronecore {
 
 class OffboardImpl;
 
+
 /**
  * @brief This class is used to control a drone with velocity commands.
  *
  * The module is called offboard because the velocity commands can be sent from external sources
  * as opposed to onboard control right inside the autopilot "board".
  *
+ * Client code must specify a setpoint before starting offboard mode.
+ * DroneCore automatically resends setpoints at 20Hz (PX4 Offboard mode requires that setpoints are
+ * minimally resent at 2Hz). If more precise control is required, clients can call the
+ * setpoint methods at whatever rate is required.
+ *
  * **Attention:** this is work in progress, use with caution!
  */
+
 class Offboard
 {
 public:
@@ -58,21 +65,21 @@ public:
      * @brief Type for Velocity commands in NED (North East Down) coordinates and yaw.
      */
     struct VelocityNEDYaw {
-        float north_m_s; /**< Velocity North in metres/second. */
-        float east_m_s; /**< Velocity East in metres/second. */
-        float down_m_s; /**< Velocity Down in metres/second. */
-        float yaw_deg; /**< Yaw in degrees (0 North, positive is clock-wise looking from above. */
+        float north_m_s; /**< @brief Velocity North in metres/second. */
+        float east_m_s; /**< @brief Velocity East in metres/second. */
+        float down_m_s; /**< @brief Velocity Down in metres/second. */
+        float yaw_deg; /**< @brief Yaw in degrees (0 North, positive is clock-wise looking from above). */
     };
 
     /**
      * @brief Type for velocity commands in body coordinates (forward, right, down and yaw angular rate).
      */
     struct VelocityBodyYawspeed {
-        float forward_m_s; /**< Velocity forward in metres/second. */
-        float right_m_s; /**< Velocity right in metres/secon.d */
-        float down_m_s; /**< Velocity down in metres/second. */
-        float yawspeed_deg_s; /**< Yaw angular rate in degrees/second (positive for clock-wise
-                                   looking from above. */
+        float forward_m_s; /**< @brief Velocity forward in metres/second. */
+        float right_m_s; /**< @brief Velocity right in metres/secon.d */
+        float down_m_s; /**< @brief Velocity down in metres/second. */
+        float yawspeed_deg_s; /**< @brief Yaw angular rate in degrees/second (positive for clock-wise
+                                   looking from above). */
     };
 
     /**
@@ -121,7 +128,6 @@ public:
      */
     void set_velocity_body(VelocityBodyYawspeed velocity_body_yawspeed);
 
-    // Non-copyable
     /**
      * @brief Copy constructor (object is not copyable).
      */

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -94,6 +94,8 @@ public:
     /**
      * @brief Stop offboard control (synchronous).
      *
+     * The vehicle will be put into Hold mode: https://docs.px4.io/en/flight_modes/hold.html
+     *
      * @return Result of request.
      */
     Offboard::Result stop() const;
@@ -109,6 +111,8 @@ public:
 
     /**
      * @brief Stop offboard control (asynchronous).
+     *
+     * The vehicle will be put into Hold mode: https://docs.px4.io/en/flight_modes/hold.html
      *
      * @param callback Callback to receive request result.
      */

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -89,7 +89,7 @@ public:
      *
      * @return Result of request.
      */
-    Offboard::Result start() const;
+    Offboard::Result start();
 
     /**
      * @brief Stop offboard control (synchronous).
@@ -98,7 +98,7 @@ public:
      *
      * @return Result of request.
      */
-    Offboard::Result stop() const;
+    Offboard::Result stop();
 
     /**
      * @brief Start offboard control (asynchronous).
@@ -117,6 +117,16 @@ public:
      * @param callback Callback to receive request result.
      */
     void stop_async(result_callback_t callback);
+
+    /**
+     * @brief Check if offboard control is active.
+     *
+     * `true` means that the vehicle is in offboard mode and we are actively sending
+     * setpoints.
+     *
+     * @return `true` if active
+     */
+    bool is_active() const;
 
     /**
      * @brief Set the velocity in NED coordinates and yaw.

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -37,6 +37,7 @@ public:
         BUSY, /**< @brief Vehicle busy. */
         COMMAND_DENIED, /**< @brief Command denied. */
         TIMEOUT, /**< @brief %Request timeout. */
+        NO_SETPOINT_SET, /**< Can't start without setpoint set. */
         UNKNOWN /**< @brief Unknown error. */
     };
 

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -111,11 +111,6 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback),
         MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
-
-    _result_callback = callback;
-
-    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0,
-                                      &_timeout_cookie);
 }
 
 void OffboardImpl::stop_async(Offboard::result_callback_t callback)
@@ -145,37 +140,15 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
                   std::placeholders::_1, callback),
         MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 
-    _result_callback = callback;
-
-    _parent->register_timeout_handler(std::bind(&OffboardImpl::timeout_happened, this), 1.0,
-                                      &_timeout_cookie);
 }
 
 void OffboardImpl::receive_command_result(MavlinkCommands::Result result,
                                           const Offboard::result_callback_t &callback)
 {
-    // We got a command back, so we can get rid of the timeout handler.
-    _parent->unregister_timeout_handler(_timeout_cookie);
-
     Offboard::Result offboard_result = offboard_result_from_command_result(result);
-
-    callback(offboard_result);
-}
-
-void OffboardImpl::timeout_happened()
-{
-    report_offboard_result(_result_callback, Offboard::Result::TIMEOUT);
-}
-
-void OffboardImpl::report_offboard_result(const Offboard::result_callback_t &callback,
-                                          Offboard::Result result)
-{
-    if (callback == nullptr) {
-        LogWarn() << "Callback is not set";
-        return;
+    if (callback) {
+        callback(offboard_result);
     }
-
-    callback(result);
 }
 
 void OffboardImpl::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -57,7 +57,7 @@ Offboard::Result OffboardImpl::start() const
 Offboard::Result OffboardImpl::stop() const
 {
     {
-        //std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if (_mode != Mode::NOT_ACTIVE && _call_every_cookie != nullptr) {
             _parent->remove_call_every(_call_every_cookie);
         }
@@ -84,7 +84,7 @@ Offboard::Result OffboardImpl::stop() const
 void OffboardImpl::start_async(Offboard::result_callback_t callback)
 {
     {
-        //std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
 
         if (_mode == Mode::NOT_ACTIVE) {
             if (callback) {

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -90,6 +90,7 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
             if (callback) {
                 callback(Offboard::Result::NO_SETPOINT_SET);
             }
+            return;
         }
     }
 

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -159,6 +159,8 @@ void OffboardImpl::receive_command_result(MavlinkCommands::Result result,
 void OffboardImpl::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)
 {
     _mutex.lock();
+    _velocity_ned_yaw = velocity_ned_yaw;
+
     if (_mode != Mode::VELOCITY_NED) {
         if (_call_every_cookie) {
             // If we're already sending other setpoints, stop that now.
@@ -176,7 +178,6 @@ void OffboardImpl::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)
         // reschedule the next call, so we don't send setpoints too often.
         _parent->reset_call_every(_call_every_cookie);
     }
-    _velocity_ned_yaw = velocity_ned_yaw;
     _mutex.unlock();
 
     // also send it right now to reduce latency
@@ -186,6 +187,8 @@ void OffboardImpl::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)
 void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed)
 {
     _mutex.lock();
+    _velocity_body_yawspeed = velocity_body_yawspeed;
+
     if (_mode != Mode::VELOCITY_BODY) {
         if (_call_every_cookie) {
             // If we're already sending other setpoints, stop that now.
@@ -203,7 +206,6 @@ void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_bod
         // reschedule the next call, so we don't send setpoints too often.
         _parent->reset_call_every(_call_every_cookie);
     }
-    _velocity_body_yawspeed = velocity_body_yawspeed;
     _mutex.unlock();
 
     // also send it right now to reduce latency

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -34,18 +34,9 @@ private:
     void receive_command_result(MavlinkCommands::Result result,
                                 const Offboard::result_callback_t &callback);
 
-    static void report_offboard_result(const Offboard::result_callback_t &callback,
-                                       Offboard::Result result);
-
     static Offboard::Result offboard_result_from_command_result(
         MavlinkCommands::Result result);
 
-    void timeout_happened();
-
-    bool _offboard_mode_active = false;
-    Offboard::result_callback_t _result_callback = nullptr;
-
-    void *_timeout_cookie = nullptr;
 
     mutable std::mutex _mutex {};
     enum class Mode {

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -17,11 +17,13 @@ public:
     void init() override;
     void deinit() override;
 
-    Offboard::Result start() const;
-    Offboard::Result stop() const;
+    Offboard::Result start();
+    Offboard::Result stop();
 
     void start_async(Offboard::result_callback_t callback);
     void stop_async(Offboard::result_callback_t callback);
+
+    bool is_active() const;
 
     void set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw);
     void set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
@@ -37,6 +39,7 @@ private:
     static Offboard::Result offboard_result_from_command_result(
         MavlinkCommands::Result result);
 
+    void stop_sending_setpoints();
 
     mutable std::mutex _mutex {};
     enum class Mode {


### PR DESCRIPTION
This changes the offboard API so that it is no longer required to send
setpoints at least every 0.5 seconds. Instead, this enables to set a
setpoint once and only set it again when it changes. The implementation
will automatically send it at 20 Hz internally.

If the setpoints need to be sent at a higher rate, e.g. for very smooth
control, that is still possible by just setting the setpoints at high
rate. Whenever a setpoint changes, it is immediately sent to the
vehicle.

Tested in SITL using the integration tests as well as the offboard example.