### PR TITLE
appveyor: try to run on more than one core

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,7 @@ before_build:
 build: on
 
 build_script:
+  - set CL=/MP
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cd curl-7.56.1\winbuild
   - if "%configuration%"=="Debug" (


### PR DESCRIPTION
Appveyor CI should provide 2 cores, so we can make use of that.

This is also in the docs:
https://github.com/dronecore/docs/pull/98