### PR TITLE
cmake: more consistent use of find_package and <PACKAGE>_FOUND

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 set(CMAKE_INSTALL_PREFIX "../install" CACHE PATH "default cache path")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 project(dronecore)
 
@@ -292,9 +293,8 @@ if(NOT IOS AND NOT ANDROID)
     set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
     set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} --coverage")
 
-    # We try to find gRPC. If we find it we try to include it in the build.
-    include(grpc/FindGRPC.cmake)
-    if(GRPC_LIBRARIES)
+    find_package(GRPC)
+    if(GRPC_FOUND)
 
         # If protobuf is installed to e.g. /opt/protobuf, you need to specifiy this via environment variable:
         # `export PROTOBUF_DIR=/opt/protobuf`
@@ -307,7 +307,7 @@ if(NOT IOS AND NOT ANDROID)
             set(Protobuf_PROTOC_LIBRARIES "$ENV{PROTOBUF_DIR}/lib/libprotobuf.so")
         else()
             message(STATUS "PROTOBUF_DIR not set, checking automatically for Protobuf")
-            include(FindProtobuf REQUIRED)
+            find_package(Protobuf REQUIRED)
         endif()
 
         add_subdirectory(grpc/server)

--- a/cmake/Modules/FindGRPC.cmake
+++ b/cmake/Modules/FindGRPC.cmake
@@ -38,6 +38,7 @@ endif()
 
 set(GRPC_LIBRARIES ${GRPCPP_LIBRARY} ${GRPC_LIBRARY} ${GPR_LIBRARY})
 if(GRPC_LIBRARIES)
+    set(GRPC_FOUND YES)
     message(STATUS "Found GRPC: ${GRPC_LIBRARIES}; plugin - ${GRPC_CPP_PLUGIN}")
 endif()
 

--- a/grpc/python_client/CMakeLists.txt
+++ b/grpc/python_client/CMakeLists.txt
@@ -21,15 +21,15 @@ if(${PYTHONINTERP_FOUND})
 
     foreach(plugin ${plugins_list})
         add_custom_command(TARGET pydronecore
-	        COMMAND ${PYTHON_EXECUTABLE}
+            COMMAND ${PYTHON_EXECUTABLE}
                 -m grpc_tools.protoc
                 -I ${proto_dir}
                 -I ${plugins_dir}/${plugin}
-	            --python_out=.
+                --python_out=.
                 --grpc_python_out=.
                 ${plugins_dir}${plugin}/${plugin}.proto
             DEPENDS ${plugins_dir}/${plugin}/${plugin}.proto
     )
-	endforeach()
+    endforeach()
 
 endif()

--- a/grpc/server/CMakeLists.txt
+++ b/grpc/server/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-#project(grpcdronecore)
-
-
 add_definitions(
     -std=c++11
     -Wno-unused-parameter
@@ -28,7 +25,6 @@ add_custom_command(OUTPUT dronecore.pb.cc
         --cpp_out=. ${proto_dir}/dronecore.proto
     DEPENDS ${proto_dir}/dronecore.proto
 )
-
 
 foreach(plugin ${plugins_list})
     add_custom_command(OUTPUT ${plugin}.grpc.pb.cc
@@ -64,7 +60,6 @@ target_link_libraries(dronecore_server
     dronecore
     ${Protobuf_PROTOC_LIBRARIES}
     ${GRPC_LIBRARIES}
-    #grpc++_reflection
     dl
 )
 


### PR DESCRIPTION
I tried to use `find_package` instead of `include`, and `<PACKAGE>_FOUND` instead of checking if a variable is set. I find this easier to read.

I moved the `FindGRPC.cmake` file in `cmake/Modules`, as it seems to me like it is the proposed default that I've seen in different projects (see [here](https://cmake.org/Wiki/CMake:How_To_Find_Libraries#Using_external_libraries_that_CMake_doesn.27t_yet_have_modules_for)).

Other than that, it's only some minor indentation fixes.