### PR TITLE
build_system: remove flags for unit tests in windows

### DIFF
--- a/cmake/unit_tests.cmake
+++ b/cmake/unit_tests.cmake
@@ -6,12 +6,6 @@ add_executable(unit_tests_runner
     ${UNIT_TEST_SOURCES}
 )
 
-if (MSVC)
-    # We need this to prevent linking errors from happening in the Windows build.
-    target_compile_definitions(unit_tests_runner PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
-    target_compile_options(unit_tests_runner PUBLIC "/wd4251" "/wd4275")
-endif()
-
 target_compile_definitions(unit_tests_runner PRIVATE FAKE_TIME=1)
 
 set_target_properties(unit_tests_runner


### PR DESCRIPTION
It seems to me that gtest already does something about that
(not sure how, though), see [1] and [2].

[1]: https://github.com/google/googletest/blob/master/googletest/cmake/internal_utils.cmake#L65
[2]: https://github.com/google/googletest/blob/master/googletest/cmake/internal_utils.cmake#L201