### PR TITLE
Add Doxygen tag "\code" to include code block in plugins

### DIFF
--- a/generate_markdown_from_doxygen_xml.py
+++ b/generate_markdown_from_doxygen_xml.py
@@ -113,7 +113,7 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
             if aTag.tag=='computeroutput':
                 ignore_current_tag=True #Ignore computer output markup in links
             child_text += markdown_any_tag(child,html=html,para=para)
-        elif child.tag=='computeroutput' or child.tag=='para' or child.tag=='listitem' or child.tag=='ulink' or child.tag=='bold' or child.tag=='emphasis' or child.tag=='verbatim':
+        elif child.tag=='computeroutput' or child.tag=='para' or child.tag=='listitem' or child.tag=='ulink' or child.tag=='bold' or child.tag=='emphasis' or child.tag=='verbatim' or child.tag=='programlisting' or child.tag=='codeline' or child.tag=='highlight' or child.tag=='sp':
             child_text += markdown_any_tag(child,html=html,para=para) #.strip()
         elif child.tag=='itemizedlist':
             child_text += markdown_any_tag(child,html=True,para=para)
@@ -166,6 +166,27 @@ def markdown_any_tag(aTag, html=False,para=True,consume=False):
             tag_text='\n<li>'+lead_text+child_text+'</li>'+tail_text
         else:
             tag_text='\n* '+lead_text+child_text+tail_text #single level implementation.
+    elif aTag.tag=='programlisting':
+        if html:
+            tag_text='\n<code>'+lead_text+child_text+'</code>'+tail_text
+        else:
+            tag_text='\n```cpp'+lead_text+child_text+'\n```\n' + tail_text #single level implementation.
+    elif aTag.tag=='codeline':
+        if html:
+            tag_text='\n<br>'+lead_text+child_text+tail_text
+        else:
+            tag_text='\n'+lead_text+child_text+tail_text.strip() #single level implementation.
+    elif aTag.tag=='highlight':
+        if html:
+            tag_text='<em>'+lead_text+child_text+'</em>'+tail_text
+        else:
+            tag_text= lead_text+child_text+tail_text #single level implementation.
+    elif aTag.tag=='sp':
+        if html:
+            tag_text='<!-- sp- ->' + lead_text+child_text+tail_text
+        else:
+            tag_text= ' ' + lead_text+child_text+tail_text #single level implementation.
+
     elif aTag.tag=='ref':
         #Internal link tag handling.
         kind_ref=aTag.attrib['kindref']

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -29,9 +29,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto action = std::make_shared<Action>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/follow_me/follow_me.h
+++ b/plugins/follow_me/follow_me.h
@@ -28,9 +28,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto follow_me = std::make_shared<FollowMe>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -21,9 +21,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto gimbal = std::make_shared<Gimbal>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/info/info.h
+++ b/plugins/info/info.h
@@ -19,9 +19,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto info = std::make_shared<Info>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -21,9 +21,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto logging = std::make_shared<Logging>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -22,9 +22,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto mission = std::make_shared<Mission>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -31,9 +31,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto offboard = std::make_shared<Offboard>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -20,9 +20,9 @@ public:
      *
      * The plugin is typically created as shown below:
      *
-     *     ```cpp
+     *     \code{cpp}
      *     auto telemetry = std::make_shared<Telemetry>(&device);
-     *     ```
+     *     \endcode
      *
      * @param device The specific device associated with this plugin.
      */


### PR DESCRIPTION
Currently plugin docs use [```cpp](https://github.com/dronecore/DroneCore/blob/develop/plugins/action/action.h#L32) to include code blocks that show plugin class usage.
But Doxygen tag [\code](http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdcode) is meant for the same purpose. So, replacing with it.