### PR TITLE
make: always create openssl headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ android_arm64-v8a: android_curl
 android_curl: android_env_check
 	+@if [ ! -e $(CURL_BUILD_DIR)/prebuilt-with-ssl/android ]; then \
 		$(CURL_BUILD_DIR)/curl-compile-scripts/build_Android.sh; \
+	else \
+		$(CURL_BUILD_DIR)/curl-compile-scripts/build_Android.sh --openssl-configure-only; \
 	fi
 
 ios_curl:


### PR DESCRIPTION
This uses the build_Android.sh script to call the openssl configure step
without actually re-building all of openssl and curl.

The configure step is needed in order to be able to access the openssl
headers which are symlinked to a `include` folder, and to get the
opensslconf.h headerfile.