### PR TITLE
add enable/disable API for plugins

### DIFF
--- a/autogenerate_plugin_container.cmake
+++ b/autogenerate_plugin_container.cmake
@@ -104,6 +104,9 @@ set(FORWARD_DECLARATION_STRING "")
 # Contains the constructor entries.
 set(PLUGIN_CTOR_STRING "")
 
+# Contains the destructor entries.
+set(PLUGIN_DTOR_STRING "")
+
 # Contains the member variables for the plugin instances.
 set(PLUGIN_MEMBER_STRING "")
 
@@ -143,7 +146,7 @@ foreach(class_name ${plugin_class_names})
     set(PLUGIN_GET_STRING
         "${PLUGIN_GET_STRING}     */\n")
     set(PLUGIN_GET_STRING
-        "${PLUGIN_GET_STRING}    ${class_name} &${get_name}() { return ${member_name}; }\n\n")
+        "${PLUGIN_GET_STRING}    ${class_name} &${get_name}() { return *${member_name}; }\n\n")
 
     set(PLUGIN_MEMBER_STRING
         "${PLUGIN_MEMBER_STRING}    /** @private internal use only.*/\n")
@@ -152,12 +155,15 @@ foreach(class_name ${plugin_class_names})
     set(PLUGIN_MEMBER_STRING
         "${PLUGIN_MEMBER_STRING}    /** @private internal use only.*/\n")
     set(PLUGIN_MEMBER_STRING
-        "${PLUGIN_MEMBER_STRING}    ${class_name} ${member_name};\n")
+        "${PLUGIN_MEMBER_STRING}    ${class_name} *${member_name};\n")
 
     set(PLUGIN_CTOR_STRING
-        "${PLUGIN_CTOR_STRING}    ${impl_member_name}(new ${impl_class_name}()),\n")
+        "${PLUGIN_CTOR_STRING}    ${impl_member_name} = new ${impl_class_name}();\n")
     set(PLUGIN_CTOR_STRING
-        "${PLUGIN_CTOR_STRING}    ${member_name}(${impl_member_name}),\n")
+        "${PLUGIN_CTOR_STRING}    ${member_name} = new ${class_name}(${impl_member_name}),\n")
+
+    set(PLUGIN_DTOR_STRING
+        "${PLUGIN_DTOR_STRING}    delete ${member_name};\n")
 
     set(PLUGIN_LIST_APPEND_STRING
         "${PLUGIN_LIST_APPEND_STRING}   _plugin_impl_list.push_back(${impl_member_name});\n")

--- a/autogenerate_plugin_container.cmake
+++ b/autogenerate_plugin_container.cmake
@@ -104,9 +104,6 @@ set(FORWARD_DECLARATION_STRING "")
 # Contains the constructor entries.
 set(PLUGIN_CTOR_STRING "")
 
-# Contains the destructor entries.
-set(PLUGIN_DTOR_STRING "")
-
 # Contains the member variables for the plugin instances.
 set(PLUGIN_MEMBER_STRING "")
 
@@ -161,9 +158,6 @@ foreach(class_name ${plugin_class_names})
         "${PLUGIN_CTOR_STRING}    ${impl_member_name}(new ${impl_class_name}()),\n")
     set(PLUGIN_CTOR_STRING
         "${PLUGIN_CTOR_STRING}    ${member_name}(${impl_member_name}),\n")
-
-    set(PLUGIN_DTOR_STRING
-        "${PLUGIN_DTOR_STRING}    delete ${impl_member_name};\n")
 
     set(PLUGIN_LIST_APPEND_STRING
         "${PLUGIN_LIST_APPEND_STRING}   _plugin_impl_list.push_back(${impl_member_name});\n")

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -325,6 +325,10 @@ void DeviceImpl::set_connected()
     std::lock_guard<std::mutex> lock(_connection_mutex);
 
     if (!_connected && _target_uuid_initialized) {
+
+        if (_on_discovery_callback) {
+            _on_discovery_callback();
+        }
         _parent->notify_on_discover(_target_uuid);
         _connected = true;
 
@@ -337,6 +341,15 @@ void DeviceImpl::set_connected()
     // If not yet connected there is nothing to do/
 }
 
+void DeviceImpl::subscribe_on_discovery(std::function <void()> callback)
+{
+    _on_discovery_callback = callback;
+}
+void DeviceImpl::subscribe_on_timeout(std::function <void()> callback)
+{
+    _on_timeout_callback = callback;
+}
+
 void DeviceImpl::set_disconnected()
 {
     std::lock_guard<std::mutex> lock(_connection_mutex);
@@ -347,6 +360,9 @@ void DeviceImpl::set_disconnected()
     //_heartbeat_timeout_cookie = nullptr;
 
     _connected = false;
+    if (_on_timeout_callback) {
+        _on_timeout_callback();
+    }
     _parent->notify_on_timeout(_target_uuid);
 
     // Let's reset the flag hope again for the next time we see this target.

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -92,6 +92,8 @@ public:
     static uint8_t get_own_component_id() { return _own_component_id; }
 
     bool is_connected() const;
+    void subscribe_on_discovery(std::function <void()> callback);
+    void subscribe_on_timeout(std::function <void()> callback);
 
     Time &get_time() { return _time; };
 
@@ -159,6 +161,9 @@ private:
     std::mutex _connection_mutex {};
     bool _connected {false};
     void *_heartbeat_timeout_cookie = nullptr;
+
+    std::function<void()> _on_discovery_callback = nullptr;
+    std::function<void()> _on_timeout_callback = nullptr;
 
     std::atomic<bool> _autopilot_version_pending {false};
     void *_autopilot_version_timed_out_cookie = nullptr;

--- a/core/device_plugin_container.cpp.in
+++ b/core/device_plugin_container.cpp.in
@@ -24,6 +24,7 @@ ${PLUGIN_LIST_APPEND_STRING}
 
 DevicePluginContainer::~DevicePluginContainer()
 {
+    disable_plugins();
     deinit_plugins();
 
     while (!_plugin_impl_list.empty()) {

--- a/core/device_plugin_container.cpp.in
+++ b/core/device_plugin_container.cpp.in
@@ -24,7 +24,12 @@ DevicePluginContainer::~DevicePluginContainer()
 {
     deinit_plugins();
 
-${PLUGIN_DTOR_STRING}
+    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); /*++it*/) {
+        // Desctruct
+        delete *it;
+        // And remove from list
+        it = _plugin_impl_list.erase(it);
+    }
 
     _impl = nullptr;
 }

--- a/core/device_plugin_container.cpp.in
+++ b/core/device_plugin_container.cpp.in
@@ -12,8 +12,8 @@ ${PLUGIN_CTOR_STRING}
 {
 ${PLUGIN_LIST_APPEND_STRING}
 
-    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
-        (**it).set_parent(impl);
+    for (auto plugin_impl : _plugin_impl_list) {
+        plugin_impl->set_parent(impl);
     }
 
     init_plugins();
@@ -26,39 +26,37 @@ DevicePluginContainer::~DevicePluginContainer()
 {
     deinit_plugins();
 
-    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); /*++it*/) {
-        // Desctruct
-        delete *it;
-        // And remove from list
-        it = _plugin_impl_list.erase(it);
+    while (!_plugin_impl_list.empty()) {
+        delete _plugin_impl_list.back();
+        _plugin_impl_list.pop_back();
     }
 }
 
 void DevicePluginContainer::init_plugins()
 {
-    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
-        (**it).init();
+    for (auto plugin_impl : _plugin_impl_list) {
+        plugin_impl->init();
     }
 }
 
 void DevicePluginContainer::deinit_plugins()
 {
-    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
-        (**it).deinit();
+    for (auto plugin_impl : _plugin_impl_list) {
+        plugin_impl->deinit();
     }
 }
 
 void DevicePluginContainer::enable_plugins()
 {
-    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
-        (**it).enable();
+    for (auto plugin_impl : _plugin_impl_list) {
+        plugin_impl->enable();
     }
 }
 
 void DevicePluginContainer::disable_plugins()
 {
-    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
-        (**it).disable();
+    for (auto plugin_impl : _plugin_impl_list) {
+        plugin_impl->disable();
     }
 }
 

--- a/core/device_plugin_container.cpp.in
+++ b/core/device_plugin_container.cpp.in
@@ -6,16 +6,9 @@ ${IMPL_INCLUDES_STRING}
 
 namespace dronecore {
 
-DevicePluginContainer::DevicePluginContainer(DeviceImpl *impl) :
-${PLUGIN_CTOR_STRING}
-    _plugin_impl_list()
+DevicePluginContainer::DevicePluginContainer(DeviceImpl *impl)
 {
-${PLUGIN_LIST_APPEND_STRING}
-
-    for (auto plugin_impl : _plugin_impl_list) {
-        plugin_impl->set_parent(impl);
-    }
-
+    construct_plugins(impl);
     init_plugins();
 
     impl->subscribe_on_discovery(std::bind(&DevicePluginContainer::enable_plugins, this));
@@ -26,6 +19,23 @@ DevicePluginContainer::~DevicePluginContainer()
 {
     disable_plugins();
     deinit_plugins();
+    destruct_plugins();
+}
+
+
+void DevicePluginContainer::construct_plugins(DeviceImpl *impl)
+{
+${PLUGIN_CTOR_STRING}
+${PLUGIN_LIST_APPEND_STRING}
+
+    for (auto plugin_impl : _plugin_impl_list) {
+        plugin_impl->set_parent(impl);
+    }
+}
+
+void DevicePluginContainer::destruct_plugins()
+{
+${PLUGIN_DTOR_STRING}
 
     while (!_plugin_impl_list.empty()) {
         delete _plugin_impl_list.back();
@@ -60,6 +70,5 @@ void DevicePluginContainer::disable_plugins()
         plugin_impl->disable();
     }
 }
-
 
 } // namespace dronecore

--- a/core/device_plugin_container.cpp.in
+++ b/core/device_plugin_container.cpp.in
@@ -7,17 +7,19 @@ ${IMPL_INCLUDES_STRING}
 namespace dronecore {
 
 DevicePluginContainer::DevicePluginContainer(DeviceImpl *impl) :
-    _impl(impl),
 ${PLUGIN_CTOR_STRING}
     _plugin_impl_list()
 {
 ${PLUGIN_LIST_APPEND_STRING}
 
     for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
-        (**it).set_parent(_impl);
+        (**it).set_parent(impl);
     }
 
     init_plugins();
+
+    impl->subscribe_on_discovery(std::bind(&DevicePluginContainer::enable_plugins, this));
+    impl->subscribe_on_timeout(std::bind(&DevicePluginContainer::disable_plugins, this));
 }
 
 DevicePluginContainer::~DevicePluginContainer()
@@ -30,8 +32,6 @@ DevicePluginContainer::~DevicePluginContainer()
         // And remove from list
         it = _plugin_impl_list.erase(it);
     }
-
-    _impl = nullptr;
 }
 
 void DevicePluginContainer::init_plugins()
@@ -45,6 +45,20 @@ void DevicePluginContainer::deinit_plugins()
 {
     for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
         (**it).deinit();
+    }
+}
+
+void DevicePluginContainer::enable_plugins()
+{
+    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
+        (**it).enable();
+    }
+}
+
+void DevicePluginContainer::disable_plugins()
+{
+    for (auto it = _plugin_impl_list.begin(); it != _plugin_impl_list.end(); ++it) {
+        (**it).disable();
     }
 }
 

--- a/core/plugin_impl_base.cpp
+++ b/core/plugin_impl_base.cpp
@@ -19,6 +19,7 @@ void PluginImplBase::set_parent(DeviceImpl *parent)
 #ifdef __GNUG__ // GNU C++ compiler
 #include <cxxabi.h>
 #include <stdlib.h>
+#include <string>
 std::string demangle(const char *mangled_name)
 {
     std::string result;
@@ -34,6 +35,7 @@ std::string demangle(const char *mangled_name)
     return result;
 }
 #else
+#include <string>
 std::string demangle(const char *name)
 {
     return name;

--- a/core/plugin_impl_base.cpp
+++ b/core/plugin_impl_base.cpp
@@ -6,50 +6,11 @@
 namespace dronecore {
 
 PluginImplBase::PluginImplBase() :
-    _parent()
-{
-}
+    _parent() {}
 
 void PluginImplBase::set_parent(DeviceImpl *parent)
 {
     _parent = parent;
-}
-
-// TODO: remove this again
-#ifdef __GNUG__ // GNU C++ compiler
-#include <cxxabi.h>
-#include <stdlib.h>
-#include <string>
-std::string demangle(const char *mangled_name)
-{
-    std::string result;
-    std::size_t len = 0;
-    int status = 0;
-    char *ptr = __cxxabiv1::__cxa_demangle(mangled_name, nullptr, &len, &status);
-    if (status == 0) {
-        result = ptr;
-    } else {
-        result = "demangle error";
-    }
-    ::free(ptr);
-    return result;
-}
-#else
-#include <string>
-std::string demangle(const char *name)
-{
-    return name;
-}
-#endif // __GNUG__
-
-void PluginImplBase::enable()
-{
-    LogWarn() << "Plugin " << demangle(typeid(*this).name()) << " does not implement enable()";
-}
-
-void PluginImplBase::disable()
-{
-    LogWarn() << "Plugin " << demangle(typeid(*this).name()) << " does not implement disable()";
 }
 
 } // namespace dronecore

--- a/core/plugin_impl_base.cpp
+++ b/core/plugin_impl_base.cpp
@@ -15,4 +15,39 @@ void PluginImplBase::set_parent(DeviceImpl *parent)
     _parent = parent;
 }
 
+// TODO: remove this again
+#ifdef __GNUG__ // GNU C++ compiler
+#include <cxxabi.h>
+#include <stdlib.h>
+std::string demangle(const char *mangled_name)
+{
+    std::string result;
+    std::size_t len = 0;
+    int status = 0;
+    char *ptr = __cxxabiv1::__cxa_demangle(mangled_name, nullptr, &len, &status);
+    if (status == 0) {
+        result = ptr;
+    } else {
+        result = "demangle error";
+    }
+    ::free(ptr);
+    return result;
+}
+#else
+std::string demangle(const char *name)
+{
+    return name;
+}
+#endif // __GNUG__
+
+void PluginImplBase::enable()
+{
+    LogWarn() << "Plugin " << demangle(typeid(*this).name()) << " does not implement enable()";
+}
+
+void PluginImplBase::disable()
+{
+    LogWarn() << "Plugin " << demangle(typeid(*this).name()) << " does not implement disable()";
+}
+
 } // namespace dronecore

--- a/core/plugin_impl_base.h
+++ b/core/plugin_impl_base.h
@@ -41,7 +41,9 @@ public:
     virtual void enable() = 0;
 
     /*
-     * The method `disable()` is called when a device has timed out.
+     * The method `disable()` is called when a device has timed out. The method is also
+     * called before `deinit()` is called in case we destruct with a device still
+     * connected.
      *
      * Plugins should stop whatever they were doing in order to prevent warnings and
      * errors because communication to the device no longer work, e.g. stop setting

--- a/core/plugin_impl_base.h
+++ b/core/plugin_impl_base.h
@@ -14,11 +14,8 @@ public:
     virtual void init() = 0;
     virtual void deinit() = 0;
 
-    // TODO: make this pure virtual after a while.
-    virtual void enable();
-
-    // TODO: make this pure virtual after a while.
-    virtual void disable();
+    virtual void enable() = 0;
+    virtual void disable() = 0;
 
     // Non-copyable
     PluginImplBase(const PluginImplBase &) = delete;

--- a/core/plugin_impl_base.h
+++ b/core/plugin_impl_base.h
@@ -11,10 +11,44 @@ public:
     virtual ~PluginImplBase() = default;
 
     void set_parent(DeviceImpl *parent);
+
+    /*
+     * The method `init()` is called when a plugin is instantiated which happens
+     * when a device is constructed. This does not mean that the device actually
+     * exists and is connected, it might just be an empty dummy device.
+     *
+     * Plugins should do initialization steps with other parts of DroneCore
+     * at this state, e.g. set up callbacks with _parent (DeviceImpl).
+     */
     virtual void init() = 0;
+
+    /*
+     * The method `deinit()` is called before a plugin is destructed which happens
+     * usually only at the very end when a DroneCore instance is destructed.
+     *
+     * Plugins should do any cleanup of what has been set up during init.
+     */
     virtual void deinit() = 0;
 
+    /*
+     * The method `enable()` is called when a device is discovered (is connected).
+     *
+     * Plugins should do all initialization/configuration steps here that require a
+     * device to be connected such as setting/getting parameters.
+     *
+     * If any threads, call_every or timeouts are needed, they can be started now.
+     */
     virtual void enable() = 0;
+
+    /*
+     * The method `disable()` is called when a device has timed out.
+     *
+     * Plugins should stop whatever they were doing in order to prevent warnings and
+     * errors because communication to the device no longer work, e.g. stop setting
+     * parameters or commands.
+     *
+     * If any threads, call_every, or timeouts are running, they should be stopped now.
+     */
     virtual void disable() = 0;
 
     // Non-copyable

--- a/core/plugin_impl_base.h
+++ b/core/plugin_impl_base.h
@@ -14,6 +14,12 @@ public:
     virtual void init() = 0;
     virtual void deinit() = 0;
 
+    // TODO: make this pure virtual after a while.
+    virtual void enable();
+
+    // TODO: make this pure virtual after a while.
+    virtual void disable();
+
     // Non-copyable
     PluginImplBase(const PluginImplBase &) = delete;
     const PluginImplBase &operator=(const PluginImplBase &) = delete;

--- a/external_example/plugins/example/example_impl.cpp
+++ b/external_example/plugins/example/example_impl.cpp
@@ -6,13 +6,9 @@
 namespace dronecore {
 
 ExampleImpl::ExampleImpl() :
-    PluginImplBase()
-{
-}
+    PluginImplBase() {}
 
-ExampleImpl::~ExampleImpl()
-{
-}
+ExampleImpl::~ExampleImpl() {}
 
 void ExampleImpl::init()
 {
@@ -21,13 +17,16 @@ void ExampleImpl::init()
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&ExampleImpl::process_heartbeat, this, _1), this);
-
 }
 
 void ExampleImpl::deinit()
 {
     _parent->unregister_all_mavlink_message_handlers(this);
 }
+
+void ExampleImpl::enable() {}
+
+void ExampleImpl::disable() {}
 
 void ExampleImpl::say_hello() const
 {
@@ -40,8 +39,5 @@ void ExampleImpl::process_heartbeat(const mavlink_message_t &message)
 
     LogDebug() << "I received a heartbeat";
 }
-
-
-
 
 } // namespace dronecore

--- a/external_example/plugins/example/example_impl.h
+++ b/external_example/plugins/example/example_impl.h
@@ -17,6 +17,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
 private:
     void process_heartbeat(const mavlink_message_t &message);
 };

--- a/include/device_plugin_container.h.in
+++ b/include/device_plugin_container.h.in
@@ -50,21 +50,27 @@ ${PLUGIN_GET_STRING}
 
 protected:
     /** @private internal use only. */
-    virtual void init_plugins();
+    void construct_plugins(DeviceImpl *impl);
 
     /** @private internal use only. */
-    virtual void deinit_plugins();
+    void destruct_plugins();
 
     /** @private internal use only. */
-    virtual void enable_plugins();
+    void init_plugins();
 
     /** @private internal use only. */
-    virtual void disable_plugins();
+    void deinit_plugins();
+
+    /** @private internal use only. */
+    void enable_plugins();
+
+    /** @private internal use only. */
+    void disable_plugins();
 
 ${PLUGIN_MEMBER_STRING}
 
     /** @private internal use only. */
-    std::vector<PluginImplBase *> _plugin_impl_list;
+    std::vector<PluginImplBase *> _plugin_impl_list {};
 };
 
 } // namespace dronecore

--- a/include/device_plugin_container.h.in
+++ b/include/device_plugin_container.h.in
@@ -56,7 +56,10 @@ protected:
     virtual void deinit_plugins();
 
     /** @private internal use only. */
-    DeviceImpl *_impl;
+    virtual void enable_plugins();
+
+    /** @private internal use only. */
+    virtual void disable_plugins();
 
 ${PLUGIN_MEMBER_STRING}
 

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -14,7 +14,6 @@ ActionImpl::ActionImpl()
 
 ActionImpl::~ActionImpl()
 {
-
 }
 
 void ActionImpl::init()
@@ -23,7 +22,15 @@ void ActionImpl::init()
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_EXTENDED_SYS_STATE,
         std::bind(&ActionImpl::process_extended_sys_state, this, _1), this);
+}
 
+void ActionImpl::deinit()
+{
+    _parent->unregister_all_mavlink_message_handlers(this);
+}
+
+void ActionImpl::enable()
+{
     // And we need to make sure the system state is actually sent.
     // We use the async call here because we should not block in the init call because
     // we won't receive an answer anyway in init because the receive loop is not
@@ -32,9 +39,9 @@ void ActionImpl::init()
                                 MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
-void ActionImpl::deinit()
+void ActionImpl::disable()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+
 }
 
 Action::Result ActionImpl::arm() const

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -8,13 +8,9 @@ namespace dronecore {
 
 using namespace std::placeholders; // for `_1`
 
-ActionImpl::ActionImpl()
-{
-}
+ActionImpl::ActionImpl() {}
 
-ActionImpl::~ActionImpl()
-{
-}
+ActionImpl::~ActionImpl() {}
 
 void ActionImpl::init()
 {
@@ -39,10 +35,7 @@ void ActionImpl::enable()
                                 MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
-void ActionImpl::disable()
-{
-
-}
+void ActionImpl::disable() {}
 
 Action::Result ActionImpl::arm() const
 {

--- a/plugins/action/action_impl.h
+++ b/plugins/action/action_impl.h
@@ -17,6 +17,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     Action::Result arm() const;
     Action::Result disarm() const;
     Action::Result kill() const;

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -18,9 +18,7 @@ FollowMeImpl::FollowMeImpl() :
                                                                          NAN, NAN, NAN };
 }
 
-FollowMeImpl::~FollowMeImpl()
-{
-}
+FollowMeImpl::~FollowMeImpl() {}
 
 void FollowMeImpl::init()
 {
@@ -33,6 +31,13 @@ void FollowMeImpl::init()
 void FollowMeImpl::deinit()
 {
     _parent->unregister_all_mavlink_message_handlers(this);
+}
+
+void FollowMeImpl::enable() {}
+
+void FollowMeImpl::disable()
+{
+    stop_sending_target_location();
 }
 
 const FollowMe::Config &FollowMeImpl::get_config() const

--- a/plugins/follow_me/follow_me_impl.h
+++ b/plugins/follow_me/follow_me_impl.h
@@ -18,6 +18,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     const FollowMe::Config &get_config() const;
     bool set_config(const FollowMe::Config &config);
 

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -23,6 +23,14 @@ void GimbalImpl::deinit()
 {
 }
 
+void GimbalImpl::enable()
+{
+}
+
+void GimbalImpl::disable()
+{
+}
+
 Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     const float roll_deg = 0.0f;

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -7,29 +7,17 @@
 namespace dronecore {
 
 GimbalImpl::GimbalImpl() :
-    PluginImplBase()
-{
-}
+    PluginImplBase() {}
 
-GimbalImpl::~GimbalImpl()
-{
-}
+GimbalImpl::~GimbalImpl() {}
 
-void GimbalImpl::init()
-{
-}
+void GimbalImpl::init() {}
 
-void GimbalImpl::deinit()
-{
-}
+void GimbalImpl::deinit() {}
 
-void GimbalImpl::enable()
-{
-}
+void GimbalImpl::enable() {}
 
-void GimbalImpl::disable()
-{
-}
+void GimbalImpl::disable() {}
 
 Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {

--- a/plugins/gimbal/gimbal_impl.h
+++ b/plugins/gimbal/gimbal_impl.h
@@ -15,6 +15,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     Gimbal::Result set_pitch_and_yaw(float pitch_deg, float yaw_deg);
 
     void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -8,13 +8,9 @@ namespace dronecore {
 InfoImpl::InfoImpl() :
     PluginImplBase(),
     _version_mutex(),
-    _version()
-{
-}
+    _version() {}
 
-InfoImpl::~InfoImpl()
-{
-}
+InfoImpl::~InfoImpl() {}
 
 void InfoImpl::init()
 {
@@ -34,15 +30,9 @@ void InfoImpl::deinit()
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 
-void InfoImpl::enable()
-{
+void InfoImpl::enable() {}
 
-}
-
-void InfoImpl::disable()
-{
-
-}
+void InfoImpl::disable() {}
 
 void InfoImpl::process_heartbeat(const mavlink_message_t &message)
 {

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -34,6 +34,16 @@ void InfoImpl::deinit()
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 
+void InfoImpl::enable()
+{
+
+}
+
+void InfoImpl::disable()
+{
+
+}
+
 void InfoImpl::process_heartbeat(const mavlink_message_t &message)
 {
     UNUSED(message);

--- a/plugins/info/info_impl.h
+++ b/plugins/info/info_impl.h
@@ -13,13 +13,16 @@ public:
     InfoImpl();
     ~InfoImpl();
 
+    void init() override;
+    void deinit() override;
+
+    void enable() override;
+    void disable() override;
+
     uint64_t get_uuid() const;
     bool is_complete() const;
     Info::Version get_version() const;
     Info::Product get_product() const;
-
-    void init() override;
-    void deinit() override;
 
 private:
     void set_version(Info::Version version);

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -6,14 +6,9 @@
 
 namespace dronecore {
 
-LoggingImpl::LoggingImpl()
-{
-}
+LoggingImpl::LoggingImpl() {}
 
-LoggingImpl::~LoggingImpl()
-{
-
-}
+LoggingImpl::~LoggingImpl() {}
 
 void LoggingImpl::init()
 {
@@ -33,13 +28,9 @@ void LoggingImpl::deinit()
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 
-void LoggingImpl::enable()
-{
-}
+void LoggingImpl::enable() {}
 
-void LoggingImpl::disable()
-{
-}
+void LoggingImpl::disable() {}
 
 Logging::Result LoggingImpl::start_logging() const
 {

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -33,6 +33,14 @@ void LoggingImpl::deinit()
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 
+void LoggingImpl::enable()
+{
+}
+
+void LoggingImpl::disable()
+{
+}
+
 Logging::Result LoggingImpl::start_logging() const
 {
     return logging_result_from_command_result(

--- a/plugins/logging/logging_impl.h
+++ b/plugins/logging/logging_impl.h
@@ -16,6 +16,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     Logging::Result start_logging() const;
     Logging::Result stop_logging() const;
 

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -7,13 +7,9 @@
 namespace dronecore {
 
 MissionImpl::MissionImpl() :
-    PluginImplBase()
-{
-}
+    PluginImplBase() {}
 
-MissionImpl::~MissionImpl()
-{
-}
+MissionImpl::~MissionImpl() {}
 
 void MissionImpl::init()
 {
@@ -48,10 +44,7 @@ void MissionImpl::init()
         std::bind(&MissionImpl::process_mission_item_int, this, _1), this);
 }
 
-void MissionImpl::enable()
-{
-
-}
+void MissionImpl::enable() {}
 
 void MissionImpl::disable()
 {

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -48,10 +48,19 @@ void MissionImpl::init()
         std::bind(&MissionImpl::process_mission_item_int, this, _1), this);
 }
 
+void MissionImpl::enable()
+{
+
+}
+
+void MissionImpl::disable()
+{
+    _parent->unregister_timeout_handler(_timeout_cookie);
+}
+
 void MissionImpl::deinit()
 {
     _parent->unregister_all_mavlink_message_handlers(this);
-    _parent->unregister_timeout_handler(_timeout_cookie);
 }
 
 void MissionImpl::process_mission_request(const mavlink_message_t &unused)

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -19,6 +19,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     void upload_mission_async(const std::vector<std::shared_ptr<MissionItem>> &mission_items,
                               const Mission::result_callback_t &callback);
 

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -5,13 +5,9 @@
 
 namespace dronecore {
 
-OffboardImpl::OffboardImpl()
-{
-}
+OffboardImpl::OffboardImpl() {}
 
-OffboardImpl::~OffboardImpl()
-{
-}
+OffboardImpl::~OffboardImpl() {}
 
 void OffboardImpl::init()
 {
@@ -27,13 +23,9 @@ void OffboardImpl::deinit()
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 
-void OffboardImpl::enable()
-{
-}
+void OffboardImpl::enable() {}
 
-void OffboardImpl::disable()
-{
-}
+void OffboardImpl::disable() {}
 
 Offboard::Result OffboardImpl::start()
 {

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -27,6 +27,14 @@ void OffboardImpl::deinit()
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 
+void OffboardImpl::enable()
+{
+}
+
+void OffboardImpl::disable()
+{
+}
+
 Offboard::Result OffboardImpl::start()
 {
     {

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -17,6 +17,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     Offboard::Result start();
     Offboard::Result stop();
 

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -47,13 +47,9 @@ TelemetryImpl::TelemetryImpl() :
     _health_all_ok_subscription(nullptr),
     _rc_status_subscription(nullptr),
     _ground_speed_ned_rate_hz(0.0),
-    _position_rate_hz(0.0)
-{
-}
+    _position_rate_hz(0.0) {}
 
-TelemetryImpl::~TelemetryImpl()
-{
-}
+TelemetryImpl::~TelemetryImpl() {}
 
 void TelemetryImpl::init()
 {

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -94,6 +94,15 @@ void TelemetryImpl::init()
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_RC_CHANNELS,
         std::bind(&TelemetryImpl::process_rc_channels, this, _1), this);
+}
+
+void TelemetryImpl::deinit()
+{
+    _parent->unregister_all_mavlink_message_handlers(this);
+}
+
+void TelemetryImpl::enable()
+{
 
     _parent->register_timeout_handler(
         std::bind(&TelemetryImpl::receive_rc_channels_timeout, this), 1.0, &_timeout_cookie);
@@ -131,9 +140,9 @@ void TelemetryImpl::init()
 #endif
 }
 
-void TelemetryImpl::deinit()
+void TelemetryImpl::disable()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent->unregister_timeout_handler(_timeout_cookie);
 }
 
 Telemetry::Result TelemetryImpl::set_rate_position(double rate_hz)

--- a/plugins/telemetry/telemetry_impl.h
+++ b/plugins/telemetry/telemetry_impl.h
@@ -24,6 +24,9 @@ public:
     void init() override;
     void deinit() override;
 
+    void enable() override;
+    void disable() override;
+
     Telemetry::Result set_rate_position(double rate_hz);
     Telemetry::Result set_rate_home_position(double rate_hz);
     Telemetry::Result set_rate_in_air(double rate_hz);


### PR DESCRIPTION
By providing an enable/disable API for plugins, we can distinguish
between calls that can/need to be made when a plugin is instantiated and
calls that make sense to make once we are conntected to a vehicle.

As an example, it does not make sense for a plugin to try to get a
parameter if no vehicle is conntected. This only produces a lot of
warnings and errors and uses up CPU.

The new API does not need to be implemented by plugins yet. For a
transitional period, runtime warnings are displayed if the methods are
not implemented.