### PR TITLE
Makefile: fix make clean after make android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ distclean:
 	@rm -rf logs/
 
 clean:
-	@if [ -d build ]; then find build -mindepth 2 -path "build/*/external" -prune -o -exec rm -rf {} +; fi
+	@if [ -d build ]; then find build -mindepth 2 -delete -path "build/*/third_party"; fi
 
 android_env_check:
 ifndef ANDROID_TOOLCHAIN_CMAKE


### PR DESCRIPTION
- external is now third_party
- the argument -delete prevents "Files not found" while deleting without
  the -depth option