### PR TITLE
Fix up plugin constructor docs

### DIFF
--- a/generate_markdown_from_doxygen_xml.py
+++ b/generate_markdown_from_doxygen_xml.py
@@ -113,7 +113,7 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
             if aTag.tag=='computeroutput':
                 ignore_current_tag=True #Ignore computer output markup in links
             child_text += markdown_any_tag(child,html=html,para=para)
-        elif child.tag=='computeroutput' or child.tag=='para' or child.tag=='listitem' or child.tag=='ulink' or child.tag=='bold' or child.tag=='emphasis':
+        elif child.tag=='computeroutput' or child.tag=='para' or child.tag=='listitem' or child.tag=='ulink' or child.tag=='bold' or child.tag=='emphasis' or child.tag=='verbatim':
             child_text += markdown_any_tag(child,html=html,para=para) #.strip()
         elif child.tag=='itemizedlist':
             child_text += markdown_any_tag(child,html=True,para=para)
@@ -232,6 +232,9 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
             # Note we should ONLY see this via the detaileddescription handling 
             # Because children that are simplesect are not parsed.
             tag_text=lead_text+child_text+tail_text
+
+    elif aTag.tag=='verbatim':
+        tag_text='\n\n'+lead_text+child_text+'\n\n'+tail_text
 
 
     else:

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -25,7 +25,7 @@ class Action : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -33,9 +33,7 @@ public:
      *     auto action = std::make_shared<Action>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Action(Device *device);
 

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -25,9 +25,17 @@ class Action : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
      *
-     * @param impl Private internal implementation.
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto action = std::make_shared<Action>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Action(Device *device);
 

--- a/plugins/follow_me/follow_me.h
+++ b/plugins/follow_me/follow_me.h
@@ -24,8 +24,17 @@ class FollowMe : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
-     * @param impl Private internal implementation.
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto follow_me = std::make_shared<FollowMe>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit FollowMe(Device *device);
 

--- a/plugins/follow_me/follow_me.h
+++ b/plugins/follow_me/follow_me.h
@@ -24,7 +24,7 @@ class FollowMe : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -32,9 +32,7 @@ public:
      *     auto follow_me = std::make_shared<FollowMe>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit FollowMe(Device *device);
 

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -17,9 +17,17 @@ class Gimbal : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
      *
-     * @param impl Private internal implementation.
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto gimbal = std::make_shared<Gimbal>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Gimbal(Device *device);
 

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -17,7 +17,7 @@ class Gimbal : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -25,9 +25,7 @@ public:
      *     auto gimbal = std::make_shared<Gimbal>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Gimbal(Device *device);
 

--- a/plugins/info/info.h
+++ b/plugins/info/info.h
@@ -15,7 +15,7 @@ class Info : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -23,9 +23,7 @@ public:
      *     auto info = std::make_shared<Info>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Info(Device *device);
 

--- a/plugins/info/info.h
+++ b/plugins/info/info.h
@@ -15,7 +15,17 @@ class Info : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto info = std::make_shared<Info>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Info(Device *device);
 

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -17,7 +17,17 @@ class Logging : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto logger = std::make_shared<Logging>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Logging(Device *device);
 

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -17,17 +17,15 @@ class Logging : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto logger = std::make_shared<Logging>(&device);
+     *     auto logging = std::make_shared<Logging>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Logging(Device *device);
 

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -18,7 +18,7 @@ class Mission : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -26,9 +26,7 @@ public:
      *     auto mission = std::make_shared<Mission>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Mission(Device *device);
 

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -18,7 +18,17 @@ class Mission : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto mission = std::make_shared<Mission>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Mission(Device *device);
 

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -27,7 +27,17 @@ class Offboard : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto offboard = std::make_shared<Offboard>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Offboard(Device *device);
 

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -27,7 +27,7 @@ class Offboard : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -35,9 +35,7 @@ public:
      *     auto offboard = std::make_shared<Offboard>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Offboard(Device *device);
 

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -16,7 +16,17 @@ class Telemetry : public PluginBase
 {
 public:
     /**
-     * @brief Constructor (internal use only).
+     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto telemetry = std::make_shared<Telemetry>(&device);
+     *     ```
+     *
+     * The plugin is owned by the device (and will be destroyed along with it).
+     *
+     * @param device The device associated with this plugin.
      */
     explicit Telemetry(Device *device);
 

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -16,7 +16,7 @@ class Telemetry : public PluginBase
 {
 public:
     /**
-     * @brief Constructor. Creates the plugin and associates it with a specified Device.
+     * @brief Constructor. Creates the plugin for a specific Device.
      *
      * The plugin is typically created as shown below:
      *
@@ -24,9 +24,7 @@ public:
      *     auto telemetry = std::make_shared<Telemetry>(&device);
      *     ```
      *
-     * The plugin is owned by the device (and will be destroyed along with it).
-     *
-     * @param device The device associated with this plugin.
+     * @param device The specific device associated with this plugin.
      */
     explicit Telemetry(Device *device);
 


### PR DESCRIPTION
Constructors are no longer "for internal use". This change also adds support for verbatim tag in the source, which allows us to specify arbitrary markdown (used in this doc change).