### PR TITLE
telemetry: use absolute yaw for camera attitude

### DIFF
--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -364,12 +364,18 @@ public:
     /**
      * @brief Get the camera's attitude in quaternions (synchronous).
      *
+     * Note this attitude is relative to North, so in the absolute frame
+     * and not relative to the vehicle's attitude.
+     *
      * @return Camera's attitude as quaternion.
      */
     Quaternion camera_attitude_quaternion() const;
 
     /**
      * @brief Get the camera's attitude in Euler angles (synchronous).
+     *
+     * Note this attitude is relative to North, so in the absolute frame.
+     * and not relative to the vehicle's attitude.
      *
      * @return Camera's attitude as Euler angle.
      */

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -364,8 +364,7 @@ public:
     /**
      * @brief Get the camera's attitude in quaternions (synchronous).
      *
-     * Note this attitude is relative to North, so in the absolute frame
-     * and not relative to the vehicle's attitude.
+     * Note that the yaw component of attitude is relative to North (absolute frame).
      *
      * @return Camera's attitude as quaternion.
      */
@@ -374,8 +373,7 @@ public:
     /**
      * @brief Get the camera's attitude in Euler angles (synchronous).
      *
-     * Note this attitude is relative to North, so in the absolute frame.
-     * and not relative to the vehicle's attitude.
+     * Note that the yaw component of attitude is relative to North (absolute frame).
      *
      * @return Camera's attitude as Euler angle.
      */

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -391,7 +391,7 @@ void TelemetryImpl::process_mount_orientation(const mavlink_message_t &message)
     Telemetry::EulerAngle euler_angle {
         mount_orientation.roll,
         mount_orientation.pitch,
-        mount_orientation.yaw
+        mount_orientation.yaw_absolute
     };
 
     set_camera_attitude_euler_angle(euler_angle);


### PR DESCRIPTION
We now have an interface for the absolute yaw angle of a camera
(respectively a gimbal).

FYI @sanderux.