### PR TITLE
Multi component handling

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -166,7 +166,10 @@ void Device::process_heartbeat(const mavlink_message_t &message)
     // We do not call on_discovery here but wait with the notification until we know the UUID.
 
     /* If we don't know the UUID yet, we try to find out. */
-    if (_target_uuid == 0 && !_target_uuid_initialized) {
+    // Lets request autopilot version only from an Autopilot.
+    if (heartbeat.autopilot != MAV_AUTOPILOT_INVALID
+        && _target_uuid == 0
+        && !_target_uuid_initialized) {
         request_autopilot_version();
     }
 
@@ -357,7 +360,7 @@ void Device::set_connected()
 
         if (!_connected && _target_uuid_initialized) {
 
-            _parent->notify_on_discover(_target_uuid);
+            _parent->notify_on_discover(_target_uuid, _target_component_id);
             _connected = true;
 
             register_timeout_handler(std::bind(&Device::heartbeats_timed_out, this),
@@ -389,7 +392,7 @@ void Device::set_disconnected()
         //_heartbeat_timeout_cookie = nullptr;
 
         _connected = false;
-        _parent->notify_on_timeout(_target_uuid);
+        _parent->notify_on_timeout(_target_uuid, _target_component_id);
 
         // Let's reset the flag hope again for the next time we see this target.
         _target_uuid_initialized = false;

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -15,8 +15,10 @@ namespace dronecore {
 using namespace std::placeholders; // for `_1`
 
 Device::Device(DroneCoreImpl *parent,
-               uint8_t target_system_id) :
+               uint8_t target_system_id,
+               uint8_t target_component_id) :
     _target_system_id(target_system_id),
+    _target_component_id(target_component_id),
     _parent(parent),
     _params(this),
     _commands(this),
@@ -29,9 +31,11 @@ Device::Device(DroneCoreImpl *parent,
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&Device::process_heartbeat, this, _1), this);
 
-    register_mavlink_message_handler(
-        MAVLINK_MSG_ID_AUTOPILOT_VERSION,
-        std::bind(&Device::process_autopilot_version, this, _1), this);
+    // Request for Autopilot version, only if its Autopilot
+    if (_target_component_id == MAV_COMP_ID_AUTOPILOT1)
+        register_mavlink_message_handler(
+            MAVLINK_MSG_ID_AUTOPILOT_VERSION,
+            std::bind(&Device::process_autopilot_version, this, _1), this);
 
     register_mavlink_message_handler(
         MAVLINK_MSG_ID_STATUSTEXT,

--- a/core/device.h
+++ b/core/device.h
@@ -33,7 +33,7 @@ public:
     };
 
     explicit Device(DroneCoreImpl *parent,
-                    uint8_t target_system_id);
+                    uint8_t target_system_id, uint8_t target_component_id);
     ~Device();
 
     void process_mavlink_message(const mavlink_message_t &message);
@@ -148,8 +148,7 @@ private:
 
     std::atomic<uint8_t> _target_system_id;
 
-    // The component ID is hardcoded for now.
-    uint8_t _target_component_id = MAV_COMP_ID_AUTOPILOT1;
+    uint8_t _target_component_id;
     uint64_t _target_uuid {0};
 
     int _target_uuid_retries = 0;

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -56,22 +56,20 @@ Device &DroneCore::autopilot() const
     return _impl->get_autopilot();
 }
 
-#if 0
-Device &DroneCore::device(const uint64_t uuid) const
+Device &DroneCore::autopilot(uint64_t uuid) const
 {
-    return _impl->get_device(uuid);
+    return _impl->get_autopilot(uuid);
 }
 
-bool DroneCore::is_connected() const
+bool DroneCore::is_autopilot_connected() const
 {
-    return _impl->is_connected();
+    return _impl->is_autopilot_connected();
 }
 
-bool DroneCore::is_connected(const uint64_t uuid) const
+bool DroneCore::is_autopilot_connected(uint64_t uuid) const
 {
-    return _impl->is_connected(uuid);
+    return _impl->is_autopilot_connected(uuid);
 }
-#endif
 
 
 void DroneCore::register_on_discover(const event_callback_t callback)

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -51,11 +51,12 @@ const std::vector<uint64_t> &DroneCore::device_uuids() const
     return _impl->get_device_uuids();
 }
 
-Device &DroneCore::device() const
+Device &DroneCore::autopilot() const
 {
-    return _impl->get_device();
+    return _impl->get_autopilot();
 }
 
+#if 0
 Device &DroneCore::device(const uint64_t uuid) const
 {
     return _impl->get_device(uuid);
@@ -70,6 +71,8 @@ bool DroneCore::is_connected(const uint64_t uuid) const
 {
     return _impl->is_connected(uuid);
 }
+#endif
+
 
 void DroneCore::register_on_discover(const event_callback_t callback)
 {

--- a/core/dronecore.h
+++ b/core/dronecore.h
@@ -97,16 +97,16 @@ public:
     const std::vector<uint64_t> &device_uuids() const;
 
     /**
-     * @brief Get the first discovered device.
+     * @brief Get the first discovered autopilot device.
      *
-     * This returns the first discovered device or a null device if no device has yet been found.
+     * This returns the first discovered autopilot device or a null device if no device has yet been found.
      *
-     * @return A reference to a device.
+     * @return A reference to an autopilot device.
      */
-    Device &device() const;
+    Device &autopilot() const;
 
     /**
-     * @brief Get the device with the specified UUID.
+     * @brief Get the autopilot device of the given system UUID.
      *
      * This returns a device for a given UUID if such a device has been discovered and a null
      * device otherwise.
@@ -114,27 +114,28 @@ public:
      * @param uuid UUID of device to get.
      * @return A reference to the specified device.
      */
-    Device &device(uint64_t uuid) const;
+    Device &autopilot(uint64_t uuid) const;
 
     /**
      * @brief Callback type for discover and timeout notifications.
      *
      * @param uuid UUID of device (or MAVLink system ID for devices that don't have a UUID).
      */
-    typedef std::function<void(uint64_t uuid)> event_callback_t;
+    typedef std::function<void(uint64_t uuid, uint8_t component_id)> event_callback_t;
 
     /**
-     * @brief Returns `true` if exactly one device is currently connected.
+     * @brief Returns `true` if exactly one autopilot device is currently connected.
      *
-     * Connected means we are receiving heartbeats from this device.
+     * Connected means we are receiving heartbeats from this autopilot device.
      * It means the same as "discovered" and "not timed out".
      *
-     * If multiple devices have connected, this will return `false`.
+     * If multiple autopilot devices have connected, this will return `false`.
      *
-     * @return `true` if exactly one device is connected.
+     * @return `true` if exactly one autopilot device is connected.
      */
-    bool is_connected() const;
+    bool is_autopilot_connected() const;
 
+#if 0
     /**
      * @brief Returns `true` if a device is currently connected.
      *
@@ -145,6 +146,7 @@ public:
      * @return `true` if device is connected.
      */
     bool is_connected(uint64_t uuid) const;
+#endif
 
     /**
      * @brief Register callback for device discovery.

--- a/core/dronecore.h
+++ b/core/dronecore.h
@@ -135,7 +135,6 @@ public:
      */
     bool is_autopilot_connected() const;
 
-#if 0
     /**
      * @brief Returns `true` if a device is currently connected.
      *
@@ -145,8 +144,7 @@ public:
      * @param uuid UUID of device to check.
      * @return `true` if device is connected.
      */
-    bool is_connected(uint64_t uuid) const;
-#endif
+    bool is_autopilot_connected(uint64_t uuid) const;
 
     /**
      * @brief Register callback for device discovery.

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -74,7 +74,7 @@ void DroneCoreImpl::receive_message(const mavlink_message_t &message)
         _devices.insert(std::pair<uint8_t, Device *>(message.sysid, null_device));
     }
 
-    create_device_if_not_existing(message.sysid);
+    create_device_if_not_existing(message.sysid, message.compid);
 
     if (_should_exit) {
         // Don't try to call at() if devices have already been destroyed
@@ -262,8 +262,8 @@ Device &DroneCoreImpl::get_device()
             return *_devices.begin()->second;
         } else {
             LogErr() << "Error: no device found.";
-            uint8_t system_id = 0;
-            create_device_if_not_existing(system_id);
+            uint8_t system_id = 0, component_id = 0;
+            create_device_if_not_existing(system_id, component_id);
             return *_devices[system_id];
         }
     }
@@ -286,9 +286,8 @@ Device &DroneCoreImpl::get_device(const uint64_t uuid)
     LogErr() << "device with UUID: " << uuid << " not found";
 
     // Create a dummy
-    uint8_t system_id = 0;
-    create_device_if_not_existing(system_id);
-
+    uint8_t system_id = 0, component_id = 0;
+    create_device_if_not_existing(system_id, component_id);
     return *_devices[system_id];
 }
 
@@ -314,7 +313,7 @@ bool DroneCoreImpl::is_connected(const uint64_t uuid) const
     return false;
 }
 
-void DroneCoreImpl::create_device_if_not_existing(const uint8_t system_id)
+void DroneCoreImpl::create_device_if_not_existing(uint8_t system_id, uint8_t comp_id)
 {
     std::lock_guard<std::recursive_mutex> lock(_devices_mutex);
 
@@ -330,7 +329,7 @@ void DroneCoreImpl::create_device_if_not_existing(const uint8_t system_id)
     }
 
     // Create both lists in parallel
-    Device *new_device = new Device(this, system_id);
+    Device *new_device = new Device(this, system_id, comp_id);
     _devices.insert(std::pair<uint8_t, Device *>(system_id, new_device));
 }
 

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -41,7 +41,7 @@ public:
     void notify_on_timeout(uint64_t uuid);
 
 private:
-    void create_device_if_not_existing(uint8_t system_id);
+    void create_device_if_not_existing(uint8_t system_id, uint8_t component_id);
 
     std::mutex _connections_mutex;
     std::vector<Connection *> _connections;

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -32,9 +32,7 @@ public:
     Device &get_autopilot(uint64_t uuid);
 
     bool is_autopilot_connected() const;
-#if 0
-    bool is_connected(uint64_t uuid) const;
-#endif
+    bool is_autopilot_connected(uint64_t uuid) const;
 
     void register_on_discover(DroneCore::event_callback_t callback);
     void register_on_timeout(DroneCore::event_callback_t callback);

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -28,26 +28,28 @@ public:
     ConnectionResult add_serial_connection(const std::string &dev_path, int baudrate);
 
     const std::vector<uint64_t> &get_device_uuids() const;
-    Device &get_device();
-    Device &get_device(uint64_t uuid);
+    Device &get_autopilot();
+    Device &get_autopilot(uint64_t uuid);
 
-    bool is_connected() const;
+    bool is_autopilot_connected() const;
+#if 0
     bool is_connected(uint64_t uuid) const;
+#endif
 
     void register_on_discover(DroneCore::event_callback_t callback);
     void register_on_timeout(DroneCore::event_callback_t callback);
 
-    void notify_on_discover(uint64_t uuid);
-    void notify_on_timeout(uint64_t uuid);
+    void notify_on_discover(uint64_t uuid, uint8_t component_id);
+    void notify_on_timeout(uint64_t uuid, uint8_t component_id);
 
 private:
-    void create_device_if_not_existing(uint8_t system_id, uint8_t component_id);
+    bool make_new_device(uint8_t ystem_id, uint8_t comp_id);
 
     std::mutex _connections_mutex;
     std::vector<Connection *> _connections;
 
     mutable std::recursive_mutex _devices_mutex;
-    std::map<uint8_t, Device *> _devices;
+    std::map<uint8_t, std::vector<Device *>> _devices;
 
     DroneCore::event_callback_t _on_discover_callback;
     DroneCore::event_callback_t _on_timeout_callback;

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -57,8 +57,9 @@ int main(int /*argc*/, char ** /*argv*/)
         auto future_result = prom->get_future();
 
         std::cout << "Waiting to discover device..." << std::endl;
-        dc.register_on_discover([prom](uint64_t uuid) {
-            std::cout << "Discovered device with UUID: " << uuid << std::endl;
+        dc.register_on_discover([prom](uint64_t uuid, uint8_t component_id) {
+            std::cout << "Discovered device with UUID: " << uuid
+                      << "Component ID: " << int(component_id) << std::endl;
             prom->set_value();
         });
 
@@ -68,8 +69,10 @@ int main(int /*argc*/, char ** /*argv*/)
         future_result.get();
     }
 
-    dc.register_on_timeout([](uint64_t uuid) {
-        std::cout << "Device with UUID timed out: " << uuid << std::endl;
+    dc.register_on_timeout([](uint64_t uuid, uint8_t component_id) {
+        std::cout << "Device with UUID: " << uuid
+                  << " and Component ID: " << int(component_id)
+                  << " timed out: " << std::endl;
         std::cout << "Exiting." << std::endl;
         exit(0);
     });
@@ -77,7 +80,7 @@ int main(int /*argc*/, char ** /*argv*/)
     // We don't need to specifiy the UUID if it's only one device anyway.
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     std::shared_ptr<Action> action = std::make_shared<Action>(&device);
     std::shared_ptr<Mission> mission = std::make_shared<Mission>(&device);
     std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -66,8 +66,9 @@ int main(int argc, char **argv)
         auto future_result = prom->get_future();
 
         std::cout << "Waiting to discover device..." << std::endl;
-        dc.register_on_discover([prom](uint64_t uuid) {
-            std::cout << "Discovered device with UUID: " << uuid << std::endl;
+        dc.register_on_discover([prom](uint64_t uuid, uint8_t component_id) {
+            std::cout << "Discovered device with UUID: " << uuid
+                      << "Component ID: " << int(component_id) << std::endl;
             prom->set_value();
         });
 
@@ -77,8 +78,10 @@ int main(int argc, char **argv)
         future_result.get();
     }
 
-    dc.register_on_timeout([](uint64_t uuid) {
-        std::cout << "Device with UUID timed out: " << uuid << std::endl;
+    dc.register_on_timeout([](uint64_t uuid, uint8_t component_id) {
+        std::cout << "Device with UUID: " << uuid
+                  << " and Component ID: " << int(component_id)
+                  << " timed out: " << std::endl;
         std::cout << "Exiting." << std::endl;
         exit(0);
     });
@@ -86,7 +89,7 @@ int main(int argc, char **argv)
     // We don't need to specify the UUID if it's only one device anyway.
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     std::shared_ptr<Action> action = std::make_shared<Action>(&device);
     std::shared_ptr<Mission> mission = std::make_shared<Mission>(&device);
     std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -43,13 +43,13 @@ int main(int, char **)
     connection_error_exit(conn_result, "Connection failed");
 
     // Wait for the device to connect via heartbeat
-    while (!dc.is_connected()) {
+    while (!dc.is_autopilot_connected()) {
         std::cout << "Wait for device to connect via heartbeat" << std::endl;
         sleep_for(seconds(1));
     }
 
     // Device got discovered.
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     std::shared_ptr<Action> action = std::make_shared<Action>(&device);
     std::shared_ptr<FollowMe> follow_me = std::make_shared<FollowMe>(&device);
     std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -175,13 +175,13 @@ int main(int, char **)
     connection_error_exit(conn_result, "Connection failed");
 
     // Wait for the device to connect via heartbeat
-    while (!dc.is_connected()) {
+    while (!dc.is_autopilot_connected()) {
         std::cout << "Wait for device to connect via heartbeat" << std::endl;
         sleep_for(seconds(1));
     }
 
     // Device got discovered.
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     std::shared_ptr<Action> action = std::make_shared<Action>(&device);
     std::shared_ptr<Offboard> offboard = std::make_shared<Offboard>(&device);
     std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -44,8 +44,9 @@ int main(int argc, char **argv)
     }
 
     std::cout << "Waiting to discover device..." << std::endl;
-    dc.register_on_discover([&discovered_device](uint64_t uuid) {
-        std::cout << "Discovered device with UUID: " << uuid << std::endl;
+    dc.register_on_discover([&discovered_device](uint64_t uuid, uint8_t component_id) {
+        std::cout << "Discovered device with UUID: " << uuid
+                  << " Component Id: " << int(component_id) << std::endl;
         discovered_device = true;
     });
 
@@ -60,10 +61,8 @@ int main(int argc, char **argv)
     // We don't need to specify the UUID if it's only one device anyway.
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
-    Device &device = dc.device();
-
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot());
+    auto action = std::make_shared<Action>(&dc.autopilot());
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -31,8 +31,9 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     std::cout << "Waiting to discover device..." << std::endl;
-    dc.register_on_discover([&discovered_device](uint64_t uuid) {
-        std::cout << "Discovered device with UUID: " << uuid << std::endl;
+    dc.register_on_discover([&discovered_device](uint64_t uuid, uint8_t component_id) {
+        std::cout << "Discovered device with UUID: " << uuid
+                  << "Component ID: " << int(component_id) << std::endl;
         discovered_device = true;
     });
 
@@ -47,7 +48,7 @@ int main(int /*argc*/, char ** /*argv*/)
     // We don't need to specify the UUID if it's only one device anyway.
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);
 
     // We want to listen to the altitude of the drone at 1 Hz.

--- a/integration_tests/async_connect.cpp
+++ b/integration_tests/async_connect.cpp
@@ -9,9 +9,10 @@ using namespace std::placeholders; // for _1
 static bool _discovered_device = false;
 static bool _timeouted_device = false;
 static uint64_t _uuid = 0;
+static uint8_t _component_id = 0;
 
-void on_discover(uint64_t uuid);
-void on_timeout(uint64_t uuid);
+void on_discover(uint64_t uuid, uint8_t component_id);
+void on_timeout(uint64_t uuid, uint8_t component_id);
 
 TEST_F(SitlTest, AsyncConnect)
 {
@@ -19,8 +20,8 @@ TEST_F(SitlTest, AsyncConnect)
 
     ASSERT_EQ(dc.add_udp_connection(), ConnectionResult::SUCCESS);
 
-    dc.register_on_discover(std::bind(&on_discover, _1));
-    dc.register_on_timeout(std::bind(&on_timeout, _1));
+    dc.register_on_discover(std::bind(&on_discover, _1, _2));
+    dc.register_on_timeout(std::bind(&on_timeout, _1, _2));
 
     while (!_discovered_device) {
         std::cout << "waiting for device to appear..." << std::endl;
@@ -39,20 +40,25 @@ TEST_F(SitlTest, AsyncConnect)
     }
 }
 
-void on_discover(uint64_t uuid)
+void on_discover(uint64_t uuid, uint8_t component_id)
 {
-    std::cout << "Found device with UUID: " << uuid << std::endl;
+    std::cout << "Found component " << int(component_id)
+              << " on device with UUID: " << uuid << std::endl;
     _discovered_device = true;
     _uuid = uuid;
-    // The UUID should not be 0.
+    _component_id = component_id;
+    // The UUID and Component ID should not be 0.
     EXPECT_NE(_uuid, 0);
+    EXPECT_NE(_component_id, 0);
 }
 
-void on_timeout(uint64_t uuid)
+void on_timeout(uint64_t uuid, uint8_t component_id)
 {
-    std::cout << "Lost device with UUID: " << uuid << std::endl;
+    std::cout << "Lost component " << int(component_id)
+              << " on device with UUID: " << uuid << std::endl;
     _timeouted_device = true;
 
-    // The UUID should still be the same.
+    // The UUID and Component ID should still be the same.
     EXPECT_EQ(_uuid, uuid);
+    EXPECT_EQ(_component_id, component_id);
 }

--- a/integration_tests/async_hover.cpp
+++ b/integration_tests/async_hover.cpp
@@ -26,13 +26,12 @@ TEST_F(SitlTest, ActionAsyncHover)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // TODO: this test is pretty dumb, should be improved with more checks.
-    Device &device = dc.device();
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot());
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
     telemetry->health_all_ok_async(std::bind(&receive_health_all_ok, _1));
     telemetry->in_air_async(std::bind(&receive_in_air, _1));
 
-    auto action = std::make_shared<Action>(&device);
+    auto action = std::make_shared<Action>(&dc.autopilot());
 
     while (!_all_ok) {
         std::cout << "Waiting to be ready..." << std::endl;

--- a/integration_tests/follow_me.cpp
+++ b/integration_tests/follow_me.cpp
@@ -30,7 +30,7 @@ TEST_F(SitlTest, FollowMeOneLocation)
 
     // Wait for device to connect via heartbeat.
     sleep_for(seconds(2));
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto follow_me = std::make_shared<FollowMe>(&device);
     auto action = std::make_shared<Action>(&device);
@@ -90,7 +90,7 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
 
     // Wait for device to connect via heartbeat.
     sleep_for(seconds(2));
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto follow_me = std::make_shared<FollowMe>(&device);
     auto action = std::make_shared<Action>(&device);

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -28,7 +28,7 @@ TEST_F(SitlTest, GimbalMove)
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto gimbal = std::make_shared<Gimbal>(&device);
 
@@ -54,7 +54,7 @@ TEST_F(SitlTest, GimbalTakeoffAndMove)
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto gimbal = std::make_shared<Gimbal>(&device);
     auto action = std::make_shared<Action>(&device);

--- a/integration_tests/logging.cpp
+++ b/integration_tests/logging.cpp
@@ -14,8 +14,7 @@ TEST_F(SitlTest, Logging)
 
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
-    auto logging = std::make_shared<Logging>(&device);
+    auto logging = std::make_shared<Logging>(&dc.autopilot());
     Logging::Result log_ret = logging->start_logging();
 
     if (log_ret == Logging::Result::COMMAND_DENIED) {

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -39,8 +39,9 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
         auto future_result = prom->get_future();
 
         LogInfo() << "Waiting to discover device...";
-        dc.register_on_discover([prom](uint64_t uuid) {
-            LogInfo() << "Discovered device with UUID: " << uuid;
+        dc.register_on_discover([prom](uint64_t uuid, uint8_t component_id) {
+            LogInfo() << "Discovered device with UUID: " << uuid
+                      << " Component ID: " << component_id;
             prom->set_value();
         });
 
@@ -50,8 +51,7 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
         future_result.get();
     }
 
-
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto mission = std::make_shared<Mission>(&device);
     auto action = std::make_shared<Action>(&device);

--- a/integration_tests/mission_change_speed.cpp
+++ b/integration_tests/mission_change_speed.cpp
@@ -40,7 +40,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto mission = std::make_shared<Mission>(&device);
     auto action = std::make_shared<Action>(&device);

--- a/integration_tests/mission_survey.cpp
+++ b/integration_tests/mission_survey.cpp
@@ -57,7 +57,7 @@ TEST_F(SitlTest, MissionSurvey)
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto mission = std::make_shared<Mission>(&device);
     auto action = std::make_shared<Action>(&device);

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -20,7 +20,7 @@ TEST_F(SitlTest, OffboardVelocityNED)
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto action = std::make_shared<Action>(&device);
     auto offboard = std::make_shared<Offboard>(&device);
@@ -116,7 +116,7 @@ TEST_F(SitlTest, OffboardVelocityBody)
 
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
 
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto action = std::make_shared<Action>(&device);

--- a/integration_tests/simple_hover.cpp
+++ b/integration_tests/simple_hover.cpp
@@ -35,11 +35,10 @@ void takeoff_and_hover_at_altitude(float altitude_m)
 
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
-    ASSERT_TRUE(dc.is_connected());
+    ASSERT_TRUE(dc.is_autopilot_connected());
 
-    Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot());
+    auto action = std::make_shared<Action>(&dc.autopilot());
 
     int iteration = 0;
     while (!telemetry->health_all_ok()) {

--- a/integration_tests/takeoff_and_kill.cpp
+++ b/integration_tests/takeoff_and_kill.cpp
@@ -9,7 +9,8 @@ using namespace dronecore;
 
 static bool _discovered_device = false;
 static uint64_t _uuid = 0;
-static void on_discover(uint64_t uuid);
+static uint8_t _component_id = 0;
+static void on_discover(uint64_t uuid, uint8_t component_id);
 
 static bool _received_arm_result = false;
 static bool _received_takeoff_result = false;
@@ -38,10 +39,12 @@ void receive_kill_result(Action::Result result)
 }
 
 
-void on_discover(uint64_t uuid)
+void on_discover(uint64_t uuid, uint8_t component_id)
 {
-    std::cout << "Found device with UUID: " << uuid << std::endl;
+    std::cout << "Found device with UUID: " << uuid
+              << " Component ID: " << component_id;
     _uuid = uuid;
+    _component_id = component_id;
     _discovered_device = true;
 }
 
@@ -50,11 +53,11 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
     DroneCore dc;
     ASSERT_EQ(dc.add_udp_connection(), ConnectionResult::SUCCESS);
 
-    dc.register_on_discover(std::bind(&on_discover, _1));
+    dc.register_on_discover(std::bind(&on_discover, _1, _2));
     std::this_thread::sleep_for(std::chrono::seconds(5));
     ASSERT_TRUE(_discovered_device);
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto telemetry = std::make_shared<Telemetry>(&device);
     auto action = std::make_shared<Action>(&device);
 

--- a/integration_tests/telemetry_async.cpp
+++ b/integration_tests/telemetry_async.cpp
@@ -62,9 +62,7 @@ TEST_F(SitlTest, TelemetryAsync)
 
     ASSERT_EQ(ret, ConnectionResult::SUCCESS);
 
-    Device &device = dc.device(uuid);
-
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot(uuid));
 
     telemetry->set_rate_position_async(10.0, std::bind(&receive_result, _1));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/integration_tests/telemetry_health.cpp
+++ b/integration_tests/telemetry_health.cpp
@@ -15,9 +15,7 @@ TEST_F(SitlTest, TelemetryHealth)
     ASSERT_EQ(ret, ConnectionResult::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
-
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot());
 
     telemetry->health_async(std::bind(&print_health, std::placeholders::_1));
     std::this_thread::sleep_for(std::chrono::seconds(3));

--- a/integration_tests/telemetry_modes.cpp
+++ b/integration_tests/telemetry_modes.cpp
@@ -17,10 +17,8 @@ TEST_F(SitlTest, TelemetryFlightModes)
     ASSERT_EQ(ret, ConnectionResult::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    Device &device = dc.device();
-
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot());
+    auto action = std::make_shared<Action>(&dc.autopilot());
 
     telemetry->flight_mode_async(
         std::bind(&print_mode, std::placeholders::_1));

--- a/integration_tests/telemetry_simple.cpp
+++ b/integration_tests/telemetry_simple.cpp
@@ -13,9 +13,8 @@ TEST_F(SitlTest, TelemetrySimple)
     ASSERT_EQ(ret, ConnectionResult::SUCCESS);
 
     std::this_thread::sleep_for(std::chrono::seconds(2));
-    Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(&dc.autopilot());
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;

--- a/integration_tests/transition_multicopter_fixedwing.cpp
+++ b/integration_tests/transition_multicopter_fixedwing.cpp
@@ -28,9 +28,9 @@ void takeoff_and_transition_to_fixedwing()
 
     // Wait for device to connect via heartbeat.
     std::this_thread::sleep_for(std::chrono::seconds(2));
-    ASSERT_TRUE(dc.is_connected());
+    ASSERT_TRUE(dc.is_autopilot_connected());
 
-    Device &device = dc.device();
+    Device &device = dc.autopilot();
     auto action = std::make_shared<Action>(&device);
     auto telemetry = std::make_shared<Telemetry>(&device);
 


### PR DESCRIPTION
**This is the pull request that makes DroneCore to handle multiple components.**



![image](https://user-images.githubusercontent.com/26615772/37065892-ea09b21c-21c8-11e8-8e7c-f43f472724d4.png)

New changes in **core**:

1. DroneCore will now maintain `std::map<uint8_t, std::vector<Device*>>`
2. All the components may share same UDP connection port (For eg: Both Autopilot and other components may send MAVLink messages on the same port)

1. As per existing model, `device_thread` continue to exist per component that deals with sending MAVLink commands over the same connection. This makes camera component to get connected.

New interface in DroneCore:
```cpp
// Return reference to autopilot device of the given system UUID
Device &autopilot(uint64_t uuid);

// Return reference to autopilot device of the first system
Device &autopilot();

// Returns vector of camera ids on the given system UUID
std::vector<uint8_t> camera_ids(uint64_t uuid);

// Returns vector of camera ids on the first system
std::vector<uint8_t> camera_ids();

// Returns reference to camera device #camera_id of the given system UUID
Device &camera(uint64_t uuid, uint8_t camera_id);

// Returns reference to first camera device on the given system UUID
Device &camera(uint64_t uuid);

// Returns reference to first camera device on the first connected system
Device &camera();

// Checks whether first camera on the first vehicle is connected.
bool is_camera_connected();

// Checks whether first vehicle is connected.
bool is_autopilot_connected();

```

Resulting camera application code would be:
```cpp
DroneCore connection;

connection.add_udp_connection(14550); // common port for all the components of the system

while (!connection.is_autopilot_connected() ||
       !connection.is_camera_connected())
    sleep_for(seconds(1));

auto offboard = std::make_shared<Offboard>(connection.autopilot());
auto camera = std::make_shared<Camera>(connection.camera());

...
```
