### PR TITLE
mavlink_commands: fix switch case fall through

### DIFF
--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -125,15 +125,28 @@ void MavlinkCommands::receive_command_ack(mavlink_message_t message)
 
         case MAV_RESULT_DENIED:
             LogWarn() << "command denied (" << work.mavlink_command << ").";
-        // FALLTHRU
+            _state = State::FAILED;
+            if (work.callback) {
+                work.callback(Result::COMMAND_DENIED, NAN);
+            }
+            break;
 
         case MAV_RESULT_UNSUPPORTED:
             LogWarn() << "command unsupported (" << work.mavlink_command << ").";
-        // FALLTHRU
+            _state = State::FAILED;
+            if (work.callback) {
+                work.callback(Result::COMMAND_DENIED, NAN);
+            }
+            break;
 
         case MAV_RESULT_TEMPORARILY_REJECTED:
             LogWarn() << "command temporarily rejected (" << work.mavlink_command << ").";
-        // FALLTHRU
+            _state = State::FAILED;
+            if (work.callback) {
+                work.callback(Result::COMMAND_DENIED, NAN);
+            }
+            break;
+
         case MAV_RESULT_FAILED:
             LogWarn() << "command failed (" << work.mavlink_command << ").";
             _state = State::FAILED;


### PR DESCRIPTION
which warns about every subsequent error case

If I get one MAVLink with the result "command denied" it outputs all 4 possible warnings.
![subsequent_errors](https://user-images.githubusercontent.com/4668506/33683307-bf1b5924-daca-11e7-8c55-53ce5332845d.PNG)
