### PR TITLE
Fix issue: https://github.com/dronecore/DroneCore/issues/227

### DIFF
--- a/start_px4_sitl.sh
+++ b/start_px4_sitl.sh
@@ -50,7 +50,7 @@ cd $px4_firmware_dir/build/posix_sitl_default/tmp
 
 # And run
 $px4_firmware_dir/Tools/sitl_run.sh \
-    $px4_firmware_dir/build/posix_sitl_default/src/firmware/posix/px4 \
+    $px4_firmware_dir/build/posix_sitl_default/px4 \
     posix-configs/SITL/init/lpe \
     none gazebo iris \
     $px4_firmware_dir \


### PR DESCRIPTION
Fixes Autostart SITL error during launch of integration tests by correcting second argument to [Tools/sitl_run.sh](https://github.com/PX4/Firmware/blob/master/Tools/sitl_run.sh#L66) as part of [start_px4_sitl.sh](https://github.com/dronecore/DroneCore/blob/develop/start_px4_sitl.sh#L53).