### PR TITLE
cmake: fix plugin getter name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ endif()
 
 if (ANDROID)
     add_definitions(-frtti)
+    # Workaround for a plugin where the __androidx86__ is necessary.
+    if (ANDROID_ABI STREQUAL "x86")
+        add_definitions(-D__androidx86__)
+    endif()
 endif()
 
 # Add definition for __FILENAME__ so we don't need to use __FILE__ because it also

--- a/autogenerate_plugin_container.cmake
+++ b/autogenerate_plugin_container.cmake
@@ -119,7 +119,13 @@ set(PLUGIN_LIST_APPEND_STRING "")
 # Go through all the plugins and generate the strings.
 foreach(class_name ${plugin_class_names})
 
-    string(TOLOWER ${class_name} class_name_lowercase)
+    # We want to go from CamelCase to snake_case.
+    # CamelCase -> Camel_Case
+    string(REGEX REPLACE "(.)([A-Z][a-z]+)" "\\1_\\2" class_name_with_underscores "${class_name}")
+    # Camel0Case -> Camel0_Case
+    string(REGEX REPLACE "([a-z0-9])([A-Z])" "\\1_\\2" class_name_with_underscores "${class_name_with_underscores}")
+    # Camel_Case to snake_case
+    string(TOLOWER ${class_name_with_underscores} class_name_lowercase)
 
     set(get_name ${class_name_lowercase})
     set(member_name "_${class_name_lowercase}")


### PR DESCRIPTION
This changes autogenerate_plugin_container.cmake script to generate the
plugin getter method to be named with an underscore as you would expect.

For instance for the plugin FollowMe this would yield `follow_me`
instead of `followme`.

Tested using #142 and merging in this branch.