### PR TITLE
core: correctly capitalize MAVLink

### DIFF
--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -164,7 +164,7 @@ void DeviceImpl::process_statustext(const mavlink_message_t &message)
     mavlink_statustext_t statustext;
     mavlink_msg_statustext_decode(&message, &statustext);
 
-    std::string debug_str = "mavlink ";
+    std::string debug_str = "MAVLink ";
 
     switch (statustext.severity) {
         case MAV_SEVERITY_EMERGENCY:

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -164,7 +164,7 @@ void DeviceImpl::process_statustext(const mavlink_message_t &message)
     mavlink_statustext_t statustext;
     mavlink_msg_statustext_decode(&message, &statustext);
 
-    std::string debug_str = "MAVLink ";
+    std::string debug_str = "MAVLink: ";
 
     switch (statustext.severity) {
         case MAV_SEVERITY_EMERGENCY:


### PR DESCRIPTION
As requested in #136.