### PR TITLE
Added script to generate docs

### DIFF
--- a/.doxygen
+++ b/.doxygen
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "docs"
+OUTPUT_DIRECTORY       = "../../docs"
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,6 @@ all: default
 default:
 	$(call cmake-build)
 
-docs:
-	- (cd $(INSTALL_PREFIX)/include/dronecore \
-        && mkdir -p docs \
-        && doxygen $(CURRENT_DIR)/.doxygen \
-        && $(CURRENT_DIR)/generate_markdown_from_doxygen_xml.py docs docs)
-
 ios: ios_curl
 	$(call cmake-build, \
 		-DCMAKE_TOOLCHAIN_FILE=iOS.cmake \
@@ -184,6 +178,6 @@ else
 endif
 
 .PHONY:
-	clean docs fix_style run_all_tests run_unit_tests run_integration_tests android_env_check
+	clean fix_style run_all_tests run_unit_tests run_integration_tests android_env_check
 
 # vim:ft=make:

--- a/autogenerate_plugin_container.cmake
+++ b/autogenerate_plugin_container.cmake
@@ -143,7 +143,7 @@ foreach(class_name ${plugin_class_names})
         "${PLUGIN_GET_STRING}    ${class_name} &${get_name}() { return ${member_name}; }\n\n")
 
     set(PLUGIN_MEMBER_STRING
-        "${PLUGIN_MEMBER_STRING}    /** @private */\n")
+        "${PLUGIN_MEMBER_STRING}    /* @private */\n")
     set(PLUGIN_MEMBER_STRING
         "${PLUGIN_MEMBER_STRING}    ${impl_class_name} *${impl_member_name};\n")
     set(PLUGIN_MEMBER_STRING

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# exit on any error
+set -e
+
+# This script will
+# 1. build and install the source,
+# 2. run doxygen and create html and xml docs,
+# 3. run script to generate markdown from xml
+
+# Get the directory where of this script.
+source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# We use a local install folder so we don't need sudo.
+install_prefix="$source_dir/install"
+
+# We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
+if [ -e $source_dir/build/ ]; then
+    echo "Build directory ($install_prefix) already exists, you should do 'make clean' first."
+    exit 1
+fi
+
+# Check for leftover install artefacts.
+if [ -e $install_prefix ]; then
+    echo "Install directory ($install_prefix) already exists, you should clean it up first."
+    exit 1
+fi
+
+# Build and install locally.
+make INSTALL_PREFIX=$install_prefix default install
+
+# Doxygen likes to run where the source is (because INPUT in .doxygen is empty),
+# so we cd there.
+pushd $install_prefix/include/dronecore
+doxygen $source_dir/.doxygen
+$source_dir/generate_markdown_from_doxygen_xml.py $install_prefix/docs $install_prefix/docs
+popd

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Run with argument `--skip-checks` to skip checks for clean build and removing install dir.
+
 # exit on any error
 set -e
 
@@ -11,19 +13,26 @@ set -e
 # Get current directory of script.
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+skip_checks=false
+if [ "$#" -eq 1 -a "$1" == "--skip-checks" ]; then
+    skip_checks=true
+fi
+
 # We use a local install folder so we don't need sudo.
 install_prefix="$source_dir/install"
 
-# We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
-if [ -e $source_dir/build/ ]; then
-    echo "Build directory ($install_prefix) already exists, you should do 'make clean' first."
-    exit 1
-fi
+if [ "$skip_checks" = false ]; then
+    # We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
+    if [ -e $source_dir/build/ ]; then
+        echo "Build directory ($install_prefix) already exists, you should do 'make clean' first."
+        exit 1
+    fi
 
-# Check for leftover install artefacts.
-if [ -e $install_prefix ]; then
-    echo "Install directory ($install_prefix) already exists, you should delete it up first."
-    exit 1
+    # Check for leftover install artefacts.
+    if [ -e $install_prefix ]; then
+        echo "Install directory ($install_prefix) already exists, you should delete it up first."
+        exit 1
+    fi
 fi
 
 # Build and install locally.

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -8,7 +8,7 @@ set -e
 # 2. run doxygen and create html and xml docs,
 # 3. run script to generate markdown from xml
 
-# Get the directory where of this script.
+# Get current directory of script.
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # We use a local install folder so we don't need sudo.
@@ -22,7 +22,7 @@ fi
 
 # Check for leftover install artefacts.
 if [ -e $install_prefix ]; then
-    echo "Install directory ($install_prefix) already exists, you should clean it up first."
+    echo "Install directory ($install_prefix) already exists, you should delete it up first."
     exit 1
 fi
 

--- a/generate_markdown_from_doxygen_xml.py
+++ b/generate_markdown_from_doxygen_xml.py
@@ -920,10 +920,10 @@ DOXYGEN_OUTPUT_DIR = args.output_dir + '/markdown'
 
 # Check if XML file path exists
 if not os.path.exists(DOXYGEN_ROOT_DIR):
-    print('Docs directory does not exist. Run: `make docs`')
+    print('Docs directory does not exist.')
     exit()
 if not os.path.exists(DOXYGEN_XML_DIR):
-    print('XML directory does not exist (created by doxygen). Run: `make docs`')
+    print('XML directory does not exist (created by doxygen).')
     exit()
 if not os.path.exists(DOXYGEN_OUTPUT_DIR):
     #make output dir

--- a/generate_markdown_from_doxygen_xml.py
+++ b/generate_markdown_from_doxygen_xml.py
@@ -953,11 +953,11 @@ for root, dirs, files in os.walk(DOXYGEN_XML_DIR, topdown=False):
             skip_string=" %s - (directory listing)" % current_filename
             skipped_files.append(skip_string)
             continue
-        if name is 'index.xml':
+        if name.endswith('index.xml'):
             skip_string=" %s - (index page)" % current_filename
             skipped_files.append(skip_string)
             continue
-        if name is 'namespacedronecore.xml':
+        if name.endswith('namespacedronecore.xml'):
             skip_string=" %s - (index page)" % current_filename
             skipped_files.append(skip_string)
             continue

--- a/include/device_plugin_container.h.in
+++ b/include/device_plugin_container.h.in
@@ -39,23 +39,28 @@ public:
 
 ${PLUGIN_GET_STRING}
 
-    // Non-copyable
+    /**
+     * @brief Copy constructor (object is not copyable).
+     */
     DevicePluginContainer(const DevicePluginContainer &) = delete;
+    /**
+     * @brief Equality operator (object is not copyable).
+     */
     const DevicePluginContainer &operator=(const DevicePluginContainer &) = delete;
 
 protected:
-    /** @private. */
+    /* @private. */
     virtual void init_plugins();
 
-    /** @private. */
+    /* @private. */
     virtual void deinit_plugins();
 
-    /** @private. */
+    /* @private. */
     DeviceImpl *_impl;
 
 ${PLUGIN_MEMBER_STRING}
 
-    /** @private. */
+    /* @private. */
     std::vector<PluginImplBase *> _plugin_impl_list;
 };
 

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -200,7 +200,7 @@ public:
     void register_on_timeout(event_callback_t callback);
 
 private:
-    /** @private. */
+    /* @private. */
     DroneCoreImpl *_impl;
 
     // Non-copyable

--- a/include/dronecore.h
+++ b/include/dronecore.h
@@ -89,6 +89,7 @@ public:
     /**
      * @brief Adds a TCP connection with a specific IP address and port number.
      *
+     * @param remote_ip Remote IP address to connect to.
      * @param remote_port The TCP port to connect to.
      * @return The result of adding the connection.
      */
@@ -106,6 +107,7 @@ public:
     /**
      * @brief Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
      *
+     * @param dev_path COM or UART dev node name/path.
      * @param baudrate Baudrate of the serial port.
      * @return The result of adding the connection.
      */

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -53,10 +53,10 @@ public:
     /**
      * @brief Returns a human-readable English string for an Action::Result.
      *
-     * @param Result The enum value for which a human readable string is required.
+     * @param result The enum value for which a human readable string is required.
      * @return Human readable string for the Action::Result.
      */
-    static const char *result_str(Result);
+    static const char *result_str(Result result);
 
     /**
      * @brief Send command to *arm* the drone (synchronous).

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -39,7 +39,7 @@ public:
     /**
      * @brief Returns a human-readable English string for Gimbal::Result.
      *
-     * @param Result The enum value for which a human readable string is required.
+     * @param result The enum value for which a human readable string is required.
      * @return Human readable string for the Gimbal::Result.
      */
     static const char *result_str(Result result);

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -41,7 +41,7 @@ public:
      * @brief Returns human-readable English string for Logging::Result.
      *
      * @param result Enum for which string is required.
-     * @return result Human-readable string.
+     * @return result Human-readable string for Logging::Result.
      */
     static const char *result_str(Result result);
 

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -74,8 +74,7 @@ public:
      * The method will fail if any of the downloaded mission items are not supported
      * by the DroneCore API.
      *
-     * @param mission_items Reference to vector of mission items.
-     * @param callback Callback to receive result of this request.
+     * @param callback Callback to receive mission items and result of this request.
      */
     void download_mission_async(mission_items_and_result_callback_t callback);
 

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -42,6 +42,9 @@ public:
 
     /**
      * @brief Gets a human-readable English string for an Mission::Result.
+     *
+     * @param result Enum for which string is required.
+     * @return Human readable string for the Mission::Result.
      */
     static const char *result_str(Result result);
 

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -155,6 +155,7 @@ public:
      * @brief Get human-readable English string for Telemetry::Result.
      *
      * @param result The enum value for which string is needed.
+     * @return Human readable string for the Telemetry::Result.
      */
     static const char *result_str(Result result);
 

--- a/travis-docker-build.sh
+++ b/travis-docker-build.sh
@@ -4,7 +4,6 @@ set -e
 
 make BUILD_TYPE=Debug run_unit_tests -j4
 make default install
-make docs
 make fix_style
 (cd example/takeoff_land && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make)
 (cd example/fly_mission && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make)
@@ -14,7 +13,6 @@ git clean -dfx
 
 make BUILD_TYPE=Release run_unit_tests -j4
 make default install
-make docs
 make fix_style
 (cd example/takeoff_land && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make)
 (cd example/fly_mission && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make)
@@ -25,3 +23,5 @@ git clean -dfx
 make EXTERNAL_DIR=external_example
 make clean
 git clean -dfx
+
+./generate_docs.sh


### PR DESCRIPTION
This removes the `make docs` target and instead adds the script
generate_docs.sh to do a clean build, install locally and run doxygen,
and the generate_markdown_from_doxygen_xml script.

Fixes #159.