### PR TITLE
FollowMe plugin: Fixed build errors

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND integration_tests
     info
     mission_change_speed
 	mission_survey
-	waypoints
+	mission
     curl
 )
 

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -43,7 +43,7 @@ void FollowMeImpl::init()
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
-        std::bind(&FollowMeImpl::process_heartbeat, this, _1), (void *)this);
+        std::bind(&FollowMeImpl::process_heartbeat, this, _1), static_cast<void *>(this));
 
 }
 
@@ -60,7 +60,7 @@ void FollowMeImpl::timeout_occurred()
     // update current location coordinates
     _motion_report.lat_int += 10;
     _motion_report.lon_int += 5;
-    _motion_report.alt += 10.0;
+    _motion_report.alt += 10.0f;
 
     _estimatation_capabilities |= (1 << static_cast<int>(FollowMe::ESTCapabilities::POS));
 
@@ -72,8 +72,8 @@ void FollowMeImpl::timeout_occurred()
     _motion_report.vz += 0.5f;
 
     // calculate x,y velocity if it's
-    _motion_report.vx += 0.05;
-    _motion_report.vy += 0.04;
+    _motion_report.vx += 0.05f;
+    _motion_report.vy += 0.04f;
 
     _estimatation_capabilities |= (1 << static_cast<int>(FollowMe::ESTCapabilities::VEL));
 


### PR DESCRIPTION
Thanks @julianoes  for the review. I have fixed build errors that you reported.
Brief description of what is happening in current implementation of FollowMe:

- `FollowMe::start()` registers a timeout handler for periodic emission of Motion reports to Vehicle
- `FollowMe::start()` changes flight mode to **FollowMe**
- Everytime timeout handler is called, Fake GPS info is used to emit motion reports repeatedly
_(I might use `CallEveryHandler` in upcoming commits)_
- I will add `setposition` next commit.
