### PR TITLE
294 ios backend framework

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -13,25 +13,27 @@ else()
 endif()
 
 # We need tinyxml2 for the camera definition parsing.
-if(APPLE AND NOT IOS)
-    # We install the tinyxml2 library manually for macOS and iOS.
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        # Need to remove that d again.
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2d.5.0.1.dylib
-            DESTINATION ${lib_path}
-            #RENAME libtinyxml2.dylib
-        )
-    else()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2.5.0.1.dylib
-            DESTINATION ${lib_path}
-            #RENAME libtinyxml2.dylib
-        )
-    endif()
+if(APPLE)
+    if(NOT IOS)
+        # We install the tinyxml2 library manually for macOS and iOS.
+        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            # Need to remove that d again.
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2d.5.0.1.dylib
+                DESTINATION ${lib_path}
+                #RENAME libtinyxml2.dylib
+            )
+        else()
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2.5.0.1.dylib
+                DESTINATION ${lib_path}
+                #RENAME libtinyxml2.dylib
+            )
+        endif()
 
-    add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
-    include_directories(SYSTEM third_party/tinyxml2)
-    link_directories(third_party/tinyxml2)
-    set(TINYXML2_LIBRARY tinyxml2)
+        add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
+        include_directories(SYSTEM third_party/tinyxml2)
+        link_directories(third_party/tinyxml2)
+        set(TINYXML2_LIBRARY tinyxml2)
+    endif()
 elseif(ANDROID)
     # We install the tinyxml2 library manually for Android.
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 endif()
 
 # We need tinyxml2 for the camera definition parsing.
-if(APPLE)
+if(APPLE AND NOT IOS)
     # We install the tinyxml2 library manually for macOS and iOS.
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         # Need to remove that d again.
@@ -31,6 +31,7 @@ if(APPLE)
     add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
     include_directories(SYSTEM third_party/tinyxml2)
     link_directories(third_party/tinyxml2)
+    set(TINYXML2_LIBRARY tinyxml2)
 elseif(ANDROID)
     # We install the tinyxml2 library manually for Android.
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -48,13 +49,16 @@ elseif(ANDROID)
     add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
     include_directories(SYSTEM third_party/tinyxml2)
     link_directories(third_party/tinyxml2)
+    set(TINYXML2_LIBRARY tinyxml2)
 elseif(MSVC)
     add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
     include_directories(SYSTEM third_party/tinyxml2)
     link_directories(third_party/tinyxml2)
+    set(TINYXML2_LIBRARY tinyxml2)
 else()
     # For Linux for now we use the system tinyxml2, otherwise the unit test crashes
     # miraculously.
+    set(TINYXML2_LIBRARY tinyxml2)
 endif()
 
 add_library(dronecore ${LIBRARY_TYPE}
@@ -81,7 +85,7 @@ add_library(dronecore ${LIBRARY_TYPE}
 target_link_libraries(dronecore
     ${CMAKE_THREAD_LIBS_INIT}
     ${CURL_LIBRARY}
-    tinyxml2
+    ${TINYXML2_LIBRARY}
     ${DRONECORE_ZLIB_LIBRARIES}
 )
 

--- a/grpc/server/src/CMakeLists.txt
+++ b/grpc/server/src/CMakeLists.txt
@@ -12,11 +12,26 @@ foreach(COMPONENT_NAME ${COMPONENTS_LIST})
     list(APPEND GRPC_COMPILED_SOURCES ${GRPC_COMPILED_SOURCE})
 endforeach()
 
-add_library(backend
+set(BACKEND_SOURCES
+    backend_api.h
+    backend_api.cpp
     backend.cpp
     ${GRPC_COMPILED_SOURCES}
     ${PB_COMPILED_SOURCES}
 )
+
+if(IOS)
+    set_property(SOURCE module.modulemap
+        PROPERTY MACOSX_PACKAGE_LOCATION "Modules")
+
+    list(APPEND BACKEND_SOURCES module.modulemap)
+endif()
+
+if(ANDROID OR IOS)
+    add_library(backend SHARED ${BACKEND_SOURCES})
+else()
+    add_library(backend STATIC ${BACKEND_SOURCES})
+endif()
 
 target_link_libraries(backend
     dronecore
@@ -36,16 +51,29 @@ target_include_directories(backend
     ${PLUGINS_DIR}
 )
 
-add_executable(backend_bin
-    dronecore_server.cpp
-)
+if(IOS)
+    set_target_properties(backend PROPERTIES
+        FRAMEWORK TRUE
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_NAME_DIR @rpath
+        MACOSX_FRAMEWORK_IDENTIFIER io.dronecore.backend
+        VERSION 0.0.1
+        SOVERSION 0.0.1
+        PUBLIC_HEADER backend_api.h
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "DroneCore"
+    )
+else()
+    add_executable(backend_bin
+        dronecore_server.cpp
+    )
 
-target_link_libraries(backend_bin
-    backend
-    dronecore
-)
+    target_link_libraries(backend_bin
+        backend
+        dronecore
+    )
 
-target_include_directories(backend_bin
-    PRIVATE
-    ${CMAKE_SOURCE_DIR}/core
-)
+    target_include_directories(backend_bin
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/core
+    )
+endif()

--- a/grpc/server/src/backend.cpp
+++ b/grpc/server/src/backend.cpp
@@ -5,9 +5,12 @@
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
 #include <grpc++/security/server_credentials.h>
+#include <mutex>
 
 #include "action/actionrpc_impl.h"
+#include "connection_initiator.h"
 #include "core/corerpc_impl.h"
+#include "dronecore.h"
 #include "log.h"
 #include "mission/missionrpc_impl.h"
 #include "telemetry/telemetryrpc_impl.h"
@@ -15,42 +18,61 @@
 namespace dronecore {
 namespace backend {
 
-bool DroneCoreBackend::run(const int mavlink_listen_port)
+class DroneCoreBackend::Impl
 {
-    _connection_initiator.start(_dc, 14540);
-    _connection_initiator.wait();
+public:
+    Impl() {}
+    ~Impl() {}
 
-    grpc::ServerBuilder builder;
-    setup_port(builder);
+    bool run(const int mavlink_listen_port)
+    {
+        _connection_initiator.start(_dc, 14540);
+        _connection_initiator.wait();
 
-    CoreServiceImpl core(_dc);
-    builder.RegisterService(&core);
+        grpc::ServerBuilder builder;
+        setup_port(builder);
 
-    Action action(&_dc.device());
-    ActionServiceImpl actionService(action);
-    builder.RegisterService(&actionService);
+        CoreServiceImpl core(_dc);
+        builder.RegisterService(&core);
 
-    Mission mission(&_dc.device());
-    MissionServiceImpl missionService(mission);
-    builder.RegisterService(&missionService);
+        Action action(&_dc.device());
+        ActionServiceImpl actionService(action);
+        builder.RegisterService(&actionService);
 
-    Telemetry telemetry(&_dc.device());
-    TelemetryServiceImpl telemetryService(telemetry);
-    builder.RegisterService(&telemetryService);
+        Mission mission(&_dc.device());
+        MissionServiceImpl missionService(mission);
+        builder.RegisterService(&missionService);
 
-    _server = builder.BuildAndStart();
-    LogInfo() << "Server started";
-    _server->Wait();
+        Telemetry telemetry(&_dc.device());
+        TelemetryServiceImpl telemetryService(telemetry);
+        builder.RegisterService(&telemetryService);
 
-    return true;
-}
+        _server = builder.BuildAndStart();
+        LogInfo() << "Server started";
+        _server->Wait();
 
-void DroneCoreBackend::setup_port(grpc::ServerBuilder &builder)
-{
-    std::string server_address("0.0.0.0:50051");
-    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-    LogInfo() << "Server set to listen on " << server_address;
-}
+        return true;
+    }
+
+private:
+    void setup_port(grpc::ServerBuilder &builder)
+    {
+        std::string server_address("0.0.0.0:50051");
+        builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+        LogInfo() << "Server set to listen on " << server_address;
+    }
+
+    dronecore::DroneCore _dc;
+    dronecore::backend::ConnectionInitiator<dronecore::DroneCore> _connection_initiator;
+    std::unique_ptr<grpc::Server> _server;
+};
+
+DroneCoreBackend::DroneCoreBackend() : _impl(new Impl()) {}
+DroneCoreBackend::~DroneCoreBackend() = default;
+DroneCoreBackend::DroneCoreBackend(DroneCoreBackend &&) = default;
+DroneCoreBackend &DroneCoreBackend::operator=(DroneCoreBackend &&) = default;
+
+bool DroneCoreBackend::run(const int mavlink_listen_port) { return _impl->run(mavlink_listen_port); }
 
 } // namespace backend
 } //namespace dronecore

--- a/grpc/server/src/backend.h
+++ b/grpc/server/src/backend.h
@@ -1,9 +1,4 @@
-#include <grpc++/server.h>
 #include <memory>
-#include <mutex>
-
-#include "connection_initiator.h"
-#include "dronecore.h"
 
 namespace dronecore {
 namespace backend {
@@ -11,18 +6,17 @@ namespace backend {
 class DroneCoreBackend
 {
 public:
-    DroneCoreBackend() {}
-    ~DroneCoreBackend() {}
+    DroneCoreBackend();
+    ~DroneCoreBackend();
+
+    DroneCoreBackend(DroneCoreBackend &&op);
+    DroneCoreBackend &operator=(DroneCoreBackend &&op);
 
     bool run(const int mavlink_listen_port = 14540);
 
 private:
-    bool run_server();
-    void setup_port(grpc::ServerBuilder &builder);
-
-    dronecore::DroneCore _dc;
-    dronecore::backend::ConnectionInitiator<dronecore::DroneCore> _connection_initiator;
-    std::unique_ptr<grpc::Server> _server;
+    class Impl;
+    std::unique_ptr<Impl> _impl;
 };
 
 } // namespace backend

--- a/grpc/server/src/backend_api.cpp
+++ b/grpc/server/src/backend_api.cpp
@@ -1,0 +1,15 @@
+#include "backend_api.h"
+
+#include "backend.h"
+
+int runBackend(const int mavlink_listen_port)
+{
+    dronecore::backend::DroneCoreBackend backend;
+    bool had_error = backend.run(mavlink_listen_port);
+
+    if (had_error) {
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/grpc/server/src/backend_api.h
+++ b/grpc/server/src/backend_api.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((visibility("default"))) int runBackend(int mavlink_listen_port);
+
+#ifdef __cplusplus
+}
+#endif

--- a/grpc/server/src/core/corerpc_impl.h
+++ b/grpc/server/src/core/corerpc_impl.h
@@ -1,4 +1,5 @@
 #include "core/core.grpc.pb.h"
+#include "dronecore.h"
 
 using grpc::Status;
 using grpc::ServerContext;

--- a/grpc/server/src/module.modulemap
+++ b/grpc/server/src/module.modulemap
@@ -1,0 +1,6 @@
+framework module backend {
+  umbrella header "backend_api.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
When building for iOS, the backend is now automatically built as an iOS Framework that can be directly added in an Xcode project and used (it only exposes the one `runBackend(port)` function).

There are two small glitches regarding dependencies:
* Json11 has to be built as a static library. I still need to figure what's a good way to do that, but maybe for now I will just fork it.
* Tinyxml2 has to be built as a static library. Here, there is a way to do it, but with a not-so-generic variable (`-DBUILD_STATIC_LIBS`) that we may not want to set for the whole project. So I'd like to build tinyxml2 separately (like grpc and others). For now, I don't link it in iOS.

Fixes #294.