### PR TITLE
Correct API description of Telemetry and Offboard plugins.

### DIFF
--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -136,7 +136,7 @@ public:
     void set_velocity_ned(VelocityNEDYaw velocity_ned_yaw);
 
     /**
-     * @brief Set the velocity body coordinates coordinates and yaw angular rate.
+     * @brief Set the velocity body coordinates and yaw angular rate.
      *
      * @param velocity_body_yawspeed Velocity and yaw angular rate `struct`.
      */

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -553,7 +553,7 @@ public:
     typedef std::function<void(FlightMode flight_mode)> flight_mode_callback_t;
 
     /**
-     * @brief Subscribe to battery status updates (asynchronous).
+     * @brief Subscribe to flight mode updates (asynchronous).
      *
      * Note that flight mode updates are limited to 1Hz.
      *


### PR DESCRIPTION
Corrected in `Telemetry::flight_mode_async()` and
`Offboard::set_velocity_body()` API description. Possibly these are typos.