### PR TITLE
core: SerialConnection Initialize _should_exit with false

### DIFF
--- a/core/serial_connection.h
+++ b/core/serial_connection.h
@@ -34,7 +34,7 @@ private:
     std::mutex _mutex = {};
     int _fd = -1;
     std::thread *_recv_thread = nullptr;
-    std::atomic_bool _should_exit;
+    std::atomic_bool _should_exit{false};
 };
 
 } // namespace dronecore


### PR DESCRIPTION
When _should_exit isn't initialized on an ARM platform (Udoo Dual), it defaults to true and the serial connection receive thread exits immediately. Explicitly initializing the variable solves the issue.