### PR TITLE
core: send HITL bit with DO_SET_MODE command

### DIFF
--- a/core/device.h
+++ b/core/device.h
@@ -156,7 +156,8 @@ private:
     std::atomic<bool> _target_uuid_initialized {false};
 
     bool _target_supports_mission_int {false};
-    bool _armed {false};
+    std::atomic<bool> _armed {false};
+    std::atomic<bool> _hitl_enabled {false};
 
     DroneCoreImpl *_parent;
 


### PR DESCRIPTION
Commander gets confused if this bit is not set correctly, so we need to
add it.
Also, the _armed and _hitl_enabled flags should both be atomic in order
to be thread-safe, also we should only update the flags if a heartbeat
originates from the autopilot but ignore other components such as the
camera or gimbal.