### PR TITLE
Set Flight Mode using new interface set_flight_mode in DeviceImpl

### DIFF
--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -453,29 +453,30 @@ MavlinkCommands::Result DeviceImpl::set_flight_mode(FlightMode device_mode)
     uint8_t custom_sub_mode = 0;
 
     switch (device_mode) {
-        case FlightMode::HOLD :
+        case FlightMode::HOLD:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
             break;
-        case FlightMode::RETURN_TO_LAUNCH :
+        case FlightMode::RETURN_TO_LAUNCH:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
             break;
-        case FlightMode::TAKEOFF :
+        case FlightMode::TAKEOFF:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
             break;
-        case FlightMode::LAND :
+        case FlightMode::LAND:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
             break;
-        case FlightMode::MISSION :
+        case FlightMode::MISSION:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
             break;
-        case FlightMode::FOLLOW_ME :
+        case FlightMode::FOLLOW_ME:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
             break;
-        case FlightMode::OFFBOARD :
+        case FlightMode::OFFBOARD:
             custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
             break;
         default :
-            return MavlinkCommands::Result::UNSUPPORTED_MODE;
+            LogErr() << "Unknown Flight mode.";
+            return MavlinkCommands::Result::ERROR;
 
     }
 
@@ -490,8 +491,7 @@ MavlinkCommands::Result DeviceImpl::set_flight_mode(FlightMode device_mode)
     return ret;
 }
 
-void DeviceImpl::set_flight_mode_async(FlightMode device_mode,
-                                       command_result_callback_t callback)
+void DeviceImpl::set_flight_mode_async(FlightMode device_mode, command_result_callback_t callback)
 {
     uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
 
@@ -503,40 +503,43 @@ void DeviceImpl::set_flight_mode_async(FlightMode device_mode,
     uint8_t custom_sub_mode = 0;
 
     switch (device_mode) {
-        case FlightMode::HOLD :
+        case FlightMode::HOLD:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
             break;
-        case FlightMode::RETURN_TO_LAUNCH :
+        case FlightMode::RETURN_TO_LAUNCH:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
             break;
-        case FlightMode::TAKEOFF :
+        case FlightMode::TAKEOFF:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
             break;
-        case FlightMode::LAND :
+        case FlightMode::LAND:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
             break;
-        case FlightMode::MISSION :
+        case FlightMode::MISSION:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
             break;
-        case FlightMode::FOLLOW_ME :
+        case FlightMode::FOLLOW_ME:
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
             break;
-        case FlightMode::OFFBOARD :
+        case FlightMode::OFFBOARD:
             custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
             break;
         default :
+            LogErr() << "Unknown flight mode.";
+            if (callback) {
+                callback(MavlinkCommands::Result::ERROR, NAN);
+            }
             return ;
     }
 
 
-    send_command_with_ack_async(
-        MAV_CMD_DO_SET_MODE,
-        MavlinkCommands::Params {float(mode),
-                                 float(custom_mode),
-                                 float(custom_sub_mode),
-                                 NAN, NAN, NAN, NAN},
-        callback,
-        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    send_command_with_ack_async(MAV_CMD_DO_SET_MODE,
+                                MavlinkCommands::Params {float(mode),
+                                                         float(custom_mode),
+                                                         float(custom_sub_mode),
+                                                         NAN, NAN, NAN, NAN},
+                                callback,
+                                MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
 void DeviceImpl::get_param_int_async(const std::string &name,

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -441,11 +441,34 @@ void DeviceImpl::get_param_float_async(const std::string &name,
                                             callback));
 }
 
-MavlinkCommands::Result DeviceImpl::set_flight_mode(uint8_t custom_sub_mode, uint8_t custom_mode)
+MavlinkCommands::Result DeviceImpl::set_flight_mode(FLIGHT_MODE device_mode)
 {
-    uint8_t flag_safety_armed = DeviceImpl::is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
+    uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
 
     uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
+
+    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
+    uint8_t custom_sub_mode = 0;
+
+    switch (device_mode) {
+        case HOLD: custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
+            break;
+        case RETURN_TO_LAUNCH :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
+            break;
+        case TAKEOFF : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
+            break;
+        case LAND : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
+            break;
+        case MISSION : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
+            break;
+        case FOLLOW_ME : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
+            break;
+        case OFFBOARD : custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
+            break;
+        default : return MavlinkCommands::Result::UNSUPPORTED_MODE;
+
+    }
 
     MavlinkCommands::Result ret = send_command_with_ack(
                                       MAV_CMD_DO_SET_MODE,
@@ -458,12 +481,35 @@ MavlinkCommands::Result DeviceImpl::set_flight_mode(uint8_t custom_sub_mode, uin
     return ret;
 }
 
-void DeviceImpl::set_flight_mode_async(uint8_t custom_sub_mode, uint8_t custom_mode,
+void DeviceImpl::set_flight_mode_async(FLIGHT_MODE device_mode,
                                        command_result_callback_t callback)
 {
-    uint8_t flag_safety_armed = DeviceImpl::is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
+    uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
 
     uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
+
+    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
+    uint8_t custom_sub_mode = 0;
+
+    switch (device_mode) {
+        case HOLD: custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
+            break;
+        case RETURN_TO_LAUNCH :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
+            break;
+        case TAKEOFF : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
+            break;
+        case LAND : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
+            break;
+        case MISSION : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
+            break;
+        case FOLLOW_ME : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
+            break;
+        case OFFBOARD : custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
+            break;
+        default : return ;
+    }
+
 
     send_command_with_ack_async(
         MAV_CMD_DO_SET_MODE,

--- a/core/device_impl.cpp
+++ b/core/device_impl.cpp
@@ -441,32 +441,41 @@ void DeviceImpl::get_param_float_async(const std::string &name,
                                             callback));
 }
 
-MavlinkCommands::Result DeviceImpl::set_flight_mode(FLIGHT_MODE device_mode)
+MavlinkCommands::Result DeviceImpl::set_flight_mode(FlightMode device_mode)
 {
     uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
 
     uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
 
+    // Note: the safety flag is not needed in future versions of the PX4 Firmware
+    //       but want to be rather safe than sorry.
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = 0;
 
     switch (device_mode) {
-        case HOLD: custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
+        case FlightMode::HOLD :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
             break;
-        case RETURN_TO_LAUNCH :
+        case FlightMode::RETURN_TO_LAUNCH :
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
             break;
-        case TAKEOFF : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
+        case FlightMode::TAKEOFF :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
             break;
-        case LAND : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
+        case FlightMode::LAND :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
             break;
-        case MISSION : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
+        case FlightMode::MISSION :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
             break;
-        case FOLLOW_ME : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
+        case FlightMode::FOLLOW_ME :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
             break;
-        case OFFBOARD : custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
+        case FlightMode::OFFBOARD :
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
             break;
-        default : return MavlinkCommands::Result::UNSUPPORTED_MODE;
+        default :
+            return MavlinkCommands::Result::UNSUPPORTED_MODE;
 
     }
 
@@ -481,33 +490,42 @@ MavlinkCommands::Result DeviceImpl::set_flight_mode(FLIGHT_MODE device_mode)
     return ret;
 }
 
-void DeviceImpl::set_flight_mode_async(FLIGHT_MODE device_mode,
+void DeviceImpl::set_flight_mode_async(FlightMode device_mode,
                                        command_result_callback_t callback)
 {
     uint8_t flag_safety_armed = is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
 
     uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
 
+    // Note: the safety flag is not needed in future versions of the PX4 Firmware
+    //       but want to be rather safe than sorry.
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = 0;
 
     switch (device_mode) {
-        case HOLD: custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
+        case FlightMode::HOLD :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
             break;
-        case RETURN_TO_LAUNCH :
+        case FlightMode::RETURN_TO_LAUNCH :
             custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
             break;
-        case TAKEOFF : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
+        case FlightMode::TAKEOFF :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF;
             break;
-        case LAND : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
+        case FlightMode::LAND :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LAND;
             break;
-        case MISSION : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
+        case FlightMode::MISSION :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
             break;
-        case FOLLOW_ME : custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
+        case FlightMode::FOLLOW_ME :
+            custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
             break;
-        case OFFBOARD : custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
+        case FlightMode::OFFBOARD :
+            custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
             break;
-        default : return ;
+        default :
+            return ;
     }
 
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -18,10 +18,19 @@ namespace dronecore {
 
 class DroneCoreImpl;
 
-
 class DeviceImpl
 {
 public:
+    enum FLIGHT_MODE {
+        HOLD = 0,
+        RETURN_TO_LAUNCH,
+        TAKEOFF,
+        LAND,
+        MISSION,
+        FOLLOW_ME,
+        OFFBOARD,
+    };
+
     explicit DeviceImpl(DroneCoreImpl *parent,
                         uint8_t target_system_id);
     ~DeviceImpl();
@@ -79,8 +88,8 @@ public:
     void set_param_int_async(const std::string &name, int32_t value, success_t callback);
     void set_param_ext_float_async(const std::string &name, float value, success_t callback);
     void set_param_ext_int_async(const std::string &name, int32_t value, success_t callback);
-    MavlinkCommands::Result set_flight_mode(uint8_t custom_sub_mode, uint8_t custom_mode);
-    void set_flight_mode_async(uint8_t custom_sub_mode, uint8_t custom_mode,
+    MavlinkCommands::Result set_flight_mode(FLIGHT_MODE mode);
+    void set_flight_mode_async(FLIGHT_MODE mode,
                                command_result_callback_t callback);
 
     typedef std::function <void(bool success, float value)> get_param_float_callback_t;
@@ -109,6 +118,8 @@ public:
     // Non-copyable
     DeviceImpl(const DeviceImpl &) = delete;
     const DeviceImpl &operator=(const DeviceImpl &) = delete;
+
+
 
 private:
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -79,6 +79,9 @@ public:
     void set_param_int_async(const std::string &name, int32_t value, success_t callback);
     void set_param_ext_float_async(const std::string &name, float value, success_t callback);
     void set_param_ext_int_async(const std::string &name, int32_t value, success_t callback);
+    MavlinkCommands::Result set_flight_mode(uint8_t custom_sub_mode, uint8_t custom_mode);
+    void set_flight_mode_async(uint8_t custom_sub_mode, uint8_t custom_mode,
+                               command_result_callback_t callback);
 
     typedef std::function <void(bool success, float value)> get_param_float_callback_t;
     typedef std::function <void(bool success, int32_t value)> get_param_int_callback_t;

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -21,7 +21,7 @@ class DroneCoreImpl;
 class DeviceImpl
 {
 public:
-    enum FLIGHT_MODE {
+    enum class FlightMode {
         HOLD = 0,
         RETURN_TO_LAUNCH,
         TAKEOFF,
@@ -88,8 +88,8 @@ public:
     void set_param_int_async(const std::string &name, int32_t value, success_t callback);
     void set_param_ext_float_async(const std::string &name, float value, success_t callback);
     void set_param_ext_int_async(const std::string &name, int32_t value, success_t callback);
-    MavlinkCommands::Result set_flight_mode(FLIGHT_MODE mode);
-    void set_flight_mode_async(FLIGHT_MODE mode,
+    MavlinkCommands::Result set_flight_mode(FlightMode mode);
+    void set_flight_mode_async(FlightMode mode,
                                command_result_callback_t callback);
 
     typedef std::function <void(bool success, float value)> get_param_float_callback_t;
@@ -118,8 +118,6 @@ public:
     // Non-copyable
     DeviceImpl(const DeviceImpl &) = delete;
     const DeviceImpl &operator=(const DeviceImpl &) = delete;
-
-
 
 private:
 

--- a/core/device_impl.h
+++ b/core/device_impl.h
@@ -89,8 +89,7 @@ public:
     void set_param_ext_float_async(const std::string &name, float value, success_t callback);
     void set_param_ext_int_async(const std::string &name, int32_t value, success_t callback);
     MavlinkCommands::Result set_flight_mode(FlightMode mode);
-    void set_flight_mode_async(FlightMode mode,
-                               command_result_callback_t callback);
+    void set_flight_mode_async(FlightMode mode, command_result_callback_t callback);
 
     typedef std::function <void(bool success, float value)> get_param_float_callback_t;
     typedef std::function <void(bool success, int32_t value)> get_param_int_callback_t;

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -25,7 +25,7 @@ public:
         COMMAND_DENIED,
         TIMEOUT,
         IN_PROGRESS,
-        UNSUPPORTED_MODE
+        ERROR
     };
 
     typedef std::function<void(Result, float)> command_result_callback_t;

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -24,7 +24,8 @@ public:
         BUSY,
         COMMAND_DENIED,
         TIMEOUT,
-        IN_PROGRESS
+        IN_PROGRESS,
+        UNSUPPORTED_MODE
     };
 
     typedef std::function<void(Result, float)> command_result_callback_t;

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -45,11 +45,8 @@ Action::Result ActionImpl::arm() const
     }
 
     // Go to LOITER mode first.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     ret = action_result_from_command_result(
-              _parent->set_flight_mode(custom_sub_mode, custom_mode));
+              _parent->set_flight_mode(DeviceImpl::HOLD));
 
     if (ret != Action::Result::SUCCESS) {
         return ret;
@@ -93,12 +90,8 @@ Action::Result ActionImpl::takeoff() const
     }
 
     // Go to LOITER mode first.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     ret = action_result_from_command_result(_parent->set_flight_mode(
-                                                custom_sub_mode,
-                                                custom_mode));
+                                                DeviceImpl::HOLD));
 
     return action_result_from_command_result(
                _parent->send_command_with_ack(
@@ -121,12 +114,9 @@ Action::Result ActionImpl::return_to_launch() const
 {
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
 
     return action_result_from_command_result(_parent->set_flight_mode(
-                                                 custom_sub_mode,
-                                                 custom_mode));
+                                                 DeviceImpl::RETURN_TO_LAUNCH));
 }
 
 Action::Result ActionImpl::transition_to_fixedwing() const
@@ -321,11 +311,9 @@ void ActionImpl::return_to_launch_async(const Action::result_callback_t &callbac
 {
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_RTL;
 
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::RETURN_TO_LAUNCH,
         std::bind(&ActionImpl::command_result_callback,
                   _1,
                   callback));
@@ -391,22 +379,16 @@ void ActionImpl::process_extended_sys_state(const mavlink_message_t &message)
 
 void ActionImpl::loiter_before_takeoff_async(const Action::result_callback_t &callback)
 {
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::HOLD,
         std::bind(&ActionImpl::takeoff_async_continued, this, _1,
                   callback));
 }
 
 void ActionImpl::loiter_before_arm_async(const Action::result_callback_t &callback)
 {
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::HOLD,
         std::bind(&ActionImpl::arm_async_continued, this, _1,
                   callback));
 }

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -46,7 +46,7 @@ Action::Result ActionImpl::arm() const
 
     // Go to LOITER mode first.
     ret = action_result_from_command_result(
-              _parent->set_flight_mode(DeviceImpl::HOLD));
+              _parent->set_flight_mode(DeviceImpl::FlightMode::HOLD));
 
     if (ret != Action::Result::SUCCESS) {
         return ret;
@@ -91,7 +91,7 @@ Action::Result ActionImpl::takeoff() const
 
     // Go to LOITER mode first.
     ret = action_result_from_command_result(_parent->set_flight_mode(
-                                                DeviceImpl::HOLD));
+                                                DeviceImpl::FlightMode::HOLD));
 
     return action_result_from_command_result(
                _parent->send_command_with_ack(
@@ -112,11 +112,8 @@ Action::Result ActionImpl::land() const
 
 Action::Result ActionImpl::return_to_launch() const
 {
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
-
     return action_result_from_command_result(_parent->set_flight_mode(
-                                                 DeviceImpl::RETURN_TO_LAUNCH));
+                                                 DeviceImpl::FlightMode::RETURN_TO_LAUNCH));
 }
 
 Action::Result ActionImpl::transition_to_fixedwing() const
@@ -309,11 +306,8 @@ void ActionImpl::land_async(const Action::result_callback_t &callback)
 
 void ActionImpl::return_to_launch_async(const Action::result_callback_t &callback)
 {
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
-
     _parent->set_flight_mode_async(
-        DeviceImpl::RETURN_TO_LAUNCH,
+        DeviceImpl::FlightMode::RETURN_TO_LAUNCH,
         std::bind(&ActionImpl::command_result_callback,
                   _1,
                   callback));
@@ -380,7 +374,7 @@ void ActionImpl::process_extended_sys_state(const mavlink_message_t &message)
 void ActionImpl::loiter_before_takeoff_async(const Action::result_callback_t &callback)
 {
     _parent->set_flight_mode_async(
-        DeviceImpl::HOLD,
+        DeviceImpl::FlightMode::HOLD,
         std::bind(&ActionImpl::takeoff_async_continued, this, _1,
                   callback));
 }
@@ -388,7 +382,7 @@ void ActionImpl::loiter_before_takeoff_async(const Action::result_callback_t &ca
 void ActionImpl::loiter_before_arm_async(const Action::result_callback_t &callback)
 {
     _parent->set_flight_mode_async(
-        DeviceImpl::HOLD,
+        DeviceImpl::FlightMode::HOLD,
         std::bind(&ActionImpl::arm_async_continued, this, _1,
                   callback));
 }

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -90,8 +90,8 @@ Action::Result ActionImpl::takeoff() const
     }
 
     // Go to LOITER mode first.
-    ret = action_result_from_command_result(_parent->set_flight_mode(
-                                                DeviceImpl::FlightMode::HOLD));
+    ret = action_result_from_command_result(
+              _parent->set_flight_mode(DeviceImpl::FlightMode::HOLD));
 
     return action_result_from_command_result(
                _parent->send_command_with_ack(
@@ -112,8 +112,8 @@ Action::Result ActionImpl::land() const
 
 Action::Result ActionImpl::return_to_launch() const
 {
-    return action_result_from_command_result(_parent->set_flight_mode(
-                                                 DeviceImpl::FlightMode::RETURN_TO_LAUNCH));
+    return action_result_from_command_result(
+               _parent->set_flight_mode(DeviceImpl::FlightMode::RETURN_TO_LAUNCH));
 }
 
 Action::Result ActionImpl::transition_to_fixedwing() const
@@ -308,9 +308,7 @@ void ActionImpl::return_to_launch_async(const Action::result_callback_t &callbac
 {
     _parent->set_flight_mode_async(
         DeviceImpl::FlightMode::RETURN_TO_LAUNCH,
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback));
+        std::bind(&ActionImpl::command_result_callback, _1, callback));
 }
 
 Action::Result ActionImpl::arming_allowed() const
@@ -375,16 +373,14 @@ void ActionImpl::loiter_before_takeoff_async(const Action::result_callback_t &ca
 {
     _parent->set_flight_mode_async(
         DeviceImpl::FlightMode::HOLD,
-        std::bind(&ActionImpl::takeoff_async_continued, this, _1,
-                  callback));
+        std::bind(&ActionImpl::takeoff_async_continued, this, _1, callback));
 }
 
 void ActionImpl::loiter_before_arm_async(const Action::result_callback_t &callback)
 {
     _parent->set_flight_mode_async(
         DeviceImpl::FlightMode::HOLD,
-        std::bind(&ActionImpl::arm_async_continued, this, _1,
-                  callback));
+        std::bind(&ActionImpl::arm_async_continued, this, _1, callback));
 }
 
 

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -146,21 +146,14 @@ FollowMe::Result FollowMeImpl::start()
 {
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
 
 
     FollowMe::Result result = to_follow_me_result(
-                                  _parent->send_command_with_ack(
-                                      MAV_CMD_DO_SET_MODE,
-                                      MavlinkCommands::Params {float(mode),
-                                                               float(custom_mode),
-                                                               float(custom_sub_mode),
-                                                               NAN, NAN, NAN, NAN},
-                                      MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+                                  _parent->set_flight_mode(
+                                      custom_sub_mode,
+                                      custom_mode));
 
     if (result == FollowMe::Result::SUCCESS) {
         // If location was set before, lets send it to vehicle
@@ -185,20 +178,13 @@ FollowMe::Result FollowMeImpl::stop()
     }
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
 
     return to_follow_me_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_SET_MODE,
-                   MavlinkCommands::Params {float(mode),
-                                            float(custom_mode),
-                                            float(custom_sub_mode),
-                                            NAN, NAN, NAN, NAN},
-                   MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+               _parent->set_flight_mode(
+                   custom_sub_mode,
+                   custom_mode));
 }
 
 // Applies default FollowMe configuration to the device

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -146,14 +146,9 @@ FollowMe::Result FollowMeImpl::start()
 {
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET;
-
-
     FollowMe::Result result = to_follow_me_result(
                                   _parent->set_flight_mode(
-                                      custom_sub_mode,
-                                      custom_mode));
+                                      DeviceImpl::FOLLOW_ME));
 
     if (result == FollowMe::Result::SUCCESS) {
         // If location was set before, lets send it to vehicle
@@ -178,13 +173,9 @@ FollowMe::Result FollowMeImpl::stop()
     }
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     return to_follow_me_result(
                _parent->set_flight_mode(
-                   custom_sub_mode,
-                   custom_mode));
+                   DeviceImpl::HOLD));
 }
 
 // Applies default FollowMe configuration to the device

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -144,11 +144,9 @@ bool FollowMeImpl::is_active() const
 
 FollowMe::Result FollowMeImpl::start()
 {
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     FollowMe::Result result = to_follow_me_result(
                                   _parent->set_flight_mode(
-                                      DeviceImpl::FOLLOW_ME));
+                                      DeviceImpl::FlightMode::FOLLOW_ME));
 
     if (result == FollowMe::Result::SUCCESS) {
         // If location was set before, lets send it to vehicle
@@ -171,11 +169,9 @@ FollowMe::Result FollowMeImpl::stop()
             stop_sending_target_location();
         }
     }
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     return to_follow_me_result(
                _parent->set_flight_mode(
-                   DeviceImpl::HOLD));
+                   DeviceImpl::FlightMode::HOLD));
 }
 
 // Applies default FollowMe configuration to the device

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -671,13 +671,11 @@ void MissionImpl::start_mission_async(const Mission::result_callback_t &callback
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
 
     _activity = Activity::SEND_COMMAND;
 
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::MISSION,
         std::bind(&MissionImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 
@@ -695,13 +693,10 @@ void MissionImpl::pause_mission_async(const Mission::result_callback_t &callback
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     _activity = Activity::SEND_COMMAND;
 
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::HOLD,
         std::bind(&MissionImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -669,13 +669,10 @@ void MissionImpl::start_mission_async(const Mission::result_callback_t &callback
         return;
     }
 
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
-
     _activity = Activity::SEND_COMMAND;
 
     _parent->set_flight_mode_async(
-        DeviceImpl::MISSION,
+        DeviceImpl::FlightMode::MISSION,
         std::bind(&MissionImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 
@@ -691,12 +688,10 @@ void MissionImpl::pause_mission_async(const Mission::result_callback_t &callback
         return;
     }
 
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     _activity = Activity::SEND_COMMAND;
 
     _parent->set_flight_mode_async(
-        DeviceImpl::HOLD,
+        DeviceImpl::FlightMode::HOLD,
         std::bind(&MissionImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -671,23 +671,15 @@ void MissionImpl::start_mission_async(const Mission::result_callback_t &callback
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_MISSION;
 
     _activity = Activity::SEND_COMMAND;
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_SET_MODE,
-        MavlinkCommands::Params {float(mode),
-                                 float(custom_mode),
-                                 float(custom_sub_mode),
-                                 NAN, NAN, NAN, NAN},
+    _parent->set_flight_mode_async(
+        custom_sub_mode, custom_mode,
         std::bind(&MissionImpl::receive_command_result, this,
-                  std::placeholders::_1, callback),
-        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+                  std::placeholders::_1, callback));
 
     _result_callback = callback;
 }
@@ -703,23 +695,15 @@ void MissionImpl::pause_mission_async(const Mission::result_callback_t &callback
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
 
     _activity = Activity::SEND_COMMAND;
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_SET_MODE,
-        MavlinkCommands::Params {float(mode),
-                                 float(custom_mode),
-                                 float(custom_sub_mode),
-                                 NAN, NAN, NAN, NAN},
+    _parent->set_flight_mode_async(
+        custom_sub_mode, custom_mode,
         std::bind(&MissionImpl::receive_command_result, this,
-                  std::placeholders::_1, callback),
-        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+                  std::placeholders::_1, callback));
 
     _result_callback = callback;
 }

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -38,20 +38,11 @@ Offboard::Result OffboardImpl::start()
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
     uint8_t custom_sub_mode = 0;
 
     return offboard_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_SET_MODE,
-                   MavlinkCommands::Params {float(mode),
-                                            float(custom_mode),
-                                            float(custom_sub_mode),
-                                            NAN, NAN, NAN, NAN},
-                   MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+               _parent->set_flight_mode(custom_sub_mode, custom_mode));
 }
 
 Offboard::Result OffboardImpl::stop()
@@ -65,20 +56,11 @@ Offboard::Result OffboardImpl::stop()
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
 
     return offboard_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_SET_MODE,
-                   MavlinkCommands::Params {float(mode),
-                                            float(custom_mode),
-                                            float(custom_sub_mode),
-                                            NAN, NAN, NAN, NAN},
-                   MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+               _parent->set_flight_mode(custom_sub_mode, custom_mode));
 }
 
 void OffboardImpl::start_async(Offboard::result_callback_t callback)
@@ -96,21 +78,13 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
     uint8_t custom_sub_mode = 0;
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_SET_MODE,
-        MavlinkCommands::Params {float(mode),
-                                 float(custom_mode),
-                                 float(custom_sub_mode),
-                                 NAN, NAN, NAN, NAN},
+    _parent->set_flight_mode_async(
+        custom_sub_mode, custom_mode,
         std::bind(&OffboardImpl::receive_command_result, this,
-                  std::placeholders::_1, callback),
-        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+                  std::placeholders::_1, callback));
 }
 
 void OffboardImpl::stop_async(Offboard::result_callback_t callback)
@@ -124,21 +98,13 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t flag_safety_armed = _parent->is_armed() ? MAV_MODE_FLAG_SAFETY_ARMED : 0;
-
-    uint8_t mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | flag_safety_armed;
     uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
     uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_SET_MODE,
-        MavlinkCommands::Params {float(mode),
-                                 float(custom_mode),
-                                 float(custom_sub_mode),
-                                 NAN, NAN, NAN, NAN},
+    _parent->set_flight_mode_async(
+        custom_sub_mode, custom_mode,
         std::bind(&OffboardImpl::receive_command_result, this,
-                  std::placeholders::_1, callback),
-        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+                  std::placeholders::_1, callback));
 }
 
 bool OffboardImpl::is_active() const

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -38,11 +38,8 @@ Offboard::Result OffboardImpl::start()
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
-    uint8_t custom_sub_mode = 0;
-
     return offboard_result_from_command_result(
-               _parent->set_flight_mode(custom_sub_mode, custom_mode));
+               _parent->set_flight_mode(DeviceImpl::OFFBOARD));
 }
 
 Offboard::Result OffboardImpl::stop()
@@ -56,11 +53,8 @@ Offboard::Result OffboardImpl::stop()
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     return offboard_result_from_command_result(
-               _parent->set_flight_mode(custom_sub_mode, custom_mode));
+               _parent->set_flight_mode(DeviceImpl::HOLD));
 }
 
 void OffboardImpl::start_async(Offboard::result_callback_t callback)
@@ -78,11 +72,8 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_OFFBOARD;
-    uint8_t custom_sub_mode = 0;
-
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::OFFBOARD,
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 }
@@ -98,11 +89,8 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
 
     // Note: the safety flag is not needed in future versions of the PX4 Firmware
     //       but want to be rather safe than sorry.
-    uint8_t custom_mode = px4::PX4_CUSTOM_MAIN_MODE_AUTO;
-    uint8_t custom_sub_mode = px4::PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
-
     _parent->set_flight_mode_async(
-        custom_sub_mode, custom_mode,
+        DeviceImpl::HOLD,
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 }

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -36,10 +36,8 @@ Offboard::Result OffboardImpl::start()
         }
     }
 
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     return offboard_result_from_command_result(
-               _parent->set_flight_mode(DeviceImpl::OFFBOARD));
+               _parent->set_flight_mode(DeviceImpl::FlightMode::OFFBOARD));
 }
 
 Offboard::Result OffboardImpl::stop()
@@ -51,10 +49,8 @@ Offboard::Result OffboardImpl::stop()
         }
     }
 
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     return offboard_result_from_command_result(
-               _parent->set_flight_mode(DeviceImpl::HOLD));
+               _parent->set_flight_mode(DeviceImpl::FlightMode::HOLD));
 }
 
 void OffboardImpl::start_async(Offboard::result_callback_t callback)
@@ -70,10 +66,8 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
         }
     }
 
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     _parent->set_flight_mode_async(
-        DeviceImpl::OFFBOARD,
+        DeviceImpl::FlightMode::OFFBOARD,
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 }
@@ -87,10 +81,8 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
         }
     }
 
-    // Note: the safety flag is not needed in future versions of the PX4 Firmware
-    //       but want to be rather safe than sorry.
     _parent->set_flight_mode_async(
-        DeviceImpl::HOLD,
+        DeviceImpl::FlightMode::HOLD,
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
 }


### PR DESCRIPTION
Modifies plugins to use `set_flight_mode` instead of using MAV_CMD_DO_SET_MODE
Issue : #193 