### PR TITLE
core: Move implementation into the pImpl.

### DIFF
--- a/core/connection.cpp
+++ b/core/connection.cpp
@@ -7,10 +7,7 @@ namespace dronecore {
 
 Connection::Connection(DroneCoreImpl *parent) :
     _parent(parent),
-    _mavlink_receiver()
-
-{
-}
+    _mavlink_receiver() {}
 
 Connection::~Connection()
 {
@@ -39,7 +36,6 @@ void Connection::stop_mavlink_receiver()
         MavlinkChannels::Instance().checkin_used_channel(used_channel);
     }
 }
-
 
 void Connection::receive_message(const mavlink_message_t &message)
 {

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -1,13 +1,7 @@
 #include "dronecore.h"
+
 #include "dronecore_impl.h"
 #include "global_include.h"
-#include "connection.h"
-#include "udp_connection.h"
-#include "tcp_connection.h"
-#ifndef WINDOWS
-#include "serial_connection.h"
-#endif
-
 
 namespace dronecore {
 
@@ -25,134 +19,31 @@ DroneCore::~DroneCore()
 
 DroneCore::ConnectionResult DroneCore::add_any_connection(const std::string &connection_url)
 {
-    std::string delimiter = "://";
-    std::string conn_url(connection_url);
-    std::vector<std::string> connection_str;
-    size_t pos = 0;
-    /*Parse the connection url to get Protocol, IP or Serial dev node
-      and port number or baudrate as per the URL definition
-    */
-    for (int i = 0; i < 2; i++) {
-        pos = conn_url.find(delimiter);
-        if (pos != std::string::npos) {
-            connection_str.push_back(conn_url.substr(0, pos));
-            // Erase the string which is parsed already
-            conn_url.erase(0, pos + delimiter.length());
-            if (conn_url == "") {
-                break;
-            }
-            delimiter = ":";
-        }
-    }
-    connection_str.push_back(conn_url);
-    /* check if the protocol is Network protocol or Serial */
-    if (connection_str.at(0) != "serial") {
-        int port = 0;
-        if (connection_str.at(2) != "") {
-            port = std::stoi(connection_str.at(2));
-        }
-        return add_link_connection(connection_str.at(0), connection_str.at(1),
-                                   port); //Network Protocol : TCP or UDP
-    } else {
-        if (connection_str.at(1) == "") {
-            return add_serial_connection();
-        } else {
-            return add_serial_connection(connection_str.at(1), std::stoi(connection_str.at(2)));
-        }
-    }
+    return _impl->add_any_connection(connection_url);
 }
 
-/* Creates a connection link only for the Network protocols : UDP and TCP*/
 DroneCore::ConnectionResult DroneCore::add_link_connection(const std::string &protocol,
                                                            const std::string &ip,
                                                            const int port)
 {
-    int local_port_number = 0;
-    std::string local_ip = ip;
-    if (port == 0) {
-        if (ip != "") {
-            local_port_number = std::stoi(ip);
-            /* default ip for tcp if only port number is specified */
-            local_ip = "127.0.0.1";
-        }
-    } else {
-        local_port_number = port;
-    }
-
-    if (protocol == "udp") {
-        return add_udp_connection(local_port_number);
-    } else { //TCP connection
-        return add_tcp_connection(local_ip, local_port_number);
-    }
+    return _impl->add_link_connection(protocol, ip, port);
 }
 
-DroneCore::ConnectionResult DroneCore::add_udp_connection()
+DroneCore::ConnectionResult DroneCore::add_udp_connection(const int local_port_number)
 {
-    return add_udp_connection(0);
+    return _impl->add_udp_connection(local_port_number);
 }
 
-DroneCore::ConnectionResult DroneCore::add_udp_connection(int local_port_number)
+DroneCore::ConnectionResult DroneCore::add_tcp_connection(const std::string &remote_ip,
+                                                          const int remote_port)
 {
-    Connection *new_connection = new UdpConnection(_impl, local_port_number);
-    DroneCore::ConnectionResult ret = new_connection->start();
-
-    if (ret != DroneCore::ConnectionResult::SUCCESS) {
-        delete new_connection;
-        return ret;
-    }
-
-    _impl->add_connection(new_connection);
-    return DroneCore::ConnectionResult::SUCCESS;
+    return _impl->add_tcp_connection(remote_ip, remote_port);
 }
 
-DroneCore::ConnectionResult DroneCore::add_tcp_connection()
+DroneCore::ConnectionResult DroneCore::add_serial_connection(const std::string &dev_path,
+                                                             const int baudrate)
 {
-    return add_tcp_connection("", 0);
-}
-
-DroneCore::ConnectionResult DroneCore::add_tcp_connection(std::string remote_ip,
-                                                          int remote_port)
-{
-    Connection *new_connection = new TcpConnection(_impl, remote_ip, remote_port);
-    DroneCore::ConnectionResult ret = new_connection->start();
-
-    if (ret != DroneCore::ConnectionResult::SUCCESS) {
-        delete new_connection;
-        return ret;
-    }
-
-    _impl->add_connection(new_connection);
-    return DroneCore::ConnectionResult::SUCCESS;
-}
-
-DroneCore::ConnectionResult DroneCore::add_serial_connection()
-{
-#if !defined(WINDOWS) && !defined(APPLE)
-    return add_serial_connection("", 0);
-#else
-    return ConnectionResult::NOT_IMPLEMENTED;
-#endif
-}
-
-DroneCore::ConnectionResult DroneCore::add_serial_connection(std::string dev_path,
-                                                             int baudrate)
-{
-#if !defined(WINDOWS) && !defined(APPLE)
-    Connection *new_connection = new SerialConnection(_impl, dev_path, baudrate);
-    DroneCore::ConnectionResult ret = new_connection->start();
-
-    if (ret != DroneCore::ConnectionResult::SUCCESS) {
-        delete new_connection;
-        return ret;
-    }
-
-    _impl->add_connection(new_connection);
-    return DroneCore::ConnectionResult::SUCCESS;
-#else
-    UNUSED(dev_path);
-    UNUSED(baudrate);
-    return DroneCore::ConnectionResult::NOT_IMPLEMENTED;
-#endif
+    return _impl->add_serial_connection(dev_path, baudrate);
 }
 
 const std::vector<uint64_t> &DroneCore::device_uuids() const
@@ -165,7 +56,7 @@ Device &DroneCore::device() const
     return _impl->get_device();
 }
 
-Device &DroneCore::device(uint64_t uuid) const
+Device &DroneCore::device(const uint64_t uuid) const
 {
     return _impl->get_device(uuid);
 }
@@ -175,22 +66,22 @@ bool DroneCore::is_connected() const
     return _impl->is_connected();
 }
 
-bool DroneCore::is_connected(uint64_t uuid) const
+bool DroneCore::is_connected(const uint64_t uuid) const
 {
     return _impl->is_connected(uuid);
 }
 
-void DroneCore::register_on_discover(event_callback_t callback)
+void DroneCore::register_on_discover(const event_callback_t callback)
 {
     _impl->register_on_discover(callback);
 }
 
-void DroneCore::register_on_timeout(event_callback_t callback)
+void DroneCore::register_on_timeout(const event_callback_t callback)
 {
     _impl->register_on_timeout(callback);
 }
 
-const char *DroneCore::connection_result_str(ConnectionResult result)
+const char *DroneCore::connection_result_str(const ConnectionResult result)
 {
     switch (result) {
         case ConnectionResult::SUCCESS:

--- a/core/dronecore.h
+++ b/core/dronecore.h
@@ -4,8 +4,6 @@
 #include <vector>
 #include <functional>
 
-//#include "device.h"
-
 namespace dronecore {
 
 class DroneCoreImpl;
@@ -22,6 +20,12 @@ class Device;
 class DroneCore
 {
 public:
+    static constexpr auto DEFAULT_UDP_CONNECTION_URL = "udp://:14540";
+    static constexpr int DEFAULT_UDP_PORT = 14540;
+    static constexpr auto DEFAULT_TCP_REMOTE_IP = "127.0.0.1";
+    static constexpr int DEFAULT_TCP_REMOTE_PORT = 5760;
+    static constexpr auto DEFAULT_SERIAL_DEV_PATH = "/dev/ttyS0";
+    static constexpr int DEFAULT_SERIAL_BAUDRATE = 57600;
 
     /**
      * @brief Constructor.
@@ -60,7 +64,7 @@ public:
     /**
      * @brief Translates the DroneCore::ConnectionResult enum to a human-readable English string.
      */
-    static const char *connection_result_str(ConnectionResult);
+    static const char *connection_result_str(const ConnectionResult result);
 
     /**
      * @brief Adds Connection via URL
@@ -77,60 +81,35 @@ public:
      * @param connection_url connection URL string.
      * @return The result of adding the connection.
      */
-    ConnectionResult add_any_connection(const std::string &connection_url = "udp://:14540");
-
-    /**
-     * @brief Adds a UDP connection to the default port.
-     *
-     * This will listen on UDP port 14540.
-     *
-     * @return The result of adding the connection.
-     */
-    ConnectionResult add_udp_connection();
+    ConnectionResult add_any_connection(const std::string &connection_url = DEFAULT_UDP_CONNECTION_URL);
 
     /**
      * @brief Adds a UDP connection to the specified port number.
      *
-     * @param local_port_number The local UDP port to listen to.
+     * @param local_port_number The local UDP port to listen to (defaults to 14540, the same as mavros).
      * @return The result of adding the connection.
      */
-    ConnectionResult add_udp_connection(int local_port_number);
-
-    /**
-     * @brief Adds a TCP connection to the default IP address/port.
-     *
-     * This will connect to local TCP port 5760.
-     *
-     * @return The result of adding the connection.
-     */
-    ConnectionResult add_tcp_connection();
+    ConnectionResult add_udp_connection(int local_port_number = DEFAULT_UDP_PORT);
 
     /**
      * @brief Adds a TCP connection with a specific IP address and port number.
      *
-     * @param remote_ip Remote IP address to connect to.
-     * @param remote_port The TCP port to connect to.
+     * @param remote_ip Remote IP address to connect to (defaults to 127.0.0.1).
+     * @param remote_port The TCP port to connect to (defaults to 5760).
      * @return The result of adding the connection.
      */
-    ConnectionResult add_tcp_connection(std::string remote_ip, int remote_port);
-
-    /**
-     * @brief Adds a serial connection with the default arguments.
-     *
-     * This will connect to serial port ttyS1 (COM0).
-     *
-     * @return The result of adding the connection.
-     */
-    ConnectionResult add_serial_connection();
+    ConnectionResult add_tcp_connection(const std::string &remote_ip = DEFAULT_TCP_REMOTE_IP,
+                                        int remote_port = DEFAULT_TCP_REMOTE_PORT);
 
     /**
      * @brief Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
      *
-     * @param dev_path COM or UART dev node name/path.
-     * @param baudrate Baudrate of the serial port.
+     * @param dev_path COM or UART dev node name/path (defaults to "/dev/ttyS0").
+     * @param baudrate Baudrate of the serial port (defaults to 57600).
      * @return The result of adding the connection.
      */
-    ConnectionResult add_serial_connection(std::string dev_path, int baudrate);
+    ConnectionResult add_serial_connection(const std::string &dev_path = DEFAULT_SERIAL_DEV_PATH,
+                                           int baudrate = DEFAULT_SERIAL_BAUDRATE);
 
     /**
      * @brief Get vector of device UUIDs.
@@ -225,6 +204,7 @@ private:
     // Non-copyable
     DroneCore(const DroneCore &) = delete;
     const DroneCore &operator=(const DroneCore &) = delete;
+
     /* Adds a connection for Network protocol*/
     ConnectionResult add_link_connection(const std::string &protocol, const std::string &ip,
                                          const int port);

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "dronecore.h"
-#include "connection.h"
-#include "device.h"
-#include "mavlink_include.h"
-#include <vector>
 #include <map>
 #include <mutex>
+#include <vector>
 
+#include "connection.h"
+#include "device.h"
+#include "dronecore.h"
+#include "mavlink_include.h"
 
 namespace dronecore {
 
@@ -19,7 +19,13 @@ public:
 
     void receive_message(const mavlink_message_t &message);
     bool send_message(const mavlink_message_t &message);
+    DroneCore::ConnectionResult add_any_connection(const std::string &connection_url);
+    DroneCore::ConnectionResult add_link_connection(const std::string &protocol, const std::string &ip,
+                                                    int port);
+    DroneCore::ConnectionResult add_udp_connection(int local_port_number);
     void add_connection(Connection *connection);
+    DroneCore::ConnectionResult add_tcp_connection(const std::string &remote_ip, int remote_port);
+    DroneCore::ConnectionResult add_serial_connection(const std::string &dev_path, int baudrate);
 
     const std::vector<uint64_t> &get_device_uuids() const;
     Device &get_device();

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -26,15 +26,7 @@ TcpConnection::TcpConnection(DroneCoreImpl *parent, const std::string &remote_ip
     Connection(parent),
     _remote_ip(remote_ip),
     _remote_port_number(remote_port),
-    _should_exit(false)
-{
-    if (_remote_port_number == 0) {
-        _remote_port_number = DEFAULT_TCP_REMOTE_PORT;
-    }
-    if (_remote_ip == "") {
-        _remote_ip = DEFAULT_TCP_REMOTE_IP;
-    }
-}
+    _should_exit(false) {}
 
 TcpConnection::~TcpConnection()
 {

--- a/core/tcp_connection.h
+++ b/core/tcp_connection.h
@@ -36,10 +36,6 @@ private:
     int resolve_address(const std::string &ip_address, int port, struct sockaddr_in *addr);
     static void receive(TcpConnection *parent);
 
-    static constexpr int DEFAULT_TCP_REMOTE_PORT = 5760;
-    static constexpr auto DEFAULT_TCP_REMOTE_IP = "127.0.0.1";
-    std::string _local_ip = "127.0.0.1";
-    int _local_port_number = 14580; //unused port
     std::string _remote_ip = {};
     int _remote_port_number;
 

--- a/core/udp_connection.cpp
+++ b/core/udp_connection.cpp
@@ -28,12 +28,7 @@ namespace dronecore {
 UdpConnection::UdpConnection(DroneCoreImpl *parent,
                              int local_port_number) :
     Connection(parent),
-    _local_port_number(local_port_number)
-{
-    if (_local_port_number == 0) {
-        _local_port_number = DEFAULT_UDP_LOCAL_PORT;
-    }
-}
+    _local_port_number(local_port_number) {}
 
 UdpConnection::~UdpConnection()
 {

--- a/core/udp_connection.h
+++ b/core/udp_connection.h
@@ -30,9 +30,6 @@ private:
 
     static void receive(UdpConnection *parent);
 
-    // This port is shared with mavros, so either one, this SDK or mavros can be used.
-    static constexpr int DEFAULT_UDP_LOCAL_PORT = 14540;
-
     int _local_port_number;
 
     std::mutex _remote_mutex = {};


### PR DESCRIPTION
Fix the DroneCore pImpl (some of the implementation had leaked into the base class).

* Pass strings by reference
* Make const arguments const
* Move some defaults value to the consumer instead of the generic classes
* Remove unused members in udp_connection
* Reorder some headers