### PR TITLE
Refactor dronecore server

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -384,7 +384,7 @@ void Device::set_disconnected()
         _parent->notify_on_timeout(_target_uuid);
 
         // Let's reset the flag hope again for the next time we see this target.
-        _target_uuid_initialized = 0;
+        _target_uuid_initialized = false;
     }
 
     {

--- a/grpc/server/src/CMakeLists.txt
+++ b/grpc/server/src/CMakeLists.txt
@@ -1,67 +1,33 @@
 cmake_minimum_required(VERSION 2.8)
 
-file(STRINGS ${PLUGINS_DIR}/plugins.conf PLUGINS_LIST)
+set(COMPONENTS_LIST core action mission telemetry)
 
-set(PROTOC_BINARY ${CMAKE_BINARY_DIR}/../default/third_party/protobuf/bin/protoc)
-set(GRPC_CPP_PLUGIN_BINARY ${CMAKE_BINARY_DIR}/../default/third_party/grpc/bin/grpc_cpp_plugin)
+include(cmake/compile_proto.cmake)
 
-if(NOT EXISTS ${PROTOC_BINARY} OR NOT EXISTS ${GRPC_CPP_PLUGIN_BINARY})
-    message(FATAL_ERROR "Could not find 'protoc' or 'grpc_cpp_plugin' in the 'default' build folder. Please build for your host first (`make BUILD_DRONECORESERVER=YES default`).")
-endif()
+foreach(COMPONENT_NAME ${COMPONENTS_LIST})
+    compile_proto_pb(${COMPONENT_NAME} PB_COMPILED_SOURCE)
+    list(APPEND PB_COMPILED_SOURCES ${PB_COMPILED_SOURCE})
 
-add_custom_command(OUTPUT core/core.grpc.pb.cc
-    COMMAND ${PROTOC_BINARY}
-        -I ${PROTO_DIR}
-        --grpc_out=.
-        --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_BINARY}
-        ${PROTO_DIR}/core/core.proto;
-)
-
-add_custom_command(OUTPUT core/core.pb.cc
-    COMMAND ${PROTOC_BINARY}
-        -I ${PROTO_DIR}
-        --cpp_out=.
-        ${PROTO_DIR}/core/core.proto
-)
-
-foreach(PLUGIN ${PLUGINS_LIST})
-    add_custom_command(OUTPUT ${PLUGIN}/${PLUGIN}.grpc.pb.cc
-        COMMAND ${PROTOC_BINARY}
-            -I ${PROTO_DIR}
-            --grpc_out=.
-            --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_BINARY}
-            --cpp_out=.
-            ${PROTO_DIR}/${PLUGIN}/${PLUGIN}.proto
-    )
+    compile_proto_grpc(${COMPONENT_NAME} GRPC_COMPILED_SOURCE)
+    list(APPEND GRPC_COMPILED_SOURCES ${GRPC_COMPILED_SOURCE})
 endforeach()
 
-foreach(PLUGIN ${PLUGINS_LIST})
-    add_custom_command(OUTPUT ${PLUGIN}/${PLUGIN}.pb.cc
-        COMMAND ${PROTOC_BINARY}
-            -I ${PROTO_DIR}
-            --cpp_out=.
-            ${PROTO_DIR}/${PLUGIN}/${PLUGIN}.proto
-    )
-endforeach()
-
-set(PLUGINS_SRC dronecore_server.cpp core/core.pb.cc core/core.grpc.pb.cc)
-foreach(PLUGIN ${PLUGINS_LIST})
-    list(APPEND PLUGINS_SRC ${PLUGIN}/${PLUGIN}.pb.cc)
-    list(APPEND PLUGINS_SRC ${PLUGIN}/${PLUGIN}.grpc.pb.cc)
-endforeach()
-
-add_executable(dronecore_server ${PLUGINS_SRC})
-
-target_compile_options(
-    dronecore_server
-    PUBLIC
-    -Wno-unused-parameter
-    -Wno-shadow
+add_library(backend
+    backend.cpp
+    ${GRPC_COMPILED_SOURCES}
+    ${PB_COMPILED_SOURCES}
 )
 
-target_include_directories(
-    dronecore_server
-    PUBLIC
+target_link_libraries(backend
+    dronecore
+    dronecore_action
+    dronecore_mission
+    dronecore_telemetry
+    gRPC::grpc++
+)
+
+target_include_directories(backend
+    PRIVATE
     ${CMAKE_SOURCE_DIR}/core
     ${CMAKE_SOURCE_DIR}/plugins/action
     ${CMAKE_SOURCE_DIR}/plugins/mission
@@ -70,12 +36,16 @@ target_include_directories(
     ${PLUGINS_DIR}
 )
 
-target_link_libraries(
-    dronecore_server
+add_executable(backend_bin
+    dronecore_server.cpp
+)
+
+target_link_libraries(backend_bin
+    backend
     dronecore
-    dronecore_action
-    dronecore_mission
-    dronecore_telemetry
-    gRPC::grpc++
-    dl
+)
+
+target_include_directories(backend_bin
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/core
 )

--- a/grpc/server/src/backend.cpp
+++ b/grpc/server/src/backend.cpp
@@ -1,0 +1,106 @@
+#include "backend.h"
+
+#include <grpc/grpc.h>
+#include <grpc++/server.h>
+#include <grpc++/server_builder.h>
+#include <grpc++/server_context.h>
+#include <grpc++/security/server_credentials.h>
+
+#include "action/actionrpc_impl.h"
+#include "core/corerpc_impl.h"
+#include "log.h"
+#include "mission/missionrpc_impl.h"
+#include "telemetry/telemetryrpc_impl.h"
+
+namespace dronecore::backend {
+
+bool DroneCoreBackend::run(const int mavlink_listen_port)
+{
+    if (!connect_to_vehicle(mavlink_listen_port)) {
+        return false;
+    }
+
+    grpc::ServerBuilder builder;
+    setup_port(builder);
+
+    CoreServiceImpl core(dc);
+    builder.RegisterService(&core);
+
+    Action action(&dc.device());
+    ActionServiceImpl actionService(action);
+    builder.RegisterService(&actionService);
+
+    Mission mission(&dc.device());
+    MissionServiceImpl missionService(mission);
+    builder.RegisterService(&missionService);
+
+    Telemetry telemetry(&dc.device());
+    TelemetryServiceImpl telemetryService(telemetry);
+    builder.RegisterService(&telemetryService);
+
+    server = builder.BuildAndStart();
+    LogInfo() << "Server started";
+    server->Wait();
+
+    return true;
+}
+
+bool DroneCoreBackend::connect_to_vehicle(const int port)
+{
+    if (!add_udp_connection(port)) {
+        return false;
+    }
+
+    log_uuid_on_timeout();
+    wait_for_discovery();
+
+    return true;
+}
+
+bool DroneCoreBackend::add_udp_connection(const int port)
+{
+    dronecore::DroneCore::ConnectionResult connection_result = dc.add_udp_connection(port);
+
+    if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
+        LogErr() << "Connection failed: " << DroneCore::connection_result_str(connection_result);
+        return false;
+    }
+
+    return true;
+}
+
+void DroneCoreBackend::log_uuid_on_timeout()
+{
+    dc.register_on_timeout([](uint64_t uuid) {
+        LogInfo() << "Device timed out [UUID: " << uuid << "]";
+    });
+}
+
+void DroneCoreBackend::wait_for_discovery()
+{
+    LogInfo() << "Waiting to discover device...";
+    auto discoveryFuture = wrapped_register_on_discover();
+    discoveryFuture.wait();
+    LogInfo() << "Device discovered [UUID: " << discoveryFuture.get() << "]";
+}
+
+std::future<uint64_t> DroneCoreBackend::wrapped_register_on_discover()
+{
+    auto promise = std::make_shared<std::promise<uint64_t>>();
+    auto future = promise->get_future();
+
+    dc.register_on_discover([promise](uint64_t uuid) {
+        promise->set_value(uuid);
+    });
+
+    return future;
+}
+
+void DroneCoreBackend::setup_port(grpc::ServerBuilder &builder)
+{
+    std::string server_address("0.0.0.0:50051");
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    LogInfo() << "Server set to listen on " << server_address;
+}
+
+} //namespace dronecore::backend

--- a/grpc/server/src/backend.h
+++ b/grpc/server/src/backend.h
@@ -1,0 +1,31 @@
+#include <future>
+#include <grpc++/server.h>
+#include <memory>
+
+#include "dronecore.h"
+
+namespace dronecore::backend {
+
+class DroneCoreBackend
+{
+public:
+    DroneCoreBackend() {}
+    ~DroneCoreBackend() {}
+
+    bool run(const int mavlink_listen_port = 14540);
+
+private:
+    bool connect_to_vehicle(int port);
+    bool add_udp_connection(int port);
+    void log_uuid_on_timeout();
+    void wait_for_discovery();
+    std::future<uint64_t> wrapped_register_on_discover();
+
+    bool run_server();
+    void setup_port(grpc::ServerBuilder &builder);
+
+    dronecore::DroneCore dc;
+    std::unique_ptr<grpc::Server> server;
+};
+
+} // namespace dronecore::backend

--- a/grpc/server/src/cmake/compile_proto.cmake
+++ b/grpc/server/src/cmake/compile_proto.cmake
@@ -1,0 +1,30 @@
+set(PROTOC_BINARY ${CMAKE_BINARY_DIR}/../default/third_party/protobuf/bin/protoc)
+set(GRPC_CPP_PLUGIN_BINARY ${CMAKE_BINARY_DIR}/../default/third_party/grpc/bin/grpc_cpp_plugin)
+
+if(NOT EXISTS ${PROTOC_BINARY} OR NOT EXISTS ${GRPC_CPP_PLUGIN_BINARY})
+    message(FATAL_ERROR "Could not find 'protoc' or 'grpc_cpp_plugin' in the 'default' build folder. Please build for your host first (`make BUILD_DRONECORESERVER=YES default`).")
+endif()
+
+function(compile_proto_pb COMPONENT_NAME PB_COMPILED_SOURCE)
+    add_custom_command(OUTPUT ${COMPONENT_NAME}/${COMPONENT_NAME}.pb.cc
+        COMMAND ${PROTOC_BINARY}
+            -I ${PROTO_DIR}
+            --cpp_out=.
+            ${PROTO_DIR}/${COMPONENT_NAME}/${COMPONENT_NAME}.proto
+    )
+
+    set(PB_COMPILED_SOURCE ${COMPONENT_NAME}/${COMPONENT_NAME}.pb.cc PARENT_SCOPE)
+endfunction()
+
+function(compile_proto_grpc COMPONENT_NAME GRPC_COMPILED_SOURCES)
+    add_custom_command(OUTPUT ${COMPONENT_NAME}/${COMPONENT_NAME}.grpc.pb.cc
+        COMMAND ${PROTOC_BINARY}
+            -I ${PROTO_DIR}
+            --grpc_out=.
+            --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_BINARY}
+            --cpp_out=.
+            ${PROTO_DIR}/${COMPONENT_NAME}/${COMPONENT_NAME}.proto
+    )
+
+    set(GRPC_COMPILED_SOURCE ${COMPONENT_NAME}/${COMPONENT_NAME}.grpc.pb.cc PARENT_SCOPE)
+endfunction()

--- a/grpc/server/src/core/corerpc_impl.h
+++ b/grpc/server/src/core/corerpc_impl.h
@@ -9,18 +9,16 @@ using namespace dronecore;
 class CoreServiceImpl final: public rpc::core::CoreService::Service
 {
 public:
-    CoreServiceImpl(DroneCore *dc_obj)
-    {
-        dc = dc_obj;
-    }
+    CoreServiceImpl(DroneCore &dc)
+        : dc(dc) {}
 
     Status SubscribeDevices(ServerContext *context,
                             const rpc::core::SubscribeDevicesRequest *request,
                             ServerWriter<rpc::core::Device> *writer) override
     {
-        std::vector<uint64_t> list = dc->device_uuids();
+        std::vector<uint64_t> list = dc.device_uuids();
 
-        for (auto uuid : dc->device_uuids()) {
+        for (auto uuid : dc.device_uuids()) {
             auto *rpc_uuid = new rpc::core::UUID();
             rpc_uuid->set_value(uuid);
 
@@ -34,5 +32,5 @@ public:
     }
 
 private:
-    DroneCore *dc;
+    DroneCore &dc;
 };

--- a/grpc/server/src/dronecore_server.cpp
+++ b/grpc/server/src/dronecore_server.cpp
@@ -33,34 +33,30 @@ static DroneCore dc;
 
 template<typename T> ::grpc::Service *createInstances(DroneCore *dc_obj) { return new T(dc_obj); }
 
-void RunServer()
+int RunServer()
 {
-    std::string server_address("0.0.0.0:50051");
-    CoreServiceImpl service(&dc);
-
-    int discovered_device = 0;
     DroneCore::ConnectionResult connection_result = dc.add_udp_connection(14540);
+
     if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
         LogErr() << "Connection failed: " << DroneCore::connection_result_str(connection_result);
-        return;
+        return 1;
     }
+
     LogInfo() << "Waiting to discover device...";
-    dc.register_on_discover([&discovered_device](uint64_t uuid) {
-        LogInfo() << "Discovered device with UUID: " << uuid;
-        discovered_device += 1;
+    dc.register_on_discover([](uint64_t uuid) {
+        LogInfo() << "Device discovered [UUID: " << uuid << "]";
+    });
+    dc.register_on_timeout([](uint64_t uuid) {
+        LogInfo() << "Device timed out [UUID: " << uuid << "]";
     });
 
-    // We usually receive heartbeats at 1Hz, therefore we should find a device after around 2 seconds.
-    std::this_thread::sleep_for(std::chrono::seconds(10));
-    if (discovered_device == 0) {
-        LogErr() << "No device found, exiting.";
-        return;
-    }
+    std::string server_address("0.0.0.0:50051");
 
     ServerBuilder builder;
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-    builder.RegisterService(&service);
 
+    CoreServiceImpl service(&dc);
+    builder.RegisterService(&service);
     builder.RegisterService(createInstances<ActionServiceImpl>(&dc));
     builder.RegisterService(createInstances<TelemetryServiceImpl>(&dc));
     builder.RegisterService(createInstances<MissionServiceImpl>(&dc));
@@ -72,6 +68,5 @@ void RunServer()
 
 int main(int argc, char **argv)
 {
-    RunServer();
-    return 0;
+    return RunServer();
 }

--- a/grpc/server/src/dronecore_server.cpp
+++ b/grpc/server/src/dronecore_server.cpp
@@ -61,7 +61,7 @@ void RunServer()
     }
 
     int discovered_device = 0;
-    DroneCore::ConnectionResult connection_result = dc.add_udp_connection(14550);
+    DroneCore::ConnectionResult connection_result = dc.add_udp_connection(14540);
     if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
         LogErr() << "Connection failed: " << DroneCore::connection_result_str(connection_result);
         return;

--- a/grpc/server/src/dronecore_server.cpp
+++ b/grpc/server/src/dronecore_server.cpp
@@ -33,32 +33,10 @@ static DroneCore dc;
 
 template<typename T> ::grpc::Service *createInstances(DroneCore *dc_obj) { return new T(dc_obj); }
 
-typedef std::map<std::string, ::grpc::Service*(*)(DroneCore *dc_obj)> map_type;
-
 void RunServer()
 {
     std::string server_address("0.0.0.0:50051");
     CoreServiceImpl service(&dc);
-
-    map_type map;
-    std::string plugin;
-    std::fstream file;
-    file.open("grpc/server/src/plugins/plugins.conf");
-
-    if (!file) {
-        LogErr() << "Error in reading conf file";
-        return;
-    }
-
-    std::vector<::grpc::Service *> list;
-    map["action"] = &createInstances<ActionServiceImpl>;
-    map["telemetry"] = &createInstances<TelemetryServiceImpl>;
-    map["mission"] = &createInstances<MissionServiceImpl>;
-
-    while (file >> plugin) {
-        auto service_obj = map[plugin](&dc);
-        list.push_back(service_obj);
-    }
 
     int discovered_device = 0;
     DroneCore::ConnectionResult connection_result = dc.add_udp_connection(14540);
@@ -71,6 +49,7 @@ void RunServer()
         LogInfo() << "Discovered device with UUID: " << uuid;
         discovered_device += 1;
     });
+
     // We usually receive heartbeats at 1Hz, therefore we should find a device after around 2 seconds.
     std::this_thread::sleep_for(std::chrono::seconds(10));
     if (discovered_device == 0) {
@@ -81,9 +60,11 @@ void RunServer()
     ServerBuilder builder;
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
     builder.RegisterService(&service);
-    for (auto plugin_service : list) {
-        builder.RegisterService(plugin_service);
-    }
+
+    builder.RegisterService(createInstances<ActionServiceImpl>(&dc));
+    builder.RegisterService(createInstances<TelemetryServiceImpl>(&dc));
+    builder.RegisterService(createInstances<MissionServiceImpl>(&dc));
+
     std::unique_ptr<Server> server(builder.BuildAndStart());
     LogInfo() << "Server listening on " << server_address;
     server->Wait();

--- a/grpc/server/src/dronecore_server.cpp
+++ b/grpc/server/src/dronecore_server.cpp
@@ -1,72 +1,12 @@
-#include <iostream>
-#include <fstream>
-#include <thread>
-#include <chrono>
-#include <cstdint>
-#include <future>
-
-#include <grpc/grpc.h>
-#include <grpc++/server.h>
-#include <grpc++/server_builder.h>
-#include <grpc++/server_context.h>
-#include <grpc++/security/server_credentials.h>
-
-#include "dronecore.h"
-#include "log.h"
-#include "action/actionrpc_impl.h"
-#include "core/core.grpc.pb.h"
-#include "core/corerpc_impl.h"
-#include "mission/missionrpc_impl.h"
-#include "telemetry/telemetryrpc_impl.h"
-
-using grpc::Server;
-using grpc::ServerBuilder;
-using grpc::ServerContext;
-using grpc::ServerReader;
-using grpc::ServerReaderWriter;
-using grpc::Status;
-
-using namespace dronecore;
-using namespace std::placeholders;
-
-static DroneCore dc;
-
-template<typename T> ::grpc::Service *createInstances(DroneCore *dc_obj) { return new T(dc_obj); }
-
-int RunServer()
-{
-    DroneCore::ConnectionResult connection_result = dc.add_udp_connection(14540);
-
-    if (connection_result != DroneCore::ConnectionResult::SUCCESS) {
-        LogErr() << "Connection failed: " << DroneCore::connection_result_str(connection_result);
-        return 1;
-    }
-
-    LogInfo() << "Waiting to discover device...";
-    dc.register_on_discover([](uint64_t uuid) {
-        LogInfo() << "Device discovered [UUID: " << uuid << "]";
-    });
-    dc.register_on_timeout([](uint64_t uuid) {
-        LogInfo() << "Device timed out [UUID: " << uuid << "]";
-    });
-
-    std::string server_address("0.0.0.0:50051");
-
-    ServerBuilder builder;
-    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-
-    CoreServiceImpl service(&dc);
-    builder.RegisterService(&service);
-    builder.RegisterService(createInstances<ActionServiceImpl>(&dc));
-    builder.RegisterService(createInstances<TelemetryServiceImpl>(&dc));
-    builder.RegisterService(createInstances<MissionServiceImpl>(&dc));
-
-    std::unique_ptr<Server> server(builder.BuildAndStart());
-    LogInfo() << "Server listening on " << server_address;
-    server->Wait();
-}
+#include "backend.h"
 
 int main(int argc, char **argv)
 {
-    return RunServer();
+    dronecore::backend::DroneCoreBackend backend;
+
+    if (!backend.run()) {
+        return 1;
+    } else {
+        return 0;
+    }
 }

--- a/grpc/server/src/plugins/action/actionrpc_impl.h
+++ b/grpc/server/src/plugins/action/actionrpc_impl.h
@@ -9,16 +9,13 @@ using namespace dronecore;
 class ActionServiceImpl final : public rpc::action::ActionService::Service
 {
 public:
-    ActionServiceImpl(DroneCore *dc_obj)
-    {
-        dc = dc_obj;
-        action = std::make_shared<Action>(&dc->device());
-    }
+    ActionServiceImpl(const Action &action)
+        : action(action) {}
 
     Status Arm(ServerContext *context, const rpc::action::ArmRequest *request,
                rpc::action::ActionResult *response) override
     {
-        const Action::Result action_result = action->arm();
+        const Action::Result action_result = action.arm();
         response->set_result(static_cast<rpc::action::ActionResult::Result>(action_result));
         response->set_result_str(Action::result_str(action_result));
         return Status::OK;
@@ -27,7 +24,7 @@ public:
     Status TakeOff(ServerContext *context, const rpc::action::TakeOffRequest *request,
                    rpc::action::ActionResult *response) override
     {
-        const Action::Result action_result = action->takeoff();
+        const Action::Result action_result = action.takeoff();
         response->set_result(static_cast<rpc::action::ActionResult::Result>(action_result));
         response->set_result_str(Action::result_str(action_result));
         return Status::OK;
@@ -36,13 +33,12 @@ public:
     Status Land(ServerContext *context, const rpc::action::LandRequest *request,
                 rpc::action::ActionResult *response) override
     {
-        const Action::Result action_result = action->land();
+        const Action::Result action_result = action.land();
         response->set_result(static_cast<rpc::action::ActionResult::Result>(action_result));
         response->set_result_str(Action::result_str(action_result));
         return Status::OK;
     }
 
 private:
-    DroneCore *dc;
-    std::shared_ptr<Action> action;
+    const Action &action;
 };

--- a/grpc/server/src/plugins/plugins.conf
+++ b/grpc/server/src/plugins/plugins.conf
@@ -1,3 +1,0 @@
-action
-telemetry
-mission

--- a/grpc/server/src/plugins/telemetry/telemetryrpc_impl.h
+++ b/grpc/server/src/plugins/telemetry/telemetryrpc_impl.h
@@ -10,17 +10,14 @@ using namespace dronecore;
 class TelemetryServiceImpl final : public rpc::telemetry::TelemetryService::Service
 {
 public:
-    TelemetryServiceImpl(DroneCore *dc_obj)
-    {
-        dc = dc_obj;
-        telemetry = std::make_shared<Telemetry>(&dc->device());
-    }
+    TelemetryServiceImpl(Telemetry &telemetry)
+        : telemetry(telemetry) {}
 
     Status SubscribePosition(ServerContext *context,
                              const rpc::telemetry::SubscribePositionRequest *request,
                              ServerWriter<rpc::telemetry::Position> *writer) override
     {
-        telemetry->position_async([&writer](
+        telemetry.position_async([&writer](
         Telemetry::Position position) {
             rpc::telemetry::Position rpc_position;
             rpc_position.set_latitude_deg(position.latitude_deg);
@@ -38,6 +35,5 @@ public:
     }
 
 private:
-    DroneCore *dc;
-    std::shared_ptr<Telemetry> telemetry;
+    Telemetry &telemetry;
 };

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -3,9 +3,10 @@
 #include <memory>
 #include <map>
 #include <mutex>
+
 #include "device.h"
-#include "mission.h"
 #include "mavlink_include.h"
+#include "mission.h"
 #include "plugin_impl_base.h"
 #include <json11.hpp>
 


### PR DESCRIPTION
* some cleanup on the proto generation (build_system)
* use references and smart pointers instead of old-style pointers
* make a library out of `dronecore_server` (necessary for running from iOS)
* rename `dronecore_server` into `backend`

A PR actually updating the proto files will come just after this one is merged.

Connects to #238.