### PR TITLE
external_example: fix compile errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
 
 script:
 - if [[ "${BUILD_TARGET}" = "gcc_build" ]]; then
-    make;
+    make EXTERNAL_DIR=external_example;
     make default install;
     make docs;
     make run_unit_tests;

--- a/external_example/plugins/example/example_impl.cpp
+++ b/external_example/plugins/example/example_impl.cpp
@@ -20,7 +20,7 @@ void ExampleImpl::init()
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
-        std::bind(&ExampleImpl::process_heartbeat, this, _1), (void *)this);
+        std::bind(&ExampleImpl::process_heartbeat, this, _1), this);
 
 }
 
@@ -31,14 +31,14 @@ void ExampleImpl::deinit()
 
 void ExampleImpl::say_hello() const
 {
-    Debug() << "Hello world, I'm a new plugin.";
+    LogInfo() << "Hello world, I'm a new plugin.";
 }
 
 void ExampleImpl::process_heartbeat(const mavlink_message_t &message)
 {
     UNUSED(message);
 
-    Debug() << "I received a heartbeat";
+    LogDebug() << "I received a heartbeat";
 }
 
 


### PR DESCRIPTION
This brings the external example up to speed. Additionally, the external example is now added to travis to prevent it from breaking in the future.