### PR TITLE
core: do blocking read on serial port

### DIFF
--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -82,8 +82,8 @@ DroneCore::ConnectionResult SerialConnection::setup_port()
     tc.c_cflag &= ~(CSIZE | PARENB | CBAUD | CRTSCTS);
     tc.c_cflag |= CS8 | BOTHER;
 
-    tc.c_cc[VMIN] = 0;
-    tc.c_cc[VTIME] = 0;
+    tc.c_cc[VMIN] = 1; // We want at least 1 byte to be available.
+    tc.c_cc[VTIME] = 0; // We don't timeout but wait indefinitely.
     tc.c_ispeed = _baudrate;
     tc.c_ospeed = _baudrate;
 

--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -66,7 +66,7 @@ DroneCore::ConnectionResult SerialConnection::setup_port()
 
     bzero(&tc, sizeof(tc));
 
-    _fd = open(_serial_node.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);// | O_NDELAY);
+    _fd = open(_serial_node.c_str(), O_RDWR | O_NOCTTY);
     if (_fd == -1) {
         return DroneCore::ConnectionResult::CONNECTION_ERROR;
     }


### PR DESCRIPTION
We should be able to read in a blocking way on the serial port since it
happens on a separate thread.

Fixes #176.