### PR TITLE
Improve Fly mission example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libs/tinyxml2"]
 	path = libs/tinyxml2
 	url = https://github.com/leethomason/tinyxml2.git
+[submodule "libs/json11"]
+	path = libs/json11
+	url = https://github.com/dropbox/json11

--- a/example/fly_mission/CMakeLists.txt
+++ b/example/fly_mission/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(fly_mission)
 
+include_directories(
+    ${CMAKE_SOURCE_DIR}/../../core
+    ${CMAKE_SOURCE_DIR}/../../libs/include
+    ${CMAKE_SOURCE_DIR}/../../libs/json11
+)
+
 if(NOT MSVC)
     add_definitions("-std=c++11 -Wall -Wextra -Werror")
 else()
@@ -10,10 +16,9 @@ else()
     link_directories(${CMAKE_SOURCE_DIR}/../../install/lib)
 endif()
 
-add_executable(fly_mission
-    fly_mission.cpp
-)
-
+add_library(json11 ${CMAKE_SOURCE_DIR}/../../libs/json11/json11.cpp)
+add_executable(fly_mission fly_mission.cpp )
 target_link_libraries(fly_mission
     dronecore
+    json11 # required for parsing QGC plan files
 )

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -1,20 +1,43 @@
-//
-// Example that demonstrates how add waypoint missions using DroneCore
-//
-// Author: Julian Oes <julian@oes.ch>, Shakthi Prashanth <shakthi.prashanth.m@intel.com>
-//
+/**
+* @file fly_mission.cpp
+*
+* @brief Demonstrates how add & fly waypoint missions from QGC plan using DroneCore.
+* The example is summarised below:
+* 1. Extracts mission items from QGroundControl mission plan (passed via command-line).
+* 2. Compose mission items; uploads them to vehicle via Mission plugin interface.
+* 3. Starts mission from first mission item.
+* 4. Exits after the mission is accomplished.
+* Note: Before you run this example, plan your missions in QGroundControl & save them to a file.
+*
+* @author Julian Oes <julian@oes.ch>,
+*         Shakthi Prashanth M <shakthi.prashanth.m@intel.com>
+
+* @date 2017-09-06
+*/
+
 
 #include <dronecore/dronecore.h>
 #include <iostream>
+#include <fstream> // for `std::ifstream`
+#include <sstream> // for `std::stringstream`
+#include <cstdlib>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <future>
-
+#include <json11.hpp> // for JSON parsing
+#include "mavlink_include.h" // for MAVLink commands
 
 using namespace dronecore;
 using namespace std::placeholders; // for `_1`
+using namespace std::this_thread; // for sleep_for()
+using namespace std::chrono; // for milliseconds(), seconds().
+using namespace json11;
 
-
+static std::vector<std::shared_ptr<MissionItem>> get_mission_items_from_QGC_plan(
+                                                  const std::string &qgc_plan_file);
+static std::vector<std::shared_ptr<MissionItem>> compose_mission_items_from_json(
+                                                  const Json &mission_json);
 static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                                      double longitude_deg,
                                                      float relative_altitude_m,
@@ -24,8 +47,13 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
                                                      float gimbal_yaw_deg,
                                                      MissionItem::CameraAction camera_action);
 
-int main(int /*argc*/, char ** /*argv*/)
+int main(int argc, char **argv)
 {
+    if (argc != 2) {
+        std::cerr << "Usage: fly_mission <path of QGC mission plan file>";
+        exit(EXIT_FAILURE);
+    }
+
     DroneCore dc;
 
     {
@@ -42,7 +70,7 @@ int main(int /*argc*/, char ** /*argv*/)
         if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
             std::cout << "Connection failed: " << DroneCore::connection_result_str(
                           connection_result) << std::endl;
-            return 1;
+            exit(EXIT_FAILURE);
         }
 
         future_result.get();
@@ -51,7 +79,7 @@ int main(int /*argc*/, char ** /*argv*/)
     dc.register_on_timeout([](uint64_t uuid) {
         std::cout << "Device with UUID timed out: " << uuid << std::endl;
         std::cout << "Exiting." << std::endl;
-        exit(0);
+        exit(EXIT_SUCCESS);
     });
 
     // We don't need to specifiy the UUID if it's only one device anyway.
@@ -61,54 +89,24 @@ int main(int /*argc*/, char ** /*argv*/)
 
     while (!device.telemetry().health_all_ok()) {
         std::cout << "Waiting for device to be ready" << std::endl;
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        sleep_for(seconds(1));
     }
-
     std::cout << "Device ready" << std::endl;
-    std::cout << "Creating and uploading mission" << std::endl;
 
     std::vector<std::shared_ptr<MissionItem>> mission_items;
+    try {
+        mission_items = get_mission_items_from_QGC_plan(argv[1]);
+    } catch (std::exception const &e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        abort();
+    }
 
-    mission_items.push_back(
-        add_mission_item(47.398170327054473,
-                         8.5456490218639658,
-                         10.0f, 5.0f, false,
-                         20.0f, 60.0f,
-                         MissionItem::CameraAction::NONE));
-
-    mission_items.push_back(
-        add_mission_item(47.398241338125118,
-                         8.5455360114574432,
-                         10.0f, 2.0f, true,
-                         0.0f, -60.0f,
-                         MissionItem::CameraAction::TAKE_PHOTO));
-
-    mission_items.push_back(
-        add_mission_item(47.398139363821485, 8.5453846156597137,
-                         10.0f, 5.0f, true,
-                         -45.0f, 0.0f,
-                         MissionItem::CameraAction::START_VIDEO));
-
-    mission_items.push_back(
-        add_mission_item(47.398058617228855,
-                         8.5454618036746979,
-                         10.0f, 2.0f, false,
-                         -90.0f, 30.0f,
-                         MissionItem::CameraAction::STOP_VIDEO));
-
-    mission_items.push_back(
-        add_mission_item(47.398100366082858,
-                         8.5456969141960144,
-                         10.0f, 5.0f, false,
-                         -45.0f, -30.0f,
-                         MissionItem::CameraAction::START_PHOTO_INTERVAL));
-
-    mission_items.push_back(
-        add_mission_item(47.398001890458097,
-                         8.5455576181411743,
-                         10.0f, 5.0f, false,
-                         0.0f, 0.0f,
-                         MissionItem::CameraAction::STOP_PHOTO_INTERVAL));
+    if (mission_items.size() == 0) {
+        std::cerr << "No missions! Exiting..." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    std::cout << "Found " << mission_items.size() << " mission items in the given QGC plan." <<
+              std::endl;
 
     {
         std::cout << "Uploading mission..." << std::endl;
@@ -124,7 +122,7 @@ int main(int /*argc*/, char ** /*argv*/)
         const Mission::Result result = future_result.get();
         if (result != Mission::Result::SUCCESS) {
             std::cout << "Mission upload failed (" << Mission::result_str(result) << "), exiting." << std::endl;
-            return 1;
+            exit(EXIT_FAILURE);
         }
         std::cout << "Mission uploaded." << std::endl;
     }
@@ -133,7 +131,7 @@ int main(int /*argc*/, char ** /*argv*/)
     const Action::Result arm_result = device.action().arm();
     if (arm_result != Action::Result::SUCCESS) {
         std::cout << "Arming failed (" << Action::result_str(arm_result) << "), exiting." << std::endl;
-        return 1;
+        exit(EXIT_FAILURE);
     }
 
     std::cout << "Armed." << std::endl;
@@ -164,12 +162,12 @@ int main(int /*argc*/, char ** /*argv*/)
         const Mission::Result result = future_result.get();
         if (result != Mission::Result::SUCCESS) {
             std::cout << "Mission start failed (" << Mission::result_str(result) << "), exiting." << std::endl;
-            return 1;
+            exit(EXIT_FAILURE);
         }
     }
 
     while (!want_to_pause) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        sleep_for(seconds(1));
     }
 
     {
@@ -191,7 +189,7 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     // Pause for 5 seconds.
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    sleep_for(seconds(5));
 
     // Then continue.
     {
@@ -213,7 +211,7 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     while (!device.mission().mission_finished()) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        sleep_for(seconds(1));
     }
 
     {
@@ -228,11 +226,11 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     // We need to wait a bit, otherwise the armed state might not be correct yet.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    sleep_for(seconds(2));
 
     while (device.telemetry().armed()) {
         // Wait until we're done.
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        sleep_for(seconds(1));
     }
     std::cout << "Disarmed, exiting." << std::endl;
 }
@@ -254,4 +252,100 @@ std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
     new_item->set_gimbal_pitch_and_yaw(gimbal_pitch_deg, gimbal_yaw_deg);
     new_item->set_camera_action(camera_action);
     return new_item;
+}
+
+std::vector<std::shared_ptr<MissionItem>> get_mission_items_from_QGC_plan(
+                                           const std::string &qgc_plan_file)
+{
+    std::vector<std::shared_ptr<MissionItem>> mission_items;
+    {
+        try {
+            std::ifstream file(qgc_plan_file);
+            if (!file.is_open()) {
+                throw std::runtime_error("Error opening QGC plan" + qgc_plan_file + "\n");
+            }
+
+            std::stringstream ss;
+            ss << file.rdbuf();
+            file.close();
+
+            std::string err;
+            const auto parsed_plan = Json::parse(ss.str(), err); // parse QGC plan
+            if (!err.empty()) {
+                // TODO Error handling
+                throw std::runtime_error("Error in loading waypoints from the file: " + qgc_plan_file);
+            }
+            mission_items = compose_mission_items_from_json(parsed_plan["mission"]);
+        } catch (std::exception const &e) {
+            std::cerr << e.what();
+            throw;
+        }
+        return mission_items;
+    }
+}
+
+std::vector<std::shared_ptr<MissionItem>> compose_mission_items_from_json(const Json &mission_json)
+{
+    std::vector<std::shared_ptr<MissionItem>> mission_items;
+    // NOTE: Unexpected type while reading values will cause an exception.
+    for (auto &mission_item : mission_json["items"].array_items()) {
+        // Parameters of Mission item & MAV command of it.
+        float speed_m_s = 0.f;
+        float gimbal_pitch_deg = 0.f, gimbal_yaw_deg = 0.f;
+        bool is_fly_through = false;
+        double lat_deg = NAN, lon_deg = NAN, rel_alt_deg = NAN;
+        size_t no_of_photos = 0;
+        auto camera_action = MissionItem::CameraAction::NONE;
+        auto command = mission_item["command"].int_value();
+
+        // Extract parameters
+        std::vector<double> params;
+        for (auto &p : mission_item["params"].array_items()) {
+            params.push_back(p.number_value());
+        }
+
+		// This looks bit complicated at app users.
+		// Should we handle them in plugin ?
+        switch (command) {
+            case MAV_CMD_IMAGE_START_CAPTURE:
+                no_of_photos = static_cast<size_t>(params[3]);
+                if (no_of_photos > 1) {
+                    camera_action = MissionItem::CameraAction::START_PHOTO_INTERVAL;
+                } else if (no_of_photos == 1) {
+                    camera_action = MissionItem::CameraAction::TAKE_PHOTO;
+                }
+                break;
+            case MAV_CMD_VIDEO_START_STREAMING:
+                camera_action = MissionItem::CameraAction::START_VIDEO;
+                break;
+            case MAV_CMD_VIDEO_STOP_STREAMING:
+                camera_action = MissionItem::CameraAction::START_VIDEO;
+                break;
+            case MAV_CMD_DO_CHANGE_SPEED:
+                speed_m_s = params[2];
+                break;
+            case MAV_CMD_DO_MOUNT_CONTROL:
+                // Possible bug in QGroundcontrol. It stores -ve values for pitch in deg.
+                gimbal_pitch_deg = -params[0];
+                gimbal_yaw_deg = params[3];
+                break;
+            case MAV_CMD_NAV_WAYPOINT:
+                is_fly_through = (params[0] == 0.0) ? true : false;
+            case MAV_CMD_NAV_TAKEOFF:
+                lat_deg = params[4];
+                lon_deg = params[5];
+                rel_alt_deg = params[6];
+                break;
+        }
+        // Add a mission item
+        mission_items.push_back(add_mission_item(lat_deg,
+                                                 lon_deg,
+                                                 rel_alt_deg,
+                                                 speed_m_s,
+                                                 is_fly_through,
+                                                 gimbal_pitch_deg,
+                                                 gimbal_yaw_deg,
+                                                 camera_action));
+    }
+    return mission_items;
 }

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -50,7 +50,7 @@ static std::shared_ptr<MissionItem> add_mission_item(double latitude_deg,
 int main(int argc, char **argv)
 {
     if (argc != 2) {
-        std::cerr << "Usage: fly_mission <path of QGC mission plan file>";
+        std::cerr << "Usage: fly_mission <path of QGC mission plan file>" << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -304,8 +304,8 @@ std::vector<std::shared_ptr<MissionItem>> compose_mission_items_from_json(const 
             params.push_back(p.number_value());
         }
 
-		// This looks bit complicated at app users.
-		// Should we handle them in plugin ?
+        // This looks bit complicated at app users.
+        // Should we handle them in plugin ?
         switch (command) {
             case MAV_CMD_IMAGE_START_CAPTURE:
                 no_of_photos = static_cast<size_t>(params[3]);


### PR DESCRIPTION
This is to improve Fly mission example based on issue #121.
Highlights:

- Adds [json11](https://github.com/dropbox/json11) as a submodule for parsing JSON files

- Example now handles waypoint missions fed from QGC plan (via command line arguments)

**Open question**: I feel the application code has more job to do. Can we provide an interface at Mission plugin ?
