### PR TITLE
Add docs support for sa and note tags

### DIFF
--- a/generate_markdown_from_doxygen_xml.py
+++ b/generate_markdown_from_doxygen_xml.py
@@ -89,15 +89,16 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
     #print('tail_text: %s' % tail_text)
 
     #This section is for when you want to affect a sub tag based on a parent tag.
+    #Main use is to prevent children of a particular type being rendered, when child processing handled elsewere.
     ignore_current_tag=False #Use to disable the current tag. Currently only used for turning off "computeroutput" if children are ref.
     for child in aTag:
         if child.tag=='simplesect':
             if child.attrib['kind']=='return':
                 pass # simplesect contains return info for function. We parse it specifically in other code so here we make sure it this tag doesn't get processed.
             elif child.attrib['kind']=='see':
-                pass #Prevent further handling of see here.  
+                pass #Prevent further handling of "see" children.  
             elif child.attrib['kind']=='note':
-                child_text += markdown_any_tag(child,html=html,para=para) #generate child text.
+                pass #Prevent further handling of "note" children.  
             else:
                 #Just in case there is a different type of simplesect, this tells us we need to think about it.
                 print('Unhanded kind in simplesect tag in markdown_any_tag:kind: %s' % child.attrib['kind'])
@@ -110,7 +111,7 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
                 child_text+=str(ET.tostring(child),'utf-8')
         elif child.tag=='ref':
             if aTag.tag=='computeroutput':
-                ignore_current_tag=True
+                ignore_current_tag=True #Ignore computer output markup in links
             child_text += markdown_any_tag(child,html=html,para=para)
         elif child.tag=='computeroutput' or child.tag=='para' or child.tag=='listitem' or child.tag=='ulink' or child.tag=='bold' or child.tag=='emphasis':
             child_text += markdown_any_tag(child,html=html,para=para) #.strip()
@@ -120,7 +121,8 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
             print('Unhanded tag in markdown_any_tag: %s' % child.tag)
             child_text+=str(ET.tostring(child),'utf-8')
 
-    # Here we handle this tag.
+    # This section handles processing of the current tag.
+    # Current params like 'html' and ignore_current_tag can affect rendering.
     tag_text=''
     if aTag.tag=='computeroutput':
         if ignore_current_tag: #This tag is ignored, meaning that we don't add any special markup for it.
@@ -199,6 +201,16 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
         #print('tag_text: %s' % tag_text)
 
     elif aTag.tag=='detaileddescription':
+        #Strip out note tags from detailed description (so it can be agreggated under Notes section)
+        note_tags=aTag.findall(".//simplesect[@kind='note']")
+        note_text=''
+        if note_tags:
+            for item in note_tags:
+                note_text+='\n- %s' % markdown_any_tag(item).strip()
+
+            note_text='\n\n**Notes:**%s\n\n' % note_text
+            #print('debug:tag:note_text: %s' % note_text)
+
         #Strip out seealso tags from detailed description (so it can be agreggated under Seealso section)
         seealso_tags=aTag.findall(".//simplesect[@kind='see']")
         seealso_text=''
@@ -209,15 +221,12 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
             seealso_text='\n\n**See Also:**%s\n\n' % seealso_text
             #print('debug:tag:seealso_text: %s' % seealso_text)
         
-        tag_text=lead_text+child_text+seealso_text+tail_text
+        tag_text=lead_text+child_text+note_text+seealso_text+tail_text
 
 
     elif aTag.tag=='simplesect':
-        if aTag.attrib['kind']=='note':
-            #Handle @note (note) tag.
-            lead_text=' %s' % lead_text
-            tag_text='\n\n> **Note** '+lead_text.strip()+child_text.strip()+tail_text.strip()+'\n\n'
-        elif aTag.attrib['kind']=='see': 
+        if aTag.attrib['kind']=='note' or aTag.attrib['kind']=='see':
+            #Handle @note (note) and @sa (see) tags.
             # Note we should ONLY see this via the detaileddescription handling 
             # Because children that are simplesect are not parsed.
             tag_text=lead_text+child_text+tail_text


### PR DESCRIPTION
This adds support see also tags (sa) and note tags. The sa tag groups all marked lines as bullet points under a heading **See Also** as requested by #180 

The notes render as a gitbook note (ie `> **Note** Some text`). The problem is that you can only have single line notes - multi-line notes render as separate notes. 

It may be better to render these JUST like see also (under their own heading). Thoughts?