### PR TITLE
Makefile: don't delete prebuilt Android libs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 	path = curl-android-ios
 	url = https://github.com/gcesarmza/curl-android-ios.git
 	ignore = dirty
+[submodule "libs/tinyxml2"]
+	path = libs/tinyxml2
+	url = https://github.com/leethomason/tinyxml2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,10 @@ set_target_properties(dronecore
     PROPERTIES COMPILE_FLAGS ${warnings}
 )
 
+# We need tinyxml2 for the camera definition parsing.
+add_subdirectory(libs/tinyxml2 EXCLUDE_FROM_ALL)
+include_directories(SYSTEM libs/tinyxml2)
+
 # We support install in order to use the header and static library files in
 # other applications.
 if(ANDROID)
@@ -203,6 +207,7 @@ if(NOT IOS AND NOT ANDROID)
         ${curl_lib}
         gmock
         ${additional_libs}
+        tinyxml2
     )
 
     add_test(unit_tests
@@ -228,6 +233,7 @@ if(NOT IOS AND NOT ANDROID)
         ${platform_libs}
         ${curl_lib}
         ${additional_libs}
+        tinyxml2
     )
 
     add_test(integration_tests

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,6 @@ all: default
 default:
 	$(call cmake-build)
 
-# install basically just runs default install
-install: ARGS += install
-install: default
-
 docs: install
 	- mkdir install/docs
 	- (cd install && doxygen ../.doxygen)

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,6 @@ clean:
 	@rm -rf build/
 	@rm -rf logs/
 	@rm -rf install/
-	@rm -rf $(CURL_BUILD_DIR)/prebuilt-with-ssl/android
 
 android_env_check:
 ifndef ANDROID_TOOLCHAIN_CMAKE

--- a/core/connection.cpp
+++ b/core/connection.cpp
@@ -31,7 +31,7 @@ bool Connection::start_mavlink_receiver()
 
 void Connection::stop_mavlink_receiver()
 {
-    if (!_mavlink_receiver) {
+    if (_mavlink_receiver) {
 
         uint8_t used_channel = _mavlink_receiver->get_channel();
         // Destroy receiver before giving the channel back.


### PR DESCRIPTION
This change speeds up the Android build because we don't always have to
rebuild openssl and curl for Android.

@darioxz was there a good reason we put that there?