### PR TITLE
Download mission capability

### DIFF
--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -112,11 +112,11 @@ int main(int /*argc*/, char ** /*argv*/)
 
     {
         std::cout << "Uploading mission..." << std::endl;
-        // We only have the send_mission function asynchronous for now, so we wrap it using
+        // We only have the upload_mission function asynchronous for now, so we wrap it using
         // std::future.
         auto prom = std::make_shared<std::promise<Mission::Result>>();
         auto future_result = prom->get_future();
-        device.mission().send_mission_async(
+        device.mission().upload_mission_async(
         mission_items, [prom](Mission::Result result) {
             prom->set_value(result);
         });

--- a/grpc/server/dronecore_server.cpp
+++ b/grpc/server/dronecore_server.cpp
@@ -78,7 +78,7 @@ public:
             mission_items.push_back(new_item);
         }
 
-        dc.device().mission().send_mission_async(
+        dc.device().mission().upload_mission_async(
         mission_items, [prom, response](Mission::Result result) {
             response->set_result(static_cast<dronecorerpc::MissionResult::Result>(result));
             response->set_result_str(Mission::result_str(result));

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -96,11 +96,11 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
 
     {
         LogInfo() << "Uploading mission...";
-        // We only have the send_mission function asynchronous for now, so we wrap it using
+        // We only have the upload_mission function asynchronous for now, so we wrap it using
         // std::future.
         auto prom = std::make_shared<std::promise<void>>();
         auto future_result = prom->get_future();
-        device.mission().send_mission_async(
+        device.mission().upload_mission_async(
         mission_items, [prom](Mission::Result result) {
             ASSERT_EQ(result, Mission::Result::SUCCESS);
             prom->set_value();

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                               float gimbal_yaw_deg,
                                               MissionItem::CameraAction camera_action)
 {
-    std::shared_ptr<MissionItem> new_item(new MissionItem());
+    auto new_item = std::make_shared<MissionItem>();
     new_item->set_position(latitude_deg, longitude_deg);
     new_item->set_relative_altitude(relative_altitude_m);
     new_item->set_speed(speed_m_s);

--- a/integration_tests/mission_change_speed.cpp
+++ b/integration_tests/mission_change_speed.cpp
@@ -9,7 +9,7 @@
 using namespace dronecore;
 using namespace std::placeholders; // for `_1`
 
-static void receive_send_mission_result(Mission::Result result);
+static void receive_upload_mission_result(Mission::Result result);
 static void receive_start_mission_result(Mission::Result result);
 static void receive_mission_progress(int current, int total);
 
@@ -53,8 +53,8 @@ TEST_F(SitlTest, MissionChangeSpeed)
     mission_items.push_back(add_waypoint(47.39824201089737, 8.5447561722784542, 10, speeds[2]));
     mission_items.push_back(add_waypoint(47.397733642793433, 8.5447776308767516, 10, speeds[3]));
 
-    device.mission().send_mission_async(mission_items,
-                                        std::bind(&receive_send_mission_result, _1));
+    device.mission().upload_mission_async(mission_items,
+                                          std::bind(&receive_upload_mission_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_TRUE(_mission_sent_ok);
 
@@ -106,7 +106,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     ASSERT_EQ(result, Action::Result::SUCCESS);
 }
 
-void receive_send_mission_result(Mission::Result result)
+void receive_upload_mission_result(Mission::Result result)
 {
     EXPECT_EQ(result, Mission::Result::SUCCESS);
 

--- a/integration_tests/mission_survey.cpp
+++ b/integration_tests/mission_survey.cpp
@@ -27,7 +27,7 @@ enum class MissionState : unsigned {
 static MissionState _mission_state = MissionState::INIT;
 
 //Mission::mission_result_t receive_mission_result;
-static void receive_send_mission_result(Mission::Result result);
+static void receive_upload_mission_result(Mission::Result result);
 static void receive_start_mission_result(Mission::Result result);
 static void receive_mission_progress(int current, int total);
 static void receive_arm_result(Action::Result result);
@@ -135,9 +135,9 @@ TEST_F(SitlTest, MissionSurvey)
         }
         switch (_mission_state) {
             case MissionState::INIT:
-                device.mission().send_mission_async(
+                device.mission().upload_mission_async(
                     mis,
-                    std::bind(&receive_send_mission_result, _1));
+                    std::bind(&receive_upload_mission_result, _1));
                 _mission_state = MissionState::UPLOADING;
                 break;
             case MissionState::UPLOADING:
@@ -199,7 +199,7 @@ TEST_F(SitlTest, MissionSurvey)
     EXPECT_EQ(_mission_state, MissionState::DONE);
 }
 
-void receive_send_mission_result(Mission::Result result)
+void receive_upload_mission_result(Mission::Result result)
 {
     EXPECT_EQ(result, Mission::Result::SUCCESS);
 

--- a/plugins/mission/mission.cpp
+++ b/plugins/mission/mission.cpp
@@ -14,10 +14,10 @@ Mission::~Mission()
 }
 
 
-void Mission::send_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
-                                 result_callback_t callback)
+void Mission::upload_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
+                                   result_callback_t callback)
 {
-    _impl->send_mission_async(mission_items, callback);
+    _impl->upload_mission_async(mission_items, callback);
 }
 
 void Mission::start_mission_async(result_callback_t callback)

--- a/plugins/mission/mission.cpp
+++ b/plugins/mission/mission.cpp
@@ -20,6 +20,11 @@ void Mission::upload_mission_async(const std::vector<std::shared_ptr<MissionItem
     _impl->upload_mission_async(mission_items, callback);
 }
 
+void Mission::download_mission_async(Mission::mission_items_and_result_callback_t callback)
+{
+    _impl->download_mission_async(callback);
+}
+
 void Mission::start_mission_async(result_callback_t callback)
 {
     _impl->start_mission_async(callback);

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -35,6 +35,8 @@ public:
         BUSY, /**< @brief %Vehicle busy. */
         TIMEOUT, /**< @brief Request timed out. */
         INVALID_ARGUMENT, /**< @brief Invalid argument. */
+        UNSUPPORTED, /**< @brief The mission downloaded from the device is not supported. */
+        NO_MISSION_AVAILABLE, /**< @brief No mission available on device. */
         UNKNOWN /**< @brief Unknown error. */
     };
 
@@ -59,6 +61,22 @@ public:
      */
     void upload_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
                               result_callback_t callback);
+
+    /**
+     * @brief Callback type for `download_mission_async` call to get mission items and result.
+     */
+    typedef std::function<void(Result, std::vector<std::shared_ptr<MissionItem>>)>
+    mission_items_and_result_callback_t;
+
+    /**
+     * @brief Downloads a vector of mission items from the device (asynchronous).
+     *
+     * The mission items are downloaded from a drone.
+     *
+     * @param mission_items reference to vector of mission items.
+     * @param callback callback to receive result of this request
+     */
+    void download_mission_async(mission_items_and_result_callback_t callback);
 
     /**
      * @brief Starts the mission (asynchronous).

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -56,8 +56,8 @@ public:
      * The mission items are uploaded to a drone. Once uploaded the mission can be started and
      * executed even if a connection is lost.
      *
-     * @param mission_items reference to vector of mission items.
-     * @param callback callback to receive result of this request
+     * @param mission_items Reference to vector of mission items.
+     * @param callback Callback to receive result of this request.
      */
     void upload_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
                               result_callback_t callback);
@@ -73,8 +73,8 @@ public:
      *
      * The mission items are downloaded from a drone.
      *
-     * @param mission_items reference to vector of mission items.
-     * @param callback callback to receive result of this request
+     * @param mission_items Reference to vector of mission items.
+     * @param callback Callback to receive result of this request.
      */
     void download_mission_async(mission_items_and_result_callback_t callback);
 
@@ -84,7 +84,7 @@ public:
      * Note that the mission must be uplaoded to the vehicle using `upload_mission_async()` before
      * this method is called.
      *
-     * @param callback callback to receive result of this request
+     * @param callback callback to receive result of this request.
      */
     void start_mission_async(result_callback_t callback);
 
@@ -96,7 +96,7 @@ public:
      * A multicopter should just hover at the spot while a fixedwing vehicle should loiter
      * around the location where it paused.
      *
-     * @param callback callback to receive result of this request
+     * @param callback Callback to receive result of this request.
      */
     void pause_mission_async(result_callback_t callback);
 
@@ -109,8 +109,8 @@ public:
      * Note that this is not necessarily true for general missions using mavlink if loop counters
      * are used.
      *
-     * @param current index for mission index to go to next (0 based)
-     * @param callback callback to receive result of this request.
+     * @param current Index for mission index to go to next (0 based).
+     * @param callback Callback to receive result of this request.
      */
     void set_current_mission_item_async(int current, result_callback_t callback);
 
@@ -143,15 +143,15 @@ public:
      *
      * The mission is finished if current == total.
      *
-     * @param current current mission item index (0 based)
-     * @param total total number of mission items
+     * @param current Current mission item index (0 based).
+     * @param total Total number of mission items.
      */
     typedef std::function<void(int current, int total)> progress_callback_t;
 
     /**
      * @brief Subscribes to mission progress (asynchronous).
      *
-     * @param callback callback to receive mission progress
+     * @param callback Callback to receive mission progress.
      */
     void subscribe_progress(progress_callback_t callback);
 

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -49,7 +49,7 @@ public:
     typedef std::function<void(Result)> result_callback_t;
 
     /**
-     * @brief Sends a vector of mission items to the device (asynchronous).
+     * @brief Uploads a vector of mission items to the device (asynchronous).
      *
      * The mission items are uploaded to a drone. Once uploaded the mission can be started and
      * executed even if a connection is lost.
@@ -57,13 +57,13 @@ public:
      * @param mission_items reference to vector of mission items.
      * @param callback callback to receive result of this request
      */
-    void send_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
-                            result_callback_t callback);
+    void upload_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
+                              result_callback_t callback);
 
     /**
      * @brief Starts the mission (asynchronous).
      *
-     * Note that the mission must be uplaoded to the vehicle using `send_mission_async()` before
+     * Note that the mission must be uplaoded to the vehicle using `upload_mission_async()` before
      * this method is called.
      *
      * @param callback callback to receive result of this request

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -7,14 +7,7 @@
 namespace dronecore {
 
 MissionImpl::MissionImpl() :
-    PluginImplBase(),
-    _result_callback(nullptr),
-    _last_current_mavlink_mission_item(-1),
-    _last_reached_mavlink_mission_item(-1),
-    _mission_items(),
-    _mavlink_mission_item_messages(),
-    _mavlink_mission_item_to_mission_item_indices(),
-    _progress_callback(nullptr)
+    PluginImplBase()
 {
 }
 
@@ -258,7 +251,7 @@ void MissionImpl::assemble_mavlink_messages()
 
             uint8_t autocontinue = 1;
 
-            std::shared_ptr<mavlink_message_t> message_speed(new mavlink_message_t());
+            auto message_speed = std::make_shared<mavlink_message_t>();
             mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
                                               _parent->get_own_component_id(),
                                               message_speed.get(),
@@ -297,7 +290,7 @@ void MissionImpl::assemble_mavlink_messages()
 
             uint8_t autocontinue = 1;
 
-            std::shared_ptr<mavlink_message_t> message_gimbal(new mavlink_message_t());
+            auto message_gimbal = std::make_shared<mavlink_message_t>();
             mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
                                               _parent->get_own_component_id(),
                                               message_gimbal.get(),
@@ -368,7 +361,7 @@ void MissionImpl::assemble_mavlink_messages()
                     break;
             }
 
-            std::shared_ptr<mavlink_message_t> message_camera(new mavlink_message_t());
+            auto message_camera = std::make_shared<mavlink_message_t>();
             mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
                                               _parent->get_own_component_id(),
                                               message_camera.get(),

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -488,6 +488,7 @@ void MissionImpl::set_current_mission_item_async(int current, Mission::result_ca
 
     if (!_parent->send_message(message)) {
         report_mission_result(callback, Mission::Result::ERROR);
+        return;
     }
 
     _activity = Activity::SET_CURRENT;

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -263,6 +263,7 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
 
     if (!_parent->send_message(message)) {
         report_mission_result(callback, Mission::Result::ERROR);
+        return;
     }
 
     _activity = Activity::SET_MISSION;

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -68,6 +68,8 @@ void MissionImpl::process_mission_request(const mavlink_message_t &unused)
 
 void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     mavlink_mission_request_int_t mission_request_int;
     mavlink_msg_mission_request_int_decode(&message, &mission_request_int);
 
@@ -92,6 +94,8 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
 
 void MissionImpl::process_mission_ack(const mavlink_message_t &message)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_activity != Activity::SET_MISSION) {
         LogWarn() << "Error: not sure how to process Mission ack.";
         return;
@@ -133,6 +137,8 @@ void MissionImpl::process_mission_ack(const mavlink_message_t &message)
 
 void MissionImpl::process_mission_current(const mavlink_message_t &message)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     mavlink_mission_current_t mission_current;
     mavlink_msg_mission_current_decode(&message, &mission_current);
 
@@ -152,6 +158,8 @@ void MissionImpl::process_mission_current(const mavlink_message_t &message)
 
 void MissionImpl::process_mission_item_reached(const mavlink_message_t &message)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     mavlink_mission_item_reached_t mission_item_reached;
     mavlink_msg_mission_item_reached_decode(&message, &mission_item_reached);
 
@@ -165,6 +173,8 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
                                        &mission_items,
                                        const Mission::result_callback_t &callback)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_activity != Activity::NONE) {
         report_mission_result(callback, Mission::Result::BUSY);
         return;
@@ -383,6 +393,8 @@ void MissionImpl::assemble_mavlink_messages()
 
 void MissionImpl::start_mission_async(const Mission::result_callback_t &callback)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_activity != Activity::NONE) {
         report_mission_result(callback, Mission::Result::BUSY);
         return;
@@ -413,6 +425,8 @@ void MissionImpl::start_mission_async(const Mission::result_callback_t &callback
 
 void MissionImpl::pause_mission_async(const Mission::result_callback_t &callback)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_activity != Activity::NONE) {
         report_mission_result(callback, Mission::Result::BUSY);
         return;
@@ -443,6 +457,8 @@ void MissionImpl::pause_mission_async(const Mission::result_callback_t &callback
 
 void MissionImpl::set_current_mission_item_async(int current, Mission::result_callback_t &callback)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_activity != Activity::NONE) {
         report_mission_result(callback, Mission::Result::BUSY);
         return;
@@ -527,6 +543,8 @@ void MissionImpl::report_progress()
 void MissionImpl::receive_command_result(MavlinkCommands::Result result,
                                          const Mission::result_callback_t &callback)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_activity == Activity::SEND_COMMAND) {
         _activity = Activity::NONE;
     }

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -544,7 +544,7 @@ void MissionImpl::assemble_mission_items()
         } else if (it->command == MAV_CMD_IMAGE_START_CAPTURE) {
             if (it->param2 > 0 && int(it->param3) == 0) {
                 new_mission_item->set_camera_action(MissionItem::CameraAction::START_PHOTO_INTERVAL);
-                new_mission_item->set_camera_photo_interval(it->param2);
+                new_mission_item->set_camera_photo_interval(double(it->param2));
             } else if (int(it->param2) == 0 && int(it->param3) == 1) {
                 new_mission_item->set_camera_action(MissionItem::CameraAction::TAKE_PHOTO);
             } else {

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -38,11 +38,20 @@ void MissionImpl::init()
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_ITEM_REACHED,
         std::bind(&MissionImpl::process_mission_item_reached, this, _1), this);
+
+    _parent->register_mavlink_message_handler(
+        MAVLINK_MSG_ID_MISSION_COUNT,
+        std::bind(&MissionImpl::process_mission_count, this, _1), this);
+
+    _parent->register_mavlink_message_handler(
+        MAVLINK_MSG_ID_MISSION_ITEM_INT,
+        std::bind(&MissionImpl::process_mission_item_int, this, _1), this);
 }
 
 void MissionImpl::deinit()
 {
     _parent->unregister_all_mavlink_message_handlers(this);
+    _parent->unregister_timeout_handler(_timeout_cookie);
 }
 
 void MissionImpl::process_mission_request(const mavlink_message_t &unused)
@@ -169,6 +178,59 @@ void MissionImpl::process_mission_item_reached(const mavlink_message_t &message)
     }
 }
 
+void MissionImpl::process_mission_count(const mavlink_message_t &message)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_activity != Activity::GET_MISSION) {
+        return;
+    }
+
+    mavlink_mission_count_t mission_count;
+    mavlink_msg_mission_count_decode(&message, &mission_count);
+
+    _num_mission_items_to_download = mission_count.count;
+    _next_mission_item_to_download = 0;
+    _parent->refresh_timeout_handler(_timeout_cookie);
+    download_next_mission_item();
+}
+
+void MissionImpl::process_mission_item_int(const mavlink_message_t &message)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    auto mission_item_int_ptr = std::make_shared<mavlink_mission_item_int_t>();
+    mavlink_msg_mission_item_int_decode(&message, mission_item_int_ptr.get());
+
+    _mavlink_mission_items_downloaded.push_back(mission_item_int_ptr);
+
+    if (mission_item_int_ptr->seq == _next_mission_item_to_download) {
+        LogDebug() << "Received mission item " << _next_mission_item_to_download;
+    }
+
+    if (_next_mission_item_to_download + 1 == _num_mission_items_to_download) {
+        _parent->unregister_timeout_handler(_timeout_cookie);
+
+        mavlink_message_t ack_message;
+        mavlink_msg_mission_ack_pack(_parent->get_own_system_id(),
+                                     _parent->get_own_component_id(),
+                                     &ack_message,
+                                     _parent->get_target_system_id(),
+                                     _parent->get_target_component_id(),
+                                     MAV_MISSION_ACCEPTED,
+                                     MAV_MISSION_TYPE_MISSION);
+
+        _parent->send_message(ack_message);
+
+        assemble_mission_items();
+
+    } else {
+        ++_next_mission_item_to_download;
+        _parent->refresh_timeout_handler(_timeout_cookie);
+        download_next_mission_item();
+    }
+}
+
 void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<MissionItem>>
                                        &mission_items,
                                        const Mission::result_callback_t &callback)
@@ -190,8 +252,6 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
 
     assemble_mavlink_messages();
 
-    _activity = Activity::SET_MISSION;
-
     mavlink_message_t message;
     mavlink_msg_mission_count_pack(_parent->get_own_system_id(),
                                    _parent->get_own_component_id(),
@@ -209,9 +269,40 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
     _result_callback = callback;
 }
 
+void MissionImpl::download_mission_async(const Mission::mission_items_and_result_callback_t
+                                         &callback)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_activity != Activity::NONE) {
+        report_mission_items_and_result(callback, Mission::Result::BUSY);
+        return;
+    }
+
+    mavlink_message_t message;
+    mavlink_msg_mission_request_list_pack(_parent->get_own_system_id(),
+                                          _parent->get_own_component_id(),
+                                          &message,
+                                          _parent->get_target_system_id(),
+                                          _parent->get_target_component_id(),
+                                          MAV_MISSION_TYPE_MISSION);
+
+    if (!_parent->send_message(message)) {
+        report_mission_items_and_result(callback, Mission::Result::ERROR);
+        return;
+    }
+
+    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this), 1.0,
+                                      &_timeout_cookie);
+
+    // Clear our internal cache and re-populate it.
+    _mavlink_mission_items_downloaded.clear();
+    _activity = Activity::GET_MISSION;
+    _mission_items_and_result_callback = callback;
+}
+
 void MissionImpl::assemble_mavlink_messages()
 {
-    // TODO: delete all entries first
     _mavlink_mission_item_messages.clear();
 
     unsigned item_i = 0;
@@ -391,6 +482,123 @@ void MissionImpl::assemble_mavlink_messages()
     }
 }
 
+void MissionImpl::assemble_mission_items()
+{
+    _mission_items.clear();
+
+    Mission::Result result = Mission::Result::SUCCESS;
+
+    auto new_mission_item = std::make_shared<MissionItem>();
+    bool have_set_position = false;
+
+    if (_mavlink_mission_items_downloaded.size() > 0) {
+        // The first mission item needs to be a waypoint with position.
+        if (_mavlink_mission_items_downloaded.at(0)->command != MAV_CMD_NAV_WAYPOINT) {
+            LogErr() << "First mission item is not a waypoint";
+            result = Mission::Result::UNSUPPORTED;
+            return;
+        }
+    }
+
+    if (_mavlink_mission_items_downloaded.size() == 0) {
+        LogErr() << "No downloaded mission items";
+        result = Mission::Result::NO_MISSION_AVAILABLE;
+        return;
+    }
+
+    for (auto &it : _mavlink_mission_items_downloaded) {
+        LogDebug() << "Assembling Message: " << int(it->seq);
+
+
+        if (it->command == MAV_CMD_NAV_WAYPOINT) {
+            if (it->frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+                LogErr() << "Waypoint frame not supported unsupported";
+                result = Mission::Result::UNSUPPORTED;
+                break;
+            }
+
+            if (have_set_position) {
+                // When a new position comes in, create next mission item.
+                _mission_items.push_back(new_mission_item);
+                new_mission_item = std::make_shared<MissionItem>();
+                have_set_position = false;
+            }
+
+            new_mission_item->set_position(double(it->x) * 1e-7, double(it->y) * 1e-7);
+            new_mission_item->set_relative_altitude(it->z);
+
+            new_mission_item->set_fly_through(!(it->param1 > 0));
+
+            have_set_position = true;
+
+        } else if (it->command == MAV_CMD_DO_MOUNT_CONTROL) {
+            if (int(it->z) != MAV_MOUNT_MODE_MAVLINK_TARGETING) {
+                LogErr() << "Gimbal mount mode unsupported";
+                result = Mission::Result::UNSUPPORTED;
+                break;
+            }
+
+            new_mission_item->set_gimbal_pitch_and_yaw(it->param1, it->param3);
+
+        } else if (it->command == MAV_CMD_IMAGE_START_CAPTURE) {
+            if (it->param2 > 0 && int(it->param3) == 0) {
+                new_mission_item->set_camera_action(MissionItem::CameraAction::START_PHOTO_INTERVAL);
+                new_mission_item->set_camera_photo_interval(it->param2);
+            } else if (int(it->param2) == 0 && int(it->param3) == 1) {
+                new_mission_item->set_camera_action(MissionItem::CameraAction::TAKE_PHOTO);
+            } else {
+                LogErr() << "Mission item START_CAPTURE params unsupported.";
+                result = Mission::Result::UNSUPPORTED;
+                break;
+            }
+
+        } else if (it->command == MAV_CMD_IMAGE_STOP_CAPTURE) {
+            new_mission_item->set_camera_action(MissionItem::CameraAction::STOP_PHOTO_INTERVAL);
+
+        } else if (it->command == MAV_CMD_VIDEO_START_CAPTURE) {
+            new_mission_item->set_camera_action(MissionItem::CameraAction::START_VIDEO);
+
+        } else if (it->command == MAV_CMD_VIDEO_STOP_CAPTURE) {
+            new_mission_item->set_camera_action(MissionItem::CameraAction::STOP_VIDEO);
+
+        } else if (it->command == MAV_CMD_DO_CHANGE_SPEED) {
+            if (int(it->param1) == 1 && it->param3 < 0 && int(it->param4) == 0) {
+                new_mission_item->set_speed(it->param2);
+            } else {
+                LogErr() << "Mission item DO_CHANGE_SPEED params unsupported";
+                result = Mission::Result::UNSUPPORTED;
+            }
+
+        } else {
+            LogErr() << "UNSUPPORTED mission item command (" << it->command << ")";
+            result = Mission::Result::UNSUPPORTED;
+            break;
+        }
+    }
+
+    // Don't forget to add last mission item.
+    _mission_items.push_back(new_mission_item);
+
+    report_mission_items_and_result(_mission_items_and_result_callback, result);
+    _activity = Activity::NONE;
+}
+
+void MissionImpl::download_next_mission_item()
+{
+    mavlink_message_t message;
+    mavlink_msg_mission_request_int_pack(_parent->get_own_system_id(),
+                                         _parent->get_own_component_id(),
+                                         &message,
+                                         _parent->get_target_system_id(),
+                                         _parent->get_target_component_id(),
+                                         _next_mission_item_to_download,
+                                         MAV_MISSION_TYPE_MISSION);
+
+    LogDebug() << "Requested mission item " << _next_mission_item_to_download;
+
+    _parent->send_message(message);
+}
+
 void MissionImpl::start_mission_async(const Mission::result_callback_t &callback)
 {
     std::lock_guard<std::mutex> lock(_mutex);
@@ -531,6 +739,22 @@ void MissionImpl::report_mission_result(const Mission::result_callback_t &callba
     callback(result);
 }
 
+void MissionImpl::report_mission_items_and_result(const Mission::mission_items_and_result_callback_t
+                                                  &callback,
+                                                  Mission::Result result)
+{
+    if (callback == nullptr) {
+        LogWarn() << "Callback is not set";
+        return;
+    }
+
+    if (result != Mission::Result::SUCCESS) {
+        // Don't return garbage, better clear it.
+        _mission_items.clear();
+    }
+    callback(result, _mission_items);
+}
+
 void MissionImpl::report_progress()
 {
     if (_progress_callback == nullptr) {
@@ -610,6 +834,17 @@ int MissionImpl::total_mission_items() const
 void MissionImpl::subscribe_progress(Mission::progress_callback_t callback)
 {
     _progress_callback = callback;
+}
+
+void MissionImpl::process_timeout()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    LogErr() << "Mission handling timed out.";
+
+    if (_activity != Activity::NONE) {
+        report_mission_result(_result_callback, Mission::Result::TIMEOUT);
+    }
 }
 
 } // namespace dronecore

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -90,7 +90,7 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
         return;
     }
 
-    send_mission_item(mission_request_int.seq);
+    upload_mission_item(mission_request_int.seq);
 
 
     // Reset the timeout because we're still communicating.
@@ -167,9 +167,9 @@ void MissionImpl::process_mission_item_reached(const mavlink_message_t &message)
     }
 }
 
-void MissionImpl::send_mission_async(const std::vector<std::shared_ptr<MissionItem>>
-                                     &mission_items,
-                                     const Mission::result_callback_t &callback)
+void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<MissionItem>>
+                                       &mission_items,
+                                       const Mission::result_callback_t &callback)
 {
     if (_activity != Activity::NONE) {
         report_mission_result(callback, Mission::Result::BUSY);
@@ -501,7 +501,7 @@ void MissionImpl::set_current_mission_item_async(int current, Mission::result_ca
     _result_callback = callback;
 }
 
-void MissionImpl::send_mission_item(uint16_t seq)
+void MissionImpl::upload_mission_item(uint16_t seq)
 {
     LogDebug() << "Send mission item " << int(seq);
     if (seq >= _mavlink_mission_item_messages.size()) {

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -204,10 +204,6 @@ void MissionImpl::assemble_mavlink_messages()
     // TODO: delete all entries first
     _mavlink_mission_item_messages.clear();
 
-    float last_speed_m_s = NAN;
-    float last_gimbal_pitch_deg = NAN;
-    float last_gimbal_yaw_deg = NAN;
-
     unsigned item_i = 0;
     for (auto item : _mission_items) {
 
@@ -243,8 +239,7 @@ void MissionImpl::assemble_mavlink_messages()
             _mavlink_mission_item_messages.push_back(message);
         }
 
-        if (std::isfinite(mission_item_impl.get_speed_m_s()) &&
-            !are_equal(last_speed_m_s, mission_item_impl.get_speed_m_s())) {
+        if (std::isfinite(mission_item_impl.get_speed_m_s())) {
 
             // The speed has changed, we need to add a speed command.
 
@@ -277,14 +272,10 @@ void MissionImpl::assemble_mavlink_messages()
                 std::pair <int, int>
             {static_cast<int>(_mavlink_mission_item_messages.size()), item_i});
             _mavlink_mission_item_messages.push_back(message_speed);
-
-            last_speed_m_s = mission_item_impl.get_speed_m_s();
         }
 
-        if ((std::isfinite(mission_item_impl.get_gimbal_yaw_deg()) ||
-             std::isfinite(mission_item_impl.get_gimbal_pitch_deg())) &&
-            (!are_equal(last_gimbal_yaw_deg, mission_item_impl.get_gimbal_yaw_deg()) ||
-             !are_equal(last_gimbal_pitch_deg, mission_item_impl.get_gimbal_pitch_deg()))) {
+        if (std::isfinite(mission_item_impl.get_gimbal_yaw_deg()) ||
+            std::isfinite(mission_item_impl.get_gimbal_pitch_deg())) {
             // The gimbal has changed, we need to add a gimbal command.
 
             // Current is the 0th waypoint
@@ -316,9 +307,6 @@ void MissionImpl::assemble_mavlink_messages()
                 std::pair <int, int>
             {static_cast<int>(_mavlink_mission_item_messages.size()), item_i});
             _mavlink_mission_item_messages.push_back(message_gimbal);
-
-            last_gimbal_yaw_deg = mission_item_impl.get_gimbal_yaw_deg();
-            last_gimbal_pitch_deg = mission_item_impl.get_gimbal_pitch_deg();
         }
 
         if (mission_item_impl.get_camera_action() != MissionItem::CameraAction::NONE) {
@@ -387,9 +375,6 @@ void MissionImpl::assemble_mavlink_messages()
                 std::pair <int, int>
             {static_cast<int>(_mavlink_mission_item_messages.size()), item_i});
             _mavlink_mission_item_messages.push_back(message_camera);
-
-            last_gimbal_yaw_deg = mission_item_impl.get_gimbal_yaw_deg();
-            last_gimbal_pitch_deg = mission_item_impl.get_gimbal_pitch_deg();
         }
 
         ++item_i;

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -117,9 +117,10 @@ void MissionImpl::process_mission_ack(const mavlink_message_t &message)
         _last_current_mavlink_mission_item = -1;
         _last_reached_mavlink_mission_item = -1;
 
+        _activity = Activity::NONE;
+
         report_mission_result(_result_callback, Mission::Result::SUCCESS);
         LogInfo() << "Mission accepted";
-        _activity = Activity::NONE;
     } else if (mission_ack.type == MAV_MISSION_NO_SPACE) {
         LogErr() << "Error: too many waypoints: " << int(mission_ack.type);
         report_mission_result(_result_callback, Mission::Result::TOO_MANY_MISSION_ITEMS);
@@ -194,6 +195,7 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
         report_mission_result(callback, Mission::Result::ERROR);
     }
 
+    _activity = Activity::SET_MISSION;
     _result_callback = callback;
 }
 

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -57,7 +57,7 @@ private:
     void receive_command_result(MavlinkCommands::Result result,
                                 const Mission::result_callback_t &callback);
 
-    Mission::result_callback_t _result_callback;
+    Mission::result_callback_t _result_callback = nullptr;
 
     enum class Activity {
         NONE,
@@ -66,15 +66,15 @@ private:
         SEND_COMMAND
     } _activity = Activity::NONE;
 
-    int _last_current_mavlink_mission_item;
-    int _last_reached_mavlink_mission_item;
+    int _last_current_mavlink_mission_item = -1;
+    int _last_reached_mavlink_mission_item = -1;
 
-    std::vector<std::shared_ptr<MissionItem>> _mission_items;
-    std::vector<std::shared_ptr<mavlink_message_t>> _mavlink_mission_item_messages;
+    std::vector<std::shared_ptr<MissionItem>> _mission_items {};
+    std::vector<std::shared_ptr<mavlink_message_t>> _mavlink_mission_item_messages {};
 
-    std::map<int, int> _mavlink_mission_item_to_mission_item_indices;
+    std::map<int, int> _mavlink_mission_item_to_mission_item_indices {};
 
-    Mission::progress_callback_t _progress_callback;
+    Mission::progress_callback_t _progress_callback = nullptr;
 
     static constexpr uint8_t VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED = 1;
 
@@ -85,9 +85,9 @@ private:
     static constexpr uint8_t PX4_CUSTOM_SUB_MODE_AUTO_LOITER = 3;
     static constexpr uint8_t PX4_CUSTOM_SUB_MODE_AUTO_MISSION = 4;
 
+    int _num_mission_items_to_download = -1;
+    int _next_mission_item_to_download = -1;
     void *_timeout_cookie = nullptr;
 };
-
-//static std::function<void(MavlinkCommands::Result)> empty_callback;
 
 } // namespace dronecore

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -18,8 +18,8 @@ public:
     void init() override;
     void deinit() override;
 
-    void send_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
-                            const Mission::result_callback_t &callback);
+    void upload_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
+                              const Mission::result_callback_t &callback);
 
     void start_mission_async(const Mission::result_callback_t &callback);
     void pause_mission_async(const Mission::result_callback_t &callback);
@@ -45,7 +45,7 @@ private:
     void process_mission_ack(const mavlink_message_t &message);
     void process_mission_current(const mavlink_message_t &message);
     void process_mission_item_reached(const mavlink_message_t &message);
-    void send_mission_item(uint16_t seq);
+    void upload_mission_item(uint16_t seq);
 
     void copy_mission_item_vector(const std::vector<std::shared_ptr<MissionItem>> &mission_items);
 

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <map>
+#include <mutex>
 #include "device_impl.h"
 #include "mission.h"
 #include "mavlink_include.h"
@@ -57,6 +58,8 @@ private:
     void receive_command_result(MavlinkCommands::Result result,
                                 const Mission::result_callback_t &callback);
 
+
+    std::mutex _mutex {};
     Mission::result_callback_t _result_callback = nullptr;
 
     enum class Activity {


### PR DESCRIPTION
This changes the API from `send_mission_async()` to `upload_mission_async()` and adds `download_mission_async`.

This allows missions created with DroneCore to be downloaded from the vehicle. However, DroneCore only supports a subset of the mavlink mission protocol and will fail with the `Result::UNSUPPORTED` for anything it does not know.