### PR TITLE
genrate_docs: Removed annoying prompts to clean build/install dir

### DIFF
--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -25,8 +25,8 @@ if [ "$skip_checks" = false ]; then
     # We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
     # Check for leftover install artefacts.
     if [ -e $source_dir/build/ ] || [ -e $install_prefix ] ; then
-		printf "Cleaup your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
-		exit 1
+	printf "Cleaup your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
+	exit 1
     fi
 fi
 

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -23,14 +23,11 @@ install_prefix="$source_dir/install"
 
 if [ "$skip_checks" = false ]; then
     # We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
-    if [ -e $source_dir/build/ ]; then
-        echo "Build directory ($install_prefix) already exists, you should do 'make clean' first."
-        exit 1
-    fi
-
     # Check for leftover install artefacts.
-    if [ -e $install_prefix ]; then
-        echo "Install directory ($install_prefix) already exists, you should delete it up first."
+    if [ -e $source_dir/build/ ] || [ -e $install_prefix ] ; then
+        echo "Either your Build/Install directory ($install_prefix) already exists, Lets clean it for you. Re-run now!"
+		rm -rf $install_prefix
+		make clean
         exit 1
     fi
 fi

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Run with argument `--clean` for clean build and removal of install directory.
+# Run with argument `--skip-checks` to skip checks for clean build and removing install dir.
 
 # exit on any error
 set -e
@@ -13,37 +13,20 @@ set -e
 # Get current directory of script.
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-help_msg="
-Usage: ./generate_docs.sh [OPTIONS]
-1. Builds and installs the source
-2. Runs doxygen and create HTML and XML docs
-3. Runs script to generate markdown from XML
-
-  --clean    for clean build and removal of install directory.
-  --help     display this help and exit
-"
-
-clean_build=false
-if [ "$#" -eq 1 -a "$1" == "--clean" ]; then
-    clean_build=true
-elif [ "$#" -eq 1 ]; then
-	echo "$help_msg"
-	if [ "$1" == "--help" ]; then
-		exit 0
-	else
-		exit 1
-	fi
+skip_checks=false
+if [ "$#" -eq 1 -a "$1" == "--skip-checks" ]; then
+    skip_checks=true
 fi
 
 # We use a local install folder so we don't need sudo.
 install_prefix="$source_dir/install"
 
-if [ "$clean_build" = true ]; then
+if [ "$skip_checks" = false ]; then
     # We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
     # Check for leftover install artefacts.
     if [ -e $source_dir/build/ ] || [ -e $install_prefix ] ; then
-		make clean
-		rm -rf $install_prefix
+		printf "Cleaup your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
+		exit 1
     fi
 fi
 

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Run with argument `--skip-checks` to skip checks for clean build and removing install dir.
+# Run with argument `--clean` for clean build and removing install dir.
 
 # exit on any error
 set -e
@@ -13,22 +13,37 @@ set -e
 # Get current directory of script.
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-skip_checks=false
-if [ "$#" -eq 1 -a "$1" == "--skip-checks" ]; then
-    skip_checks=true
+help_msg="
+Usage: ./generate_docs.sh [OPTIONS]
+1. Builds and installs the source
+2. Runs doxygen and create HTML and XML docs
+3. Runs script to generate markdown from XML
+
+  --clean    for clean build and removing install dir.
+  --help     display this help and exit
+"
+
+clean_build=false
+if [ "$#" -eq 1 -a "$1" == "--clean" ]; then
+    clean_build=true
+elif [ "$#" -eq 1 ]; then
+	echo "$help_msg"
+	if [ "$1" == "--help" ]; then
+		exit 0
+	else
+		exit 1
+	fi
 fi
 
 # We use a local install folder so we don't need sudo.
 install_prefix="$source_dir/install"
 
-if [ "$skip_checks" = false ]; then
+if [ "$clean_build" = true ]; then
     # We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
     # Check for leftover install artefacts.
     if [ -e $source_dir/build/ ] || [ -e $install_prefix ] ; then
-        echo "Either your Build/Install directory ($install_prefix) already exists, Lets clean it for you. Re-run now!"
-		rm -rf $install_prefix
 		make clean
-        exit 1
+		rm -rf $install_prefix
     fi
 fi
 

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Run with argument `--clean` for clean build and removing install dir.
+# Run with argument `--clean` for clean build and removal of install directory.
 
 # exit on any error
 set -e
@@ -19,7 +19,7 @@ Usage: ./generate_docs.sh [OPTIONS]
 2. Runs doxygen and create HTML and XML docs
 3. Runs script to generate markdown from XML
 
-  --clean    for clean build and removing install dir.
+  --clean    for clean build and removal of install directory.
   --help     display this help and exit
 "
 

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -22,10 +22,9 @@ fi
 install_prefix="$source_dir/install"
 
 if [ "$skip_checks" = false ]; then
-    # We need to do a clean build, otherwise the INSTALL_PREFIX has no effect.
-    # Check for leftover install artefacts.
+    # Clean-up build & install directory
     if [ -e $source_dir/build/ ] || [ -e $install_prefix ] ; then
-	printf "Cleaup your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
+	printf "Clean-up your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
 	exit 1
     fi
 fi


### PR DESCRIPTION
generate_doc.sh: Prompting repeatedly to clean build & install directory is annoying.
Fix is to let the script do it for us; we just need to re-run the script.

Added options `--clean` & `--help`
If the script is ran without options, it builds & installs the source and generate docs.
When `--clean` is used, it will perform clean build by deleting install folder.
When the script is ran with invalid/accidental args, help message is shown.