### PR TITLE
Fix `generate_doc.sh` issue (#236)

### DIFF
--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -23,7 +23,7 @@ install_prefix="$source_dir/install"
 
 if [ "$skip_checks" = false ]; then
     # Clean-up build & install directory
-    if [ -e $source_dir/build/ ] || [ -e $install_prefix ] ; then
+    if [ "$(ls $source_dir/build/default)" ] || [ -e $install_prefix ] ; then
 	printf "Clean-up your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
 	exit 1
     fi

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -23,7 +23,7 @@ install_prefix="$source_dir/install"
 
 if [ "$skip_checks" = false ]; then
     # Clean-up build & install directory
-    if [ "$(ls $source_dir/build/default)" ] || [ -e $install_prefix ] ; then
+    if [ -d $source_dir/build ] && [ "$(ls $source_dir/build/default)" ] || [ -d $install_prefix ] ; then
 	printf "Clean-up your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
 	exit 1
     fi

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -23,8 +23,8 @@ install_prefix="$source_dir/install"
 
 if [ "$skip_checks" = false ]; then
     # Clean-up build & install directory
-    if [ -d $source_dir/build ] && [ "$(ls $source_dir/build/default)" ] || [ -d $install_prefix ] ; then
-	printf "Clean-up your build & install directory using below command.\nmake clean && rm -rf $install_prefix\n"
+    if [ -d $source_dir/build ] || [ -d $install_prefix ] ; then
+	printf "Clean-up your build & install directory using below command.\nmake distclean && rm -rf $install_prefix\n"
 	exit 1
     fi
 fi


### PR DESCRIPTION
Script [genreate_docs.sh](https://github.com/dronecore/DroneCore/blob/904ba588f554562672e79ea9dcc9449096219d47/generate_docs.sh#L26) is looking for build directory existence; but it should actually check `build/default` directory's contents.
After `make clean`, contents of directory `build/default` will be empty.
So, this PR checks whether `build/default` is empty.
#236 