### PR TITLE
device: fix reconnect

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -386,9 +386,6 @@ void Device::set_disconnected()
 
         _connected = false;
         _parent->notify_on_timeout(_target_uuid);
-
-        // Let's reset the flag hope again for the next time we see this target.
-        _target_uuid_initialized = false;
     }
 
     {


### PR DESCRIPTION
This fix was merged earlier but somehow snuck back.

If we reset this flag but don't set the actual UUID to 0, we won't ever
request it again and therefore won't ever discover a device again that
we have discovered before.

This was already removed in #215 but somehow it came back.

@JonasVautherin maybe in a merge? Or was this on purpose?