### PR TITLE
docs: fix warnings

### DIFF
--- a/autogenerate_plugin_container.cmake
+++ b/autogenerate_plugin_container.cmake
@@ -143,11 +143,11 @@ foreach(class_name ${plugin_class_names})
         "${PLUGIN_GET_STRING}    ${class_name} &${get_name}() { return ${member_name}; }\n\n")
 
     set(PLUGIN_MEMBER_STRING
-        "${PLUGIN_MEMBER_STRING}    /* @private */\n")
+        "${PLUGIN_MEMBER_STRING}    /** @private internal use only.*/\n")
     set(PLUGIN_MEMBER_STRING
         "${PLUGIN_MEMBER_STRING}    ${impl_class_name} *${impl_member_name};\n")
     set(PLUGIN_MEMBER_STRING
-        "${PLUGIN_MEMBER_STRING}    /** @private */\n")
+        "${PLUGIN_MEMBER_STRING}    /** @private internal use only.*/\n")
     set(PLUGIN_MEMBER_STRING
         "${PLUGIN_MEMBER_STRING}    ${class_name} ${member_name};\n")
 

--- a/include/device_plugin_container.h.in
+++ b/include/device_plugin_container.h.in
@@ -49,18 +49,18 @@ ${PLUGIN_GET_STRING}
     const DevicePluginContainer &operator=(const DevicePluginContainer &) = delete;
 
 protected:
-    /* @private. */
+    /** @private internal use only. */
     virtual void init_plugins();
 
-    /* @private. */
+    /** @private internal use only. */
     virtual void deinit_plugins();
 
-    /* @private. */
+    /** @private internal use only. */
     DeviceImpl *_impl;
 
 ${PLUGIN_MEMBER_STRING}
 
-    /* @private. */
+    /** @private internal use only. */
     std::vector<PluginImplBase *> _plugin_impl_list;
 };
 


### PR DESCRIPTION
It turns out that if you add some words after private doxygen is happy.

Fixes #169.