### PR TITLE
curl-android-ios: swap to dronecore fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,7 @@
 	url = https://github.com/google/googletest
 [submodule "curl-android-ios"]
 	path = curl-android-ios
-	url = https://github.com/gcesarmza/curl-android-ios.git
-	ignore = dirty
+	url = https://github.com/dronecore/curl-android-ios.git
 [submodule "libs/tinyxml2"]
 	path = libs/tinyxml2
 	url = https://github.com/leethomason/tinyxml2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ include_directories(
     ${external_plugins}
     ${CMAKE_CURRENT_BINARY_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/core
-    SYSTEM ${EXTERNAL_DIR}/${additional_includes}
+    SYSTEM ${additional_includes}
 )
 
 if (DEFINED additional_includes AND NOT additional_includes STREQUAL "")


### PR DESCRIPTION
This requires `git submodule sync` afterwards.