### PR TITLE
cmake: add info for additional includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ include_directories(
     SYSTEM ${EXTERNAL_DIR}/${additional_includes}
 )
 
+if (DEFINED additional_includes AND NOT additional_includes STREQUAL "")
+    message(STATUS "Additional includes: ${additional_includes}")
+endif()
+
 if (ANDROID)
     include_directories(curl-android-ios/prebuilt-with-ssl/android/include)
 endif()


### PR DESCRIPTION
~~This gives more flexibility for extensions to set additional_includes.~~

This is just a build output now.