### PR TITLE
Fix linker error and lower Boost version in Follow Me example

### DIFF
--- a/example/follow_me/CMakeLists.txt
+++ b/example/follow_me/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(follow_me)
 
-find_package(Boost 1.66 COMPONENTS REQUIRED system)
+find_package(Boost 1.58 COMPONENTS REQUIRED system)
 include_directories(${Boost_INCLUDE_DIR})
 
 if(NOT MSVC)
@@ -23,5 +23,6 @@ target_link_libraries(follow_me
     dronecore
     dronecore_action
     dronecore_follow_me
+    dronecore_telemetry
     pthread
 )

--- a/example/follow_me/fake_location_provider.h
+++ b/example/follow_me/fake_location_provider.h
@@ -23,7 +23,7 @@ class FakeLocationProvider
 public:
     typedef std::function<void(double lat, double lon)> location_callback_t;
 
-    FakeLocationProvider(boost::asio::io_context &io)
+    FakeLocationProvider(boost::asio::io_service &io)
         : timer_(io, boost::posix_time::seconds(1))
     {}
 

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -90,7 +90,7 @@ int main(int, char **)
     follow_me_result = follow_me->start();
     follow_me_error_exit(follow_me_result, "Failed to start FollowMe mode");
 
-    boost::asio::io_context io; // for event loop
+    boost::asio::io_service io; // for event loop
     std::unique_ptr<FakeLocationProvider> location_provider(new FakeLocationProvider(io));
     // Register for platform-specific Location provider. We're using FakeLocationProvider for the example.
     location_provider->request_location_updates([&device, &follow_me](double lat, double lon) {


### PR DESCRIPTION
- [X] Fix linker error occurred during flexible plugin arch changes.
- [X] Lower Boost dependency version from `1.66` to `1.58` to match on Ubuntu 16.

Related: ([dronecore/docs/#94](https://github.com/dronecore/docs/pull/94))