### PR TITLE
backend: clean pImpl

### DIFF
--- a/grpc/server/src/backend.cpp
+++ b/grpc/server/src/backend.cpp
@@ -70,10 +70,8 @@ private:
 
 DroneCoreBackend::DroneCoreBackend() : _impl(new Impl()) {}
 DroneCoreBackend::~DroneCoreBackend() = default;
-DroneCoreBackend::DroneCoreBackend(DroneCoreBackend &&) = default;
-DroneCoreBackend &DroneCoreBackend::operator=(DroneCoreBackend &&) = default;
 
 bool DroneCoreBackend::run(const int mavlink_listen_port) { return _impl->run(mavlink_listen_port); }
 
 } // namespace backend
-} //namespace dronecore
+} // namespace dronecore

--- a/grpc/server/src/backend.h
+++ b/grpc/server/src/backend.h
@@ -8,9 +8,8 @@ class DroneCoreBackend
 public:
     DroneCoreBackend();
     ~DroneCoreBackend();
-
-    DroneCoreBackend(DroneCoreBackend &&op);
-    DroneCoreBackend &operator=(DroneCoreBackend &&op);
+    DroneCoreBackend(DroneCoreBackend &&) = delete;
+    DroneCoreBackend &operator=(DroneCoreBackend &&) = delete;
 
     bool run(const int mavlink_listen_port = 14540);
 


### PR DESCRIPTION
_Continuing the discussion we had on the other PR, but this one is not blocking, so we can take more time :-)._

It seems like the destructor must be defined because keeping the default doesn't compile (something like it creates a default destructor, but doesn't know `Impl` at that time.

The other two were apparently there to define them as `noexcept`, but they can be removed since we don't need it. I can also delete them if I do it in `backend.h`, but I'm not sure we actually want that.