### PR TITLE
Correct Autopilot type of Self (GCS)

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -285,8 +285,9 @@ void Device::device_thread(Device *self)
 void Device::send_heartbeat(Device *self)
 {
     mavlink_message_t message;
+    // Self is GCS (its not autopilot!); hence MAV_AUTOPILOT_INVALID.
     mavlink_msg_heartbeat_pack(_own_system_id, _own_component_id, &message,
-                               MAV_TYPE_GCS, MAV_AUTOPILOT_GENERIC, 0, 0, 0);
+                               MAV_TYPE_GCS, MAV_AUTOPILOT_INVALID, 0, 0, 0);
     self->send_message(message);
 }
 


### PR DESCRIPTION
Fixes #305 
[Currently](https://github.com/dronecore/DroneCore/blob/f308f020205c08d930e1acaa849b332e365d4965/core/device.cpp#L289) GCS type (in Heartbeat) is [MAV_AUTOPILOT_GENERIC](http://mavlink.org/messages/common/#MAV_AUTOPILOT_GENERIC) (its a type for autopilot! not for GCS).
However, MAVLink documentation recommends to use [MAV_AUTOPILOT_INVALID](http://mavlink.org/messages/common/#MAV_AUTOPILOT_INVALID) for GCS.
