### PR TITLE
grpc: Support multiple device handling

### DIFF
--- a/grpc/proto/dronecore.proto
+++ b/grpc/proto/dronecore.proto
@@ -3,8 +3,17 @@ syntax = "proto3";
 
 package dronecorerpc;
 
+import "google/protobuf/empty.proto" ;
+
 // Interface exported by the server.
 service DroneCoreRPC {
+    rpc Get_UUID_List(google.protobuf.Empty) returns(Active_UUID_List) {}
 }
 
-message Empty {}
+message UUID {
+    uint64 uuid = 1;
+}
+
+message Active_UUID_List {
+    repeated UUID uuid_list = 1;
+}

--- a/grpc/python_client/CMakeLists.txt
+++ b/grpc/python_client/CMakeLists.txt
@@ -5,6 +5,7 @@ include(FindPythonInterp REQUIRED)
 add_custom_target(pydronecore ALL)
 
 set(plugins_dir ${CMAKE_SOURCE_DIR}/grpc/server/plugins)
+set(plugins_list action mission telemetry)
 
 if(${PYTHONINTERP_FOUND})
     set(proto_dir ${CMAKE_SOURCE_DIR}/grpc/proto)

--- a/grpc/python_client/multiple_device_handling.py
+++ b/grpc/python_client/multiple_device_handling.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import grpc
+import time
+import action_pb2 as dc_action
+import action_pb2_grpc
+import dronecore_pb2 as dronecore
+import dronecore_pb2_grpc
+from google.protobuf import empty_pb2
+
+def run():
+    channel = grpc.insecure_channel('0.0.0.0:50051')
+    action_stub = action_pb2_grpc.ActionRPCStub(channel)
+    dronecore_stub = dronecore_pb2_grpc.DroneCoreRPCStub(channel)
+    response=dronecore_stub.Get_UUID_List(empty_pb2.Empty())
+    size=len(response.uuid_list)
+    print("Devices registered : {}".format(size))
+    print(response.uuid_list[0].uuid)
+
+    for i in range(size):
+        uuid_item=dronecore.UUID()
+        uuid_item.uuid=response.uuid_list[i].uuid
+        print(uuid_item.uuid)
+        arm_result = action_stub.Arm(uuid_item)
+        if arm_result.result == dc_action.ActionResult.SUCCESS:
+            print("arming ok")
+        else:
+            print("arming failed: " + arm_result.result_str)
+
+        time.sleep(2)
+
+        takeoff_result = action_stub.TakeOff(uuid_item)
+        if takeoff_result.result == dc_action.ActionResult.SUCCESS:
+            print("takeoff ok")
+        else:
+            print("takeoff failed: " + takeoff_result.result_str)
+
+        time.sleep(5)
+
+        land_result = action_stub.Land(uuid_item)
+        if land_result.result == dc_action.ActionResult.SUCCESS:
+            print("landing ok")
+        else:
+            print("landing failed: " + land_result.result_str)
+
+
+if __name__ == '__main__':
+    run()

--- a/grpc/server/dronecore_server.cpp.in
+++ b/grpc/server/dronecore_server.cpp.in
@@ -17,6 +17,7 @@
 #include "action/actionrpc_impl.h"
 #include "mission/missionrpc_impl.h"
 #include "telemetry/telemetryrpc_impl.h"
+#include "dronecore/dronecorerpc_impl.h"
 
 using grpc::Server;
 using grpc::ServerBuilder;
@@ -35,17 +36,10 @@ template<typename T> ::grpc::Service *createInstances(DroneCore *dc_obj) {return
 
 typedef std::map<std::string, ::grpc::Service*(*)(DroneCore *dc_obj)> map_type;
 
-class DroneCoreRPCImpl final : public DroneCoreRPC::Service
-{
-
-public:
-
-};
-
 void RunServer()
 {
     std::string server_address("0.0.0.0:50051");
-    DroneCoreRPCImpl service;
+    DroneCoreRPCImpl service(&dc);
 
     map_type map;
     std::string plugin;
@@ -58,13 +52,14 @@ void RunServer()
     std::vector<::grpc::Service *> list;
 ${PLUGIN_MAP_APPEND_STRING}
 
+
     while (file >> plugin) {
         auto service_obj = map[plugin](&dc);
         list.push_back(service_obj);
     }
 
-    bool discovered_device = false;
-    DroneCore::ConnectionResult connection_result = dc.add_udp_connection();
+    int discovered_device = 0;
+    DroneCore::ConnectionResult connection_result = dc.add_udp_connection(14550);
     if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
         LogErr() << "Connection failed: " << DroneCore::connection_result_str(connection_result);
         return;
@@ -72,11 +67,11 @@ ${PLUGIN_MAP_APPEND_STRING}
     LogInfo() << "Waiting to discover device...";
     dc.register_on_discover([&discovered_device](uint64_t uuid) {
         LogInfo() << "Discovered device with UUID: " << uuid;
-        discovered_device = true;
+        discovered_device += 1;
     });
     // We usually receive heartbeats at 1Hz, therefore we should find a device after around 2 seconds.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
-    if (!discovered_device) {
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    if (discovered_device == 0) {
         LogErr() << "No device found, exiting.";
         return;
     }

--- a/grpc/server/plugins/action/action.proto
+++ b/grpc/server/plugins/action/action.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
+import "dronecore.proto";
 
 package dronecorerpc;
 
 service ActionRPC {
-    rpc Arm(google.protobuf.Empty) returns(ActionResult) {}
-    rpc TakeOff(google.protobuf.Empty) returns(ActionResult) {}
-    rpc Land(google.protobuf.Empty) returns(ActionResult) {}
+    rpc Arm(UUID) returns(ActionResult) {}
+    rpc TakeOff(UUID) returns(ActionResult) {}
+    rpc Land(UUID) returns(ActionResult) {}
 }
 
 message ActionResult {

--- a/grpc/server/plugins/action/actionrpc_impl.h
+++ b/grpc/server/plugins/action/actionrpc_impl.h
@@ -5,7 +5,7 @@
 using grpc::Status;
 using grpc::ServerContext;
 using dronecorerpc::ActionRPC;
-using dronecorerpc::Empty;
+using dronecorerpc::UUID;
 
 using namespace dronecore;
 
@@ -17,28 +17,28 @@ public:
         dc = dc_obj;
     }
 
-    Status Arm(ServerContext *context, const ::google::protobuf::Empty *request,
+    Status Arm(ServerContext *context, const UUID *request,
                dronecorerpc::ActionResult *response) override
     {
-        const Action::Result action_result = dc->device().action().arm();
+        const Action::Result action_result = dc->device(request->uuid()).action().arm();
         response->set_result(static_cast<dronecorerpc::ActionResult::Result>(action_result));
         response->set_result_str(Action::result_str(action_result));
         return Status::OK;
     }
 
-    Status TakeOff(ServerContext *context, const ::google::protobuf::Empty *request,
+    Status TakeOff(ServerContext *context, const UUID *request,
                    dronecorerpc::ActionResult *response) override
     {
-        const Action::Result action_result = dc->device().action().takeoff();
+        const Action::Result action_result = dc->device(request->uuid()).action().takeoff();
         response->set_result(static_cast<dronecorerpc::ActionResult::Result>(action_result));
         response->set_result_str(Action::result_str(action_result));
         return Status::OK;
     }
 
-    Status Land(ServerContext *context, const ::google::protobuf::Empty *request,
+    Status Land(ServerContext *context, const UUID *request,
                 dronecorerpc::ActionResult *response) override
     {
-        const Action::Result action_result = dc->device().action().land();
+        const Action::Result action_result = dc->device(request->uuid()).action().land();
         response->set_result(static_cast<dronecorerpc::ActionResult::Result>(action_result));
         response->set_result_str(Action::result_str(action_result));
         return Status::OK;

--- a/grpc/server/plugins/dronecore/dronecorerpc_impl.h
+++ b/grpc/server/plugins/dronecore/dronecorerpc_impl.h
@@ -1,0 +1,35 @@
+#include "dronecore.grpc.pb.h"
+#include <google/protobuf/empty.pb.h>
+
+using grpc::Status;
+using grpc::ServerContext;
+using grpc::ServerWriter;
+using dronecorerpc::DroneCoreRPC;
+using dronecorerpc::Active_UUID_List;
+
+using namespace dronecore;
+
+class DroneCoreRPCImpl final: public DroneCoreRPC::Service
+{
+public:
+    DroneCoreRPCImpl(DroneCore *dc_obj)
+    {
+        dc = dc_obj;
+    }
+
+    Status Get_UUID_List(ServerContext *context,
+                         const ::google::protobuf::Empty *request,
+                         Active_UUID_List *response) override
+    {
+        std::vector<uint64_t> list;
+        list = dc->device_uuids();
+        for (auto it = list.begin(); it != list.end(); ++it) {
+            UUID *item = response->add_uuid_list();
+            item->set_uuid(*it);
+        }
+        return Status::OK;
+    }
+
+private:
+    DroneCore *dc;
+};

--- a/grpc/server/plugins/mission/mission.proto
+++ b/grpc/server/plugins/mission/mission.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
+import "dronecore.proto";
 
 package dronecorerpc;
 
 service MissionRPC {
     rpc SendMission(Mission) returns(MissionResult) {}
-    rpc StartMission(google.protobuf.Empty) returns(MissionResult) {}
+    rpc StartMission(UUID) returns(MissionResult) {}
 }
 
 message MissionResult {
@@ -46,6 +46,7 @@ message MissionItem {
 
 message Mission {
     repeated MissionItem mission_items = 1;
+    uint64 uuid = 2;
 }
 
 

--- a/grpc/server/plugins/mission/missionrpc_impl.h
+++ b/grpc/server/plugins/mission/missionrpc_impl.h
@@ -5,6 +5,7 @@
 using grpc::Status;
 using grpc::ServerContext;
 using dronecorerpc::MissionRPC;
+using dronecorerpc::UUID;
 
 using namespace dronecore;
 
@@ -37,7 +38,7 @@ public:
             mission_items.push_back(new_item);
         }
 
-        dc->device().mission().upload_mission_async(
+        dc->device(mission->uuid()).mission().upload_mission_async(
         mission_items, [prom, response](Mission::Result result) {
             response->set_result(static_cast<dronecorerpc::MissionResult::Result>(result));
             response->set_result_str(Mission::result_str(result));
@@ -50,14 +51,14 @@ public:
         return Status::OK;
     }
 
-    Status StartMission(ServerContext *context, const ::google::protobuf::Empty *request,
+    Status StartMission(ServerContext *context, const UUID *request,
                         dronecorerpc::MissionResult *response) override
     {
         // TODO: there has to be a beter way than using std::future.
         auto prom = std::make_shared<std::promise<void>>();
         auto future_result = prom->get_future();
 
-        dc->device().mission().start_mission_async(
+        dc->device(request->uuid()).mission().start_mission_async(
         [prom, response](Mission::Result result) {
             response->set_result(static_cast<dronecorerpc::MissionResult::Result>(result));
             response->set_result_str(Mission::result_str(result));

--- a/grpc/server/plugins/telemetry/telemetry.proto
+++ b/grpc/server/plugins/telemetry/telemetry.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
+import "dronecore.proto";
 
 package dronecorerpc;
 
 service TelemetryRPC {
-    rpc TelemetryPositionSubscription(google.protobuf.Empty) returns(stream TelemetryPosition) {}
+    rpc TelemetryPositionSubscription(UUID) returns(stream TelemetryPosition) {}
 }
 
 message TelemetryPosition {

--- a/grpc/server/plugins/telemetry/telemetryrpc_impl.h
+++ b/grpc/server/plugins/telemetry/telemetryrpc_impl.h
@@ -1,11 +1,12 @@
 #include "telemetry.h"
 #include "telemetry.grpc.pb.h"
-#include <google/protobuf/empty.pb.h>
+
 
 using grpc::Status;
 using grpc::ServerContext;
 using dronecorerpc::TelemetryRPC;
 using grpc::ServerWriter;
+using dronecorerpc::UUID;
 
 using namespace dronecore;
 
@@ -18,10 +19,10 @@ public:
     }
 
     Status TelemetryPositionSubscription(ServerContext *context,
-                                         const ::google::protobuf::Empty *request,
+                                         const UUID *request,
                                          ServerWriter<dronecorerpc::TelemetryPosition> *writer) override
     {
-        dc->device().telemetry().position_async([&writer](Telemetry::Position position) {
+        dc->device(request->uuid()).telemetry().position_async([&writer](Telemetry::Position position) {
             dronecorerpc::TelemetryPosition rpc_position;
             rpc_position.set_latitude_deg(position.latitude_deg);
             rpc_position.set_longitude_deg(position.longitude_deg);


### PR DESCRIPTION
Updates Dronecore Server, grpc plugin api's to consider UUID
Updates Python Client examples to take UUID as a parameter for distinguishing between devices
Adds a common plugin to fetch the list of UUID's discovered by dronecore server
Adds multiple_device_handling.py to illustrate an example for handling multiple devices