### PR TITLE
Robustify mission upload/download

### DIFF
--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -23,6 +23,9 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
 static void compare_mission_items(const std::shared_ptr<MissionItem> original,
                                   const std::shared_ptr<MissionItem> downloaded);
 
+// Set to 1 to test with 1200 mission items.
+#define MANY_ITEMS_TEST 0
+
 
 TEST_F(SitlTest, MissionAddWaypointsAndFly)
 {
@@ -57,52 +60,59 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
 
     std::vector<std::shared_ptr<MissionItem>> mission_items;
 
-    mission_items.push_back(
-        add_mission_item(47.398170327054473,
-                         8.5456490218639658,
-                         10.0f, 5.0f, false,
-                         20.0f, 60.0f,
-                         NAN,
-                         MissionItem::CameraAction::NONE));
+#if MANY_ITEMS_TEST==1
+    for (int i = 0; i < 50; ++i) {
+#endif
+        mission_items.push_back(
+            add_mission_item(47.398170327054473,
+                             8.5456490218639658,
+                             10.0f, 5.0f, false,
+                             20.0f, 60.0f,
+                             NAN,
+                             MissionItem::CameraAction::NONE));
 
-    mission_items.push_back(
-        add_mission_item(47.398241338125118,
-                         8.5455360114574432,
-                         10.0f, 2.0f, true,
-                         0.0f, -60.0f,
-                         5.0f,
-                         MissionItem::CameraAction::TAKE_PHOTO));
+        mission_items.push_back(
+            add_mission_item(47.398241338125118,
+                             8.5455360114574432,
+                             10.0f, 2.0f, true,
+                             0.0f, -60.0f,
+                             5.0f,
+                             MissionItem::CameraAction::TAKE_PHOTO));
 
-    mission_items.push_back(
-        add_mission_item(47.398139363821485, 8.5453846156597137,
-                         10.0f, 5.0f, true,
-                         -46.0f, 0.0f,
-                         NAN,
-                         MissionItem::CameraAction::START_VIDEO));
+        mission_items.push_back(
+            add_mission_item(47.398139363821485, 8.5453846156597137,
+                             10.0f, 5.0f, true,
+                             -46.0f, 0.0f,
+                             NAN,
+                             MissionItem::CameraAction::START_VIDEO));
 
-    mission_items.push_back(
-        add_mission_item(47.398058617228855,
-                         8.5454618036746979,
-                         10.0f, 2.0f, false,
-                         -90.0f, 30.0f,
-                         NAN,
-                         MissionItem::CameraAction::STOP_VIDEO));
+        mission_items.push_back(
+            add_mission_item(47.398058617228855,
+                             8.5454618036746979,
+                             10.0f, 2.0f, false,
+                             -90.0f, 30.0f,
+                             NAN,
+                             MissionItem::CameraAction::STOP_VIDEO));
 
-    mission_items.push_back(
-        add_mission_item(47.398100366082858,
-                         8.5456969141960144,
-                         10.0f, 5.0f, false,
-                         -45.0f, -30.0f,
-                         NAN,
-                         MissionItem::CameraAction::START_PHOTO_INTERVAL));
+        mission_items.push_back(
+            add_mission_item(47.398100366082858,
+                             8.5456969141960144,
+                             10.0f, 5.0f, false,
+                             -45.0f, -30.0f,
+                             NAN,
+                             MissionItem::CameraAction::START_PHOTO_INTERVAL));
 
-    mission_items.push_back(
-        add_mission_item(47.398001890458097,
-                         8.5455576181411743,
-                         10.0f, 5.0f, false,
-                         0.0f, 0.0f,
-                         NAN,
-                         MissionItem::CameraAction::STOP_PHOTO_INTERVAL));
+        mission_items.push_back(
+            add_mission_item(47.398001890458097,
+                             8.5455576181411743,
+                             10.0f, 5.0f, false,
+                             0.0f, 0.0f,
+                             NAN,
+                             MissionItem::CameraAction::STOP_PHOTO_INTERVAL));
+
+#if MANY_ITEMS_TEST==1
+    }
+#endif
 
     {
         LogInfo() << "Uploading mission...";

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -23,8 +23,8 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
 static void compare_mission_items(const std::shared_ptr<MissionItem> original,
                                   const std::shared_ptr<MissionItem> downloaded);
 
-// Set to 1 to test with 1200 mission items.
-#define MANY_ITEMS_TEST 0
+// Set to 50 to test with about 1200 mission items.
+static constexpr int test_with_many_items = 1;
 
 
 TEST_F(SitlTest, MissionAddWaypointsAndFly)
@@ -60,9 +60,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
 
     std::vector<std::shared_ptr<MissionItem>> mission_items;
 
-#if MANY_ITEMS_TEST==1
-    for (int i = 0; i < 50; ++i) {
-#endif
+    for (int i = 0; i < test_with_many_items; ++i) {
         mission_items.push_back(
             add_mission_item(47.398170327054473,
                              8.5456490218639658,
@@ -110,9 +108,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
                              NAN,
                              MissionItem::CameraAction::STOP_PHOTO_INTERVAL));
 
-#if MANY_ITEMS_TEST==1
     }
-#endif
 
     {
         LogInfo() << "Uploading mission...";

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -70,7 +70,6 @@ void MissionImpl::process_mission_request(const mavlink_message_t &unused)
                                  MAV_MISSION_UNSUPPORTED,
                                  MAV_MISSION_TYPE_MISSION);
 
-
     _parent->send_message(message);
 
     // Reset the timeout because we're still communicating.
@@ -96,6 +95,7 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
         return;
     }
 
+    _retries = 0;
     upload_mission_item(mission_request_int.seq);
 
 
@@ -193,7 +193,11 @@ void MissionImpl::process_mission_count(const mavlink_message_t &message)
 
     _num_mission_items_to_download = mission_count.count;
     _next_mission_item_to_download = 0;
-    _parent->refresh_timeout_handler(_timeout_cookie);
+    // We are now requesting mission items and use a lower timeout for this.
+    _parent->unregister_timeout_handler(_timeout_cookie);
+
+    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                      RETRY_TIMEOUT_S, &_timeout_cookie);
     download_next_mission_item();
 }
 
@@ -204,33 +208,49 @@ void MissionImpl::process_mission_item_int(const mavlink_message_t &message)
     auto mission_item_int_ptr = std::make_shared<mavlink_mission_item_int_t>();
     mavlink_msg_mission_item_int_decode(&message, mission_item_int_ptr.get());
 
-    _mavlink_mission_items_downloaded.push_back(mission_item_int_ptr);
-
     if (mission_item_int_ptr->seq == _next_mission_item_to_download) {
         LogDebug() << "Received mission item " << _next_mission_item_to_download;
-    }
 
-    if (_next_mission_item_to_download + 1 == _num_mission_items_to_download) {
-        _parent->unregister_timeout_handler(_timeout_cookie);
+        _mavlink_mission_items_downloaded.push_back(mission_item_int_ptr);
+        _retries = 0;
 
-        mavlink_message_t ack_message;
-        mavlink_msg_mission_ack_pack(_parent->get_own_system_id(),
-                                     _parent->get_own_component_id(),
-                                     &ack_message,
-                                     _parent->get_target_system_id(),
-                                     _parent->get_target_component_id(),
-                                     MAV_MISSION_ACCEPTED,
-                                     MAV_MISSION_TYPE_MISSION);
+        if (_next_mission_item_to_download + 1 == _num_mission_items_to_download) {
 
-        _parent->send_message(ack_message);
+            // Wrap things up if we're finished.
+            _parent->unregister_timeout_handler(_timeout_cookie);
 
-        assemble_mission_items();
+            mavlink_message_t ack_message;
+            mavlink_msg_mission_ack_pack(_parent->get_own_system_id(),
+                                         _parent->get_own_component_id(),
+                                         &ack_message,
+                                         _parent->get_target_system_id(),
+                                         _parent->get_target_component_id(),
+                                         MAV_MISSION_ACCEPTED,
+                                         MAV_MISSION_TYPE_MISSION);
+
+            _parent->send_message(ack_message);
+
+            assemble_mission_items();
+
+        } else {
+            // Otherwise keep going.
+            ++_next_mission_item_to_download;
+            _parent->refresh_timeout_handler(_timeout_cookie);
+            download_next_mission_item();
+        }
 
     } else {
-        ++_next_mission_item_to_download;
+        LogDebug() << "Received mission item " << int(mission_item_int_ptr->seq)
+                   << " instead of " << _next_mission_item_to_download << " (ignored)";
+
+        // Refresh because we at least still seem to be active.
         _parent->refresh_timeout_handler(_timeout_cookie);
+
+        // And request it again in case our request got lost.
         download_next_mission_item();
+        return;
     }
+
 }
 
 void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<MissionItem>>
@@ -268,6 +288,11 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
         return;
     }
 
+    // We use the longer process timeout here because essentially the autopilot needs to pull
+    // the items up.
+    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                      PROCESS_TIMEOUT_S, &_timeout_cookie);
+
     _activity = Activity::SET_MISSION;
     _result_callback = callback;
 }
@@ -295,12 +320,14 @@ void MissionImpl::download_mission_async(const Mission::mission_items_and_result
         return;
     }
 
-    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this), 1.0,
-                                      &_timeout_cookie);
+    // We retry the list request and mission item request, so we use the lower timeout.
+    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                      RETRY_TIMEOUT_S, &_timeout_cookie);
 
     // Clear our internal cache and re-populate it.
     _mavlink_mission_items_downloaded.clear();
     _activity = Activity::GET_MISSION;
+    _retries = 0;
     _mission_items_and_result_callback = callback;
 }
 
@@ -875,10 +902,27 @@ void MissionImpl::process_timeout()
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
-    LogErr() << "Mission handling timed out.";
+    if (_activity == Activity::SET_MISSION) {
+        // We can't retry this, the autopilot should be requesting the items
+        // again.
+        _activity = Activity::NONE;
+        LogWarn() << "Mission handling timed out while uploading mission.";
 
-    if (_activity != Activity::NONE) {
-        report_mission_result(_result_callback, Mission::Result::TIMEOUT);
+    } else if (_activity == Activity::GET_MISSION) {
+        if (_retries++ > MAX_RETRIES) {
+            _activity = Activity::NONE;
+            _retries = 0;
+            LogWarn() << "Mission handling timed out while downloading mission.";
+            report_mission_result(_result_callback, Mission::Result::TIMEOUT);
+        } else {
+            LogWarn() << "Retrying requesting mission item...";
+            // We are retrying, so we use the lower timeout.
+            _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                              RETRY_TIMEOUT_S, &_timeout_cookie);
+            download_next_mission_item();
+        }
+    } else {
+        LogWarn() << "unknown mission timeout";
     }
 }
 

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -86,6 +86,9 @@ private:
         SEND_COMMAND
     } _activity = Activity::NONE;
 
+    unsigned _retries = 0;
+    static constexpr unsigned MAX_RETRIES = 3;
+
     int _last_current_mavlink_mission_item = -1;
     int _last_reached_mavlink_mission_item = -1;
 
@@ -109,6 +112,8 @@ private:
     int _next_mission_item_to_download = -1;
     std::vector<std::shared_ptr<mavlink_mission_item_int_t>> _mavlink_mission_items_downloaded {};
 
+    static constexpr double RETRY_TIMEOUT_S = 0.250;
+    static constexpr double PROCESS_TIMEOUT_S = 1.5;
     void *_timeout_cookie = nullptr;
 };
 


### PR DESCRIPTION
This fixes the case where a mission item gets lost from the autopilot to
DroneCore and we need to request the same one again.

Previously, we just requested the next one, essentially skipping the one
we missed. This then lead the autopilot to respond with a failure
because the wrong sequence was requested.

These fixes go together with:
mavlink/qgroundcontrol#6059
PX4/Firmware#8750