### PR TITLE
Fix Windows linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,11 @@ target_link_libraries(dronecore
     ${curl_lib}
     tinyxml2
 )
+if (MSVC)
+    target_link_libraries(dronecore
+        ws2_32
+    )
+endif()
 
 # cmake should check for C++11
 set_property(TARGET dronecore PROPERTY CXX_STANDARD 11)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,48 @@ build_script:
     ) else (
       cmake --build . --target install --config Release
     )
+  - cd ..
+  - cd example\takeoff_land
+  - md build
+  - cd build
+  - cmake ..  -G "Visual Studio 15 2017 Win64"
+  - if "%configuration%"=="Debug" (
+      cmake --build . --config Debug
+    ) else (
+      cmake --build . --config Release
+    )
+  - cd ..\..\..
+  - cd example\fly_mission
+  - md build
+  - cd build
+  - cmake ..  -G "Visual Studio 15 2017 Win64"
+  - if "%configuration%"=="Debug" (
+      cmake --build . --config Debug
+    ) else (
+      cmake --build . --config Release
+    )
+  - cd ..\..\..
+  - cd example\offboard_velocity
+  - md build
+  - cd build
+  - cmake ..  -G "Visual Studio 15 2017 Win64"
+  - if "%configuration%"=="Debug" (
+      cmake --build . --config Debug
+    ) else (
+      cmake --build . --config Release
+    )
+  - cd ..\..\..
+  - cd example\transition_vtol_fixed_wing
+  - md build
+  - cd build
+  - cmake ..  -G "Visual Studio 15 2017 Win64"
+  - if "%configuration%"=="Debug" (
+      cmake --build . --config Debug
+    ) else (
+      cmake --build . --config Release
+    )
+  - cd ..\..\..
+
 
 test: on
 

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -7,8 +7,10 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <unistd.h> // for close()
+#else
 #pragma comment(lib, "Ws2_32.lib") // Without this, Ws2_32.lib is not included in static library.
 #endif
+
 #include <cassert>
 
 #ifndef WINDOWS

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -7,6 +7,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <unistd.h> // for close()
+#pragma comment(lib, "Ws2_32.lib") // Without this, Ws2_32.lib is not included in static library.
 #endif
 #include <cassert>
 

--- a/core/udp_connection.cpp
+++ b/core/udp_connection.cpp
@@ -12,6 +12,7 @@
 #include <winsock2.h>
 #include <Ws2tcpip.h> // For InetPton
 #undef SOCKET_ERROR // conflicts with ConnectionResult::SOCKET_ERROR
+#pragma comment(lib, "Ws2_32.lib") // Without this, Ws2_32.lib is not included in static library.
 #endif
 
 #include <cassert>

--- a/example/fly_mission/CMakeLists.txt
+++ b/example/fly_mission/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
+    include_directories(${CMAKE_SOURCE_DIR}/../../install/include)
+    link_directories(${CMAKE_SOURCE_DIR}/../../install/lib)
 endif()
 
 add_executable(fly_mission

--- a/example/offboard_velocity/CMakeLists.txt
+++ b/example/offboard_velocity/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
+    include_directories(${CMAKE_SOURCE_DIR}/../../install/include)
+    link_directories(${CMAKE_SOURCE_DIR}/../../install/lib)
 endif()
 
 add_executable(offboard

--- a/example/offboard_velocity/CMakeLists.txt
+++ b/example/offboard_velocity/CMakeLists.txt
@@ -6,6 +6,7 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
+    add_definitions("-D_USE_MATH_DEFINES") # For M_PI
     include_directories(${CMAKE_SOURCE_DIR}/../../install/include)
     link_directories(${CMAKE_SOURCE_DIR}/../../install/lib)
 endif()

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <iostream>
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <thread>
 #include <chrono>

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <iostream>
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <thread>
 #include <chrono>

--- a/example/takeoff_land/CMakeLists.txt
+++ b/example/takeoff_land/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
+    include_directories(${CMAKE_SOURCE_DIR}/../../install/include)
+    link_directories(${CMAKE_SOURCE_DIR}/../../install/lib)
 endif()
 
 add_executable(takeoff_and_land
@@ -15,3 +17,4 @@ add_executable(takeoff_and_land
 target_link_libraries(takeoff_and_land
     dronecore
 )
+

--- a/example/transition_vtol_fixed_wing/CMakeLists.txt
+++ b/example/transition_vtol_fixed_wing/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
     add_definitions("-std=c++11 -WX -W2")
+    include_directories(${CMAKE_SOURCE_DIR}/../../install/include)
+    link_directories(${CMAKE_SOURCE_DIR}/../../install/lib)
 endif()
 
 add_executable(transition_vtol_fixed_wing


### PR DESCRIPTION
This should fix the linking on Windows. We now properly link the static library itself to ws2_32.lib.

Also, the examples are now built in CI.

Closes #162.