### PR TITLE
build_system: create a static lib for Mac for now

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
     SYSTEM ${CMAKE_SOURCE_DIR}/third_party/mavlink/include
 )
 
-if(IOS OR MSVC)
+if(IOS OR MSVC OR APPLE)
     set(LIBRARY_TYPE "STATIC")
 else()
     set(LIBRARY_TYPE "SHARED")


### PR DESCRIPTION
This should resolve linking issues with examples. Once we have it all
packaged, we can change it again.

Fixes #233.