### PR TITLE
core: add a lock around mavlink communication

### DIFF
--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -98,6 +98,10 @@ void DeviceImpl::unregister_timeout_handler(const void *cookie)
 
 void DeviceImpl::process_mavlink_message(const mavlink_message_t &message)
 {
+    if (_communication_locked) {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(_mavlink_handler_table_mutex);
 
     for (auto it = _mavlink_handler_table.begin(); it != _mavlink_handler_table.end(); ++it) {
@@ -267,6 +271,10 @@ void DeviceImpl::send_heartbeat(DeviceImpl *self)
 
 bool DeviceImpl::send_message(const mavlink_message_t &message)
 {
+    if (_communication_locked) {
+        return false;
+    }
+
     return _parent->send_message(message);
 }
 
@@ -512,6 +520,16 @@ void DeviceImpl::set_msg_rate_async(uint16_t message_id, double rate_hz,
             MavlinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
             callback);
     }
+}
+
+void DeviceImpl::lock_communication()
+{
+    _communication_locked = true;
+}
+
+void DeviceImpl::unlock_communication()
+{
+    _communication_locked = false;
 }
 
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -95,6 +95,10 @@ public:
 
     Time &get_time() { return _time; };
 
+    // This allows a plugin to lock and unlock all mavlink communication.
+    void lock_communication();
+    void unlock_communication();
+
     // Non-copyable
     DeviceImpl(const DeviceImpl &) = delete;
     const DeviceImpl &operator=(const DeviceImpl &) = delete;
@@ -167,6 +171,8 @@ private:
     CallEveryHandler _call_every_handler;
 
     Time _time {};
+
+    std::atomic<bool> _communication_locked {false};
 };
 
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -96,6 +96,8 @@ public:
     Time &get_time() { return _time; };
 
     // This allows a plugin to lock and unlock all mavlink communication.
+    // The functionality is currently not used by a plugin included here
+    // but nevertheless there for other plugins that can be added from external.
     void lock_communication();
     void unlock_communication();
 


### PR DESCRIPTION
This adds a lock to receive and send mavlink messages. This can be used
by a plugin to lockdown DroneCore.

The lock is disabled by default, so this change should not have any
effects apart from a few more CPU cycles.