### PR TITLE
Make use of smart pointers and references

### DIFF
--- a/core/connection.cpp
+++ b/core/connection.cpp
@@ -5,7 +5,7 @@
 
 namespace dronecore {
 
-Connection::Connection(DroneCoreImpl *parent) :
+Connection::Connection(DroneCoreImpl &parent) :
     _parent(parent),
     _mavlink_receiver() {}
 
@@ -39,7 +39,7 @@ void Connection::stop_mavlink_receiver()
 
 void Connection::receive_message(const mavlink_message_t &message)
 {
-    _parent->receive_message(message);
+    _parent.receive_message(message);
 }
 
 } // namespace dronecore

--- a/core/connection.h
+++ b/core/connection.h
@@ -11,7 +11,7 @@ class DroneCoreImpl;
 class Connection
 {
 public:
-    Connection(DroneCoreImpl *parent);
+    Connection(DroneCoreImpl &parent);
     virtual ~Connection();
 
     virtual ConnectionResult start() = 0;
@@ -28,7 +28,7 @@ protected:
     bool start_mavlink_receiver();
     void stop_mavlink_receiver();
     void receive_message(const mavlink_message_t &message);
-    DroneCoreImpl *_parent;
+    DroneCoreImpl &_parent;
     std::unique_ptr<MavlinkReceiver> _mavlink_receiver;
 
     //void received_mavlink_message(mavlink_message_t &);

--- a/core/device.h
+++ b/core/device.h
@@ -32,7 +32,7 @@ public:
         OFFBOARD,
     };
 
-    explicit Device(DroneCoreImpl *parent,
+    explicit Device(DroneCoreImpl &parent,
                     uint8_t target_system_id);
     ~Device();
 
@@ -130,7 +130,7 @@ private:
     void set_disconnected();
 
     static void device_thread(Device *self);
-    static void send_heartbeat(Device *self);
+    static void send_heartbeat(Device &self);
 
     static void receive_float_param(bool success, MavlinkParameters::ParamValue value,
                                     get_param_float_callback_t callback);
@@ -159,7 +159,7 @@ private:
     std::atomic<bool> _armed {false};
     std::atomic<bool> _hitl_enabled {false};
 
-    DroneCoreImpl *_parent;
+    DroneCoreImpl &_parent;
 
     command_result_callback_t _command_result_callback {nullptr};
 

--- a/core/dronecore.cpp
+++ b/core/dronecore.cpp
@@ -6,15 +6,12 @@
 namespace dronecore {
 
 DroneCore::DroneCore() :
-    _impl(nullptr)
+    _impl { new DroneCoreImpl() }
 {
-    _impl = new DroneCoreImpl();
 }
 
 DroneCore::~DroneCore()
 {
-    delete _impl;
-    _impl = nullptr;
 }
 
 ConnectionResult DroneCore::add_any_connection(const std::string &connection_url)

--- a/core/dronecore.h
+++ b/core/dronecore.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <memory>
 #include <vector>
 #include <functional>
 
@@ -174,7 +175,7 @@ public:
 
 private:
     /* @private. */
-    DroneCoreImpl *_impl;
+    std::unique_ptr<DroneCoreImpl> _impl;
 
     // Non-copyable
     DroneCore(const DroneCore &) = delete;

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -169,7 +169,7 @@ ConnectionResult DroneCoreImpl::add_link_connection(const std::string &protocol,
 
 ConnectionResult DroneCoreImpl::add_udp_connection(const int local_port_number)
 {
-    Connection *new_connection = new UdpConnection(this, local_port_number);
+    Connection *new_connection = new UdpConnection(*this, local_port_number);
     ConnectionResult ret = new_connection->start();
 
     if (ret != ConnectionResult::SUCCESS) {
@@ -190,7 +190,7 @@ void DroneCoreImpl::add_connection(Connection *new_connection)
 ConnectionResult DroneCoreImpl::add_tcp_connection(const std::string &remote_ip,
                                                    const int remote_port)
 {
-    Connection *new_connection = new TcpConnection(this, remote_ip, remote_port);
+    Connection *new_connection = new TcpConnection(*this, remote_ip, remote_port);
     ConnectionResult ret = new_connection->start();
 
     if (ret != ConnectionResult::SUCCESS) {
@@ -206,7 +206,7 @@ ConnectionResult DroneCoreImpl::add_serial_connection(const std::string &dev_pat
                                                       const int baudrate)
 {
 #if !defined(WINDOWS) && !defined(APPLE)
-    Connection *new_connection = new SerialConnection(this, dev_path, baudrate);
+    Connection *new_connection = new SerialConnection(*this, dev_path, baudrate);
     ConnectionResult ret = new_connection->start();
 
     if (ret != ConnectionResult::SUCCESS) {
@@ -330,7 +330,7 @@ void DroneCoreImpl::create_device_if_not_existing(const uint8_t system_id)
     }
 
     // Create both lists in parallel
-    Device *new_device = new Device(this, system_id);
+    Device *new_device = new Device(*this, system_id);
     _devices.insert(std::pair<uint8_t, Device *>(system_id, new_device));
 }
 

--- a/core/dronecore_impl.h
+++ b/core/dronecore_impl.h
@@ -23,7 +23,7 @@ public:
     ConnectionResult add_link_connection(const std::string &protocol, const std::string &ip,
                                          int port);
     ConnectionResult add_udp_connection(int local_port_number);
-    void add_connection(Connection *connection);
+    void add_connection(std::shared_ptr<Connection>);
     ConnectionResult add_tcp_connection(const std::string &remote_ip, int remote_port);
     ConnectionResult add_serial_connection(const std::string &dev_path, int baudrate);
 
@@ -43,11 +43,13 @@ public:
 private:
     void create_device_if_not_existing(uint8_t system_id);
 
+    using system_entry_t = std::pair<uint8_t, std::shared_ptr<Device>>;
+
     std::mutex _connections_mutex;
-    std::vector<Connection *> _connections;
+    std::vector<std::shared_ptr<Connection>> _connections;
 
     mutable std::recursive_mutex _devices_mutex;
-    std::map<uint8_t, Device *> _devices;
+    std::map<uint8_t, std::shared_ptr<Device>> _devices;
 
     DroneCore::event_callback_t _on_discover_callback;
     DroneCore::event_callback_t _on_timeout_callback;

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -17,10 +17,10 @@ namespace dronecore {
 //       - The queue used does not support going through and checking each and every
 //         item yet.
 
-MavlinkCommands::MavlinkCommands(Device *parent) :
+MavlinkCommands::MavlinkCommands(Device &parent) :
     _parent(parent)
 {
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_COMMAND_ACK,
         std::bind(&MavlinkCommands::receive_command_ack,
                   this, std::placeholders::_1), this);
@@ -28,7 +28,7 @@ MavlinkCommands::MavlinkCommands(Device *parent) :
 
 MavlinkCommands::~MavlinkCommands()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 MavlinkCommands::Result MavlinkCommands::send_command(uint16_t command,
@@ -80,8 +80,8 @@ void MavlinkCommands::queue_command_async(uint16_t command,
     //         << (int)target_component_id;
 
     Work new_work {};
-    mavlink_msg_command_long_pack(_parent->get_own_system_id(),
-                                  _parent->get_own_component_id(),
+    mavlink_msg_command_long_pack(_parent.get_own_system_id(),
+                                  _parent.get_own_component_id(),
                                   &new_work.mavlink_message,
                                   target_system_id,
                                   target_component_id,
@@ -171,8 +171,8 @@ void MavlinkCommands::receive_command_ack(mavlink_message_t message)
             // has arrived. A possible timeout for this case is the initial
             // timeout * the possible retries because this should match the
             // case where there is no progress update and we keep trying.
-            _parent->unregister_timeout_handler(_timeout_cookie);
-            _parent->register_timeout_handler(
+            _parent.unregister_timeout_handler(_timeout_cookie);
+            _parent.register_timeout_handler(
                 std::bind(&MavlinkCommands::receive_timeout, this),
                 work.retries_to_do * work.timeout_s, &_timeout_cookie);
             break;
@@ -197,7 +197,7 @@ void MavlinkCommands::receive_timeout()
             LogInfo() << "sending again, retries to do: " << work.retries_to_do
                       << "  (" << work.mavlink_command << ").";
             // We're not sure the command arrived, let's retransmit.
-            if (!_parent->send_message(work.mavlink_message)) {
+            if (!_parent.send_message(work.mavlink_message)) {
                 LogErr() << "connection send error in retransmit (" << work.mavlink_command << ").";
                 if (work.callback) {
                     work.callback(Result::CONNECTION_ERROR, NAN);
@@ -205,7 +205,7 @@ void MavlinkCommands::receive_timeout()
                 _state = State::FAILED;
             } else {
                 --work.retries_to_do;
-                _parent->register_timeout_handler(
+                _parent.register_timeout_handler(
                     std::bind(&MavlinkCommands::receive_timeout, this),
                     work.timeout_s, &_timeout_cookie);
             }
@@ -239,7 +239,7 @@ void MavlinkCommands::do_work()
         case State::DONE:
         // FALLTHROUGH
         case State::FAILED:
-            _parent->unregister_timeout_handler(_timeout_cookie);
+            _parent.unregister_timeout_handler(_timeout_cookie);
             _work_queue.pop_front();
             _state = State::NONE;
             break;
@@ -258,7 +258,7 @@ void MavlinkCommands::do_work()
     switch (_state) {
         case State::NONE:
             // LogDebug() << "sending it the first time (" << work.mavlink_command << ")";
-            if (!_parent->send_message(work.mavlink_message)) {
+            if (!_parent.send_message(work.mavlink_message)) {
                 LogErr() << "connection send error (" << work.mavlink_command << ")";
                 if (work.callback) {
                     work.callback(Result::CONNECTION_ERROR, NAN);
@@ -267,7 +267,7 @@ void MavlinkCommands::do_work()
                 break;
             } else {
                 _state = State::WAITING;
-                _parent->register_timeout_handler(
+                _parent.register_timeout_handler(
                     std::bind(&MavlinkCommands::receive_timeout, this),
                     work.timeout_s, &_timeout_cookie);
             }

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -14,7 +14,7 @@ class Device;
 class MavlinkCommands
 {
 public:
-    explicit MavlinkCommands(Device *parent);
+    explicit MavlinkCommands(Device &parent);
     ~MavlinkCommands();
 
     enum class Result {
@@ -74,7 +74,7 @@ private:
     void receive_command_ack(mavlink_message_t message);
     void receive_timeout();
 
-    Device *_parent;
+    Device &_parent;
     LockedQueue<Work> _work_queue {};
 
     void *_timeout_cookie = nullptr;

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -17,7 +17,7 @@ class Device;
 class MavlinkParameters
 {
 public:
-    explicit MavlinkParameters(Device *parent);
+    explicit MavlinkParameters(Device &parent);
     ~MavlinkParameters();
 
     class ParamValue
@@ -159,7 +159,7 @@ private:
     void process_param_ext_ack(const mavlink_message_t &message);
     void receive_timeout();
 
-    Device *_parent;
+    Device &_parent;
 
     enum class State {
         NONE,

--- a/core/plugin_impl_base.cpp
+++ b/core/plugin_impl_base.cpp
@@ -5,7 +5,7 @@
 
 namespace dronecore {
 
-PluginImplBase::PluginImplBase(Device *device) :
+PluginImplBase::PluginImplBase(Device &device) :
     _parent(device) {}
 
 } // namespace dronecore

--- a/core/plugin_impl_base.h
+++ b/core/plugin_impl_base.h
@@ -7,7 +7,7 @@ class Device;
 class PluginImplBase
 {
 public:
-    explicit PluginImplBase(Device *device);
+    explicit PluginImplBase(Device &device);
     virtual ~PluginImplBase() = default;
 
     /*
@@ -56,7 +56,7 @@ public:
     const PluginImplBase &operator=(const PluginImplBase &) = delete;
 
 protected:
-    Device *_parent;
+    Device &_parent;
 };
 
 } // namespace dronecore

--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -19,7 +19,7 @@
 
 namespace dronecore {
 
-SerialConnection::SerialConnection(DroneCoreImpl *parent, const std::string &path, int baudrate) :
+SerialConnection::SerialConnection(DroneCoreImpl &parent, const std::string &path, int baudrate) :
     Connection(parent),
     _serial_node(path),
     _baudrate(baudrate)

--- a/core/serial_connection.h
+++ b/core/serial_connection.h
@@ -10,7 +10,7 @@ namespace dronecore {
 class SerialConnection : public Connection
 {
 public:
-    explicit SerialConnection(DroneCoreImpl *parent, const std::string &path, int baudrate);
+    explicit SerialConnection(DroneCoreImpl &parent, const std::string &path, int baudrate);
     bool is_ok() const;
     ConnectionResult start();
     ConnectionResult stop();

--- a/core/tcp_connection.cpp
+++ b/core/tcp_connection.cpp
@@ -22,7 +22,7 @@
 namespace dronecore {
 
 /* change to remote_ip and remote_port */
-TcpConnection::TcpConnection(DroneCoreImpl *parent, const std::string &remote_ip, int remote_port) :
+TcpConnection::TcpConnection(DroneCoreImpl &parent, const std::string &remote_ip, int remote_port) :
     Connection(parent),
     _remote_ip(remote_ip),
     _remote_port_number(remote_port),

--- a/core/tcp_connection.h
+++ b/core/tcp_connection.h
@@ -18,7 +18,7 @@ namespace dronecore {
 class TcpConnection : public Connection
 {
 public:
-    explicit TcpConnection(DroneCoreImpl *parent, const std::string &ip, int port_number);
+    explicit TcpConnection(DroneCoreImpl &parent, const std::string &ip, int port_number);
     ~TcpConnection();
     bool is_ok() const;
     ConnectionResult start();

--- a/core/udp_connection.cpp
+++ b/core/udp_connection.cpp
@@ -25,7 +25,7 @@
 
 namespace dronecore {
 
-UdpConnection::UdpConnection(DroneCoreImpl *parent,
+UdpConnection::UdpConnection(DroneCoreImpl &parent,
                              int local_port_number) :
     Connection(parent),
     _local_port_number(local_port_number) {}

--- a/core/udp_connection.h
+++ b/core/udp_connection.h
@@ -12,7 +12,7 @@ namespace dronecore {
 class UdpConnection : public Connection
 {
 public:
-    explicit UdpConnection(DroneCoreImpl *parent, int local_port_number);
+    explicit UdpConnection(DroneCoreImpl &parent, int local_port_number);
     ~UdpConnection();
     bool is_ok() const;
     ConnectionResult start();

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -78,9 +78,9 @@ int main(int /*argc*/, char ** /*argv*/)
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
     Device &device = dc.device();
-    std::shared_ptr<Action> action = std::make_shared<Action>(&device);
-    std::shared_ptr<Mission> mission = std::make_shared<Mission>(&device);
-    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);
+    std::shared_ptr<Action> action = std::make_shared<Action>(device);
+    std::shared_ptr<Mission> mission = std::make_shared<Mission>(device);
+    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "Waiting for device to be ready" << std::endl;

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -87,9 +87,9 @@ int main(int argc, char **argv)
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
     Device &device = dc.device();
-    std::shared_ptr<Action> action = std::make_shared<Action>(&device);
-    std::shared_ptr<Mission> mission = std::make_shared<Mission>(&device);
-    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);
+    std::shared_ptr<Action> action = std::make_shared<Action>(device);
+    std::shared_ptr<Mission> mission = std::make_shared<Mission>(device);
+    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "Waiting for device to be ready" << std::endl;

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -50,9 +50,9 @@ int main(int, char **)
 
     // Device got discovered.
     Device &device = dc.device();
-    std::shared_ptr<Action> action = std::make_shared<Action>(&device);
-    std::shared_ptr<FollowMe> follow_me = std::make_shared<FollowMe>(&device);
-    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);
+    std::shared_ptr<Action> action = std::make_shared<Action>(device);
+    std::shared_ptr<FollowMe> follow_me = std::make_shared<FollowMe>(device);
+    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "Waiting for device to be ready" << std::endl;

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -182,9 +182,9 @@ int main(int, char **)
 
     // Device got discovered.
     Device &device = dc.device();
-    std::shared_ptr<Action> action = std::make_shared<Action>(&device);
-    std::shared_ptr<Offboard> offboard = std::make_shared<Offboard>(&device);
-    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);
+    std::shared_ptr<Action> action = std::make_shared<Action>(device);
+    std::shared_ptr<Offboard> offboard = std::make_shared<Offboard>(device);
+    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "Waiting for device to be ready" << std::endl;

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -62,8 +62,8 @@ int main(int argc, char **argv)
     // dc.device(uint64_t uuid);
     Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto action = std::make_shared<Action>(device);
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -48,7 +48,7 @@ int main(int /*argc*/, char ** /*argv*/)
     // If there were multiple, we could specify it with:
     // dc.device(uint64_t uuid);
     Device &device = dc.device();
-    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(&device);
+    std::shared_ptr<Telemetry> telemetry = std::make_shared<Telemetry>(device);
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);
@@ -74,7 +74,7 @@ int main(int /*argc*/, char ** /*argv*/)
         return 1;
     }
 
-    std::shared_ptr<Action> action = std::make_shared<Action>(&device);
+    std::shared_ptr<Action> action = std::make_shared<Action>(device);
 
     // Arm vehicle
     std::cout << "Arming..." << std::endl;

--- a/external_example/integration_tests/CMakeLists.txt
+++ b/external_example/integration_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(external_example_integration_tests_runner
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/core
+    ${CMAKE_SOURCE_DIR}/external_example
 )
 
 target_link_libraries(external_example_integration_tests_runner

--- a/external_example/integration_tests/hello_world.cpp
+++ b/external_example/integration_tests/hello_world.cpp
@@ -18,7 +18,7 @@ TEST_F(SitlTest, ExampleHello)
     ASSERT_TRUE(dc.is_connected());
 
     Device &device = dc.device();
-    auto example = std::make_shared<Example>(&device);
+    auto example = std::make_shared<Example>(device);
 
     // Apparently it can say hello.
     example->say_hello();

--- a/external_example/plugins/example/example.cpp
+++ b/external_example/plugins/example/example.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Example::Example(Device *device) :
+Example::Example(Device &device) :
     PluginBase()
 {
     _impl = new ExampleImpl(device);

--- a/external_example/plugins/example/example.h
+++ b/external_example/plugins/example/example.h
@@ -10,7 +10,7 @@ class ExampleImpl;
 class Example : public PluginBase
 {
 public:
-    explicit Example(Device *device);
+    explicit Example(Device &device);
     ~Example();
 
     void say_hello() const;

--- a/external_example/plugins/example/example_impl.cpp
+++ b/external_example/plugins/example/example_impl.cpp
@@ -4,29 +4,29 @@
 
 namespace dronecore {
 
-ExampleImpl::ExampleImpl(Device *device) :
+ExampleImpl::ExampleImpl(Device &device) :
     PluginImplBase(device)
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 ExampleImpl::~ExampleImpl()
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 void ExampleImpl::init()
 {
     using namespace std::placeholders; // for `_1`
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&ExampleImpl::process_heartbeat, this, _1), this);
 }
 
 void ExampleImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void ExampleImpl::enable() {}

--- a/external_example/plugins/example/example_impl.h
+++ b/external_example/plugins/example/example_impl.h
@@ -10,7 +10,7 @@ namespace dronecore {
 class ExampleImpl : public PluginImplBase
 {
 public:
-    ExampleImpl(Device *device);
+    ExampleImpl(Device &device);
     ~ExampleImpl();
 
     void say_hello() const;

--- a/integration_tests/async_hover.cpp
+++ b/integration_tests/async_hover.cpp
@@ -28,11 +28,11 @@ TEST_F(SitlTest, ActionAsyncHover)
     // TODO: this test is pretty dumb, should be improved with more checks.
     Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
     telemetry->health_all_ok_async(std::bind(&receive_health_all_ok, _1));
     telemetry->in_air_async(std::bind(&receive_in_air, _1));
 
-    auto action = std::make_shared<Action>(&device);
+    auto action = std::make_shared<Action>(device);
 
     while (!_all_ok) {
         std::cout << "Waiting to be ready..." << std::endl;

--- a/integration_tests/follow_me.cpp
+++ b/integration_tests/follow_me.cpp
@@ -31,9 +31,9 @@ TEST_F(SitlTest, FollowMeOneLocation)
     // Wait for device to connect via heartbeat.
     sleep_for(seconds(2));
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto follow_me = std::make_shared<FollowMe>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto follow_me = std::make_shared<FollowMe>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;
@@ -91,9 +91,9 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
     // Wait for device to connect via heartbeat.
     sleep_for(seconds(2));
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto follow_me = std::make_shared<FollowMe>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto follow_me = std::make_shared<FollowMe>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "Waiting for device to be ready" << std::endl;

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -29,8 +29,8 @@ TEST_F(SitlTest, GimbalMove)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto gimbal = std::make_shared<Gimbal>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto gimbal = std::make_shared<Gimbal>(device);
 
     telemetry->set_rate_camera_attitude(10.0);
 
@@ -55,9 +55,9 @@ TEST_F(SitlTest, GimbalTakeoffAndMove)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto gimbal = std::make_shared<Gimbal>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto gimbal = std::make_shared<Gimbal>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         LogInfo() << "waiting for device to be ready";

--- a/integration_tests/info.cpp
+++ b/integration_tests/info.cpp
@@ -24,7 +24,7 @@ TEST_F(SitlTest, Info)
 
 
     Device &device = dc.device();
-    auto info = std::make_shared<Info>(&device);
+    auto info = std::make_shared<Info>(device);
 
     for (unsigned i = 0; i < 3; ++i) {
         Info::Version version = info->get_version();

--- a/integration_tests/logging.cpp
+++ b/integration_tests/logging.cpp
@@ -15,7 +15,7 @@ TEST_F(SitlTest, Logging)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     Device &device = dc.device();
-    auto logging = std::make_shared<Logging>(&device);
+    auto logging = std::make_shared<Logging>(device);
     Logging::Result log_ret = logging->start_logging();
 
     if (log_ret == Logging::Result::COMMAND_DENIED) {

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -52,9 +52,9 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
 
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto mission = std::make_shared<Mission>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto mission = std::make_shared<Mission>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         LogInfo() << "Waiting for device to be ready";

--- a/integration_tests/mission_change_speed.cpp
+++ b/integration_tests/mission_change_speed.cpp
@@ -41,9 +41,9 @@ TEST_F(SitlTest, MissionChangeSpeed)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto mission = std::make_shared<Mission>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto mission = std::make_shared<Mission>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;

--- a/integration_tests/mission_survey.cpp
+++ b/integration_tests/mission_survey.cpp
@@ -58,9 +58,9 @@ TEST_F(SitlTest, MissionSurvey)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto mission = std::make_shared<Mission>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto mission = std::make_shared<Mission>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -21,10 +21,10 @@ TEST_F(SitlTest, OffboardVelocityNED)
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
-    auto offboard = std::make_shared<Offboard>(&device);
-    auto mission = std::make_shared<Mission>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto action = std::make_shared<Action>(device);
+    auto offboard = std::make_shared<Offboard>(device);
+    auto mission = std::make_shared<Mission>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;
@@ -118,9 +118,9 @@ TEST_F(SitlTest, OffboardVelocityBody)
     std::this_thread::sleep_for(std::chrono::seconds(2));
     Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
-    auto offboard = std::make_shared<Offboard>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto action = std::make_shared<Action>(device);
+    auto offboard = std::make_shared<Offboard>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;

--- a/integration_tests/simple_hover.cpp
+++ b/integration_tests/simple_hover.cpp
@@ -38,8 +38,8 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     ASSERT_TRUE(dc.is_connected());
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto action = std::make_shared<Action>(device);
 
     int iteration = 0;
     while (!telemetry->health_all_ok()) {

--- a/integration_tests/takeoff_and_kill.cpp
+++ b/integration_tests/takeoff_and_kill.cpp
@@ -55,8 +55,8 @@ TEST_F(SitlTest, ActionTakeoffAndKill)
     ASSERT_TRUE(_discovered_device);
 
     Device &device = dc.device();
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto action = std::make_shared<Action>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;

--- a/integration_tests/telemetry_async.cpp
+++ b/integration_tests/telemetry_async.cpp
@@ -64,7 +64,7 @@ TEST_F(SitlTest, TelemetryAsync)
 
     Device &device = dc.device(uuid);
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
 
     telemetry->set_rate_position_async(10.0, std::bind(&receive_result, _1));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/integration_tests/telemetry_health.cpp
+++ b/integration_tests/telemetry_health.cpp
@@ -17,7 +17,7 @@ TEST_F(SitlTest, TelemetryHealth)
 
     Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
 
     telemetry->health_async(std::bind(&print_health, std::placeholders::_1));
     std::this_thread::sleep_for(std::chrono::seconds(3));

--- a/integration_tests/telemetry_modes.cpp
+++ b/integration_tests/telemetry_modes.cpp
@@ -19,8 +19,8 @@ TEST_F(SitlTest, TelemetryFlightModes)
 
     Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
-    auto action = std::make_shared<Action>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto action = std::make_shared<Action>(device);
 
     telemetry->flight_mode_async(
         std::bind(&print_mode, std::placeholders::_1));

--- a/integration_tests/telemetry_simple.cpp
+++ b/integration_tests/telemetry_simple.cpp
@@ -15,7 +15,7 @@ TEST_F(SitlTest, TelemetrySimple)
     std::this_thread::sleep_for(std::chrono::seconds(2));
     Device &device = dc.device();
 
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto telemetry = std::make_shared<Telemetry>(device);
 
     while (!telemetry->health_all_ok()) {
         std::cout << "waiting for device to be ready" << std::endl;

--- a/integration_tests/transition_multicopter_fixedwing.cpp
+++ b/integration_tests/transition_multicopter_fixedwing.cpp
@@ -31,8 +31,8 @@ void takeoff_and_transition_to_fixedwing()
     ASSERT_TRUE(dc.is_connected());
 
     Device &device = dc.device();
-    auto action = std::make_shared<Action>(&device);
-    auto telemetry = std::make_shared<Telemetry>(&device);
+    auto action = std::make_shared<Action>(device);
+    auto telemetry = std::make_shared<Telemetry>(device);
 
     // We need to takeoff first, otherwise we can't actually transition
     LogInfo() << "Taking off";

--- a/plugins/action/action.cpp
+++ b/plugins/action/action.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 Action::Action(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new ActionImpl(device) }
 {
-    _impl = new ActionImpl(device);
 }
 
 Action::~Action()
 {
-    delete _impl;
 }
 
 Action::Result Action::arm() const

--- a/plugins/action/action.cpp
+++ b/plugins/action/action.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Action::Action(Device *device) :
+Action::Action(Device &device) :
     PluginBase()
 {
     _impl = new ActionImpl(device);

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -29,12 +29,12 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto action = std::make_shared<Action>(&device);
+     *     auto action = std::make_shared<Action>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Action(Device *device);
+    explicit Action(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -281,7 +282,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    ActionImpl *_impl;
+    std::unique_ptr<ActionImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/action/action_impl.h
+++ b/plugins/action/action_impl.h
@@ -11,7 +11,7 @@ namespace dronecore {
 class ActionImpl : public PluginImplBase
 {
 public:
-    ActionImpl(Device *device);
+    ActionImpl(Device &device);
     ~ActionImpl();
 
     void init() override;

--- a/plugins/follow_me/follow_me.cpp
+++ b/plugins/follow_me/follow_me.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-FollowMe::FollowMe(Device *device) :
+FollowMe::FollowMe(Device &device) :
     PluginBase()
 {
     _impl = new FollowMeImpl(device);

--- a/plugins/follow_me/follow_me.cpp
+++ b/plugins/follow_me/follow_me.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 FollowMe::FollowMe(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new FollowMeImpl(device) }
 {
-    _impl = new FollowMeImpl(device);
 }
 
 FollowMe::~FollowMe()
 {
-    delete _impl;
 }
 
 const FollowMe::Config &FollowMe::get_config() const

--- a/plugins/follow_me/follow_me.h
+++ b/plugins/follow_me/follow_me.h
@@ -34,7 +34,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit FollowMe(Device *device);
+    explicit FollowMe(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/follow_me/follow_me.h
+++ b/plugins/follow_me/follow_me.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <memory>
 #include <iostream>
 #include <cmath>
 #include <functional>
@@ -188,7 +189,7 @@ public:
 
 private:
     // Underlying implementation, set at instantiation
-    FollowMeImpl *_impl;
+    std::unique_ptr<FollowMeImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/follow_me/follow_me.h
+++ b/plugins/follow_me/follow_me.h
@@ -30,7 +30,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto follow_me = std::make_shared<FollowMe>(&device);
+     *     auto follow_me = std::make_shared<FollowMe>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -7,24 +7,24 @@ namespace dronecore {
 
 using namespace std::placeholders; // for `_1`
 
-FollowMeImpl::FollowMeImpl(Device *device) :
+FollowMeImpl::FollowMeImpl(Device &device) :
     PluginImplBase(device)
 {
     // (Lat, Lon, Alt) => double, (vx, vy, vz) => float
     _last_location =  _target_location = \
                                          FollowMe::TargetLocation { double(NAN), double(NAN), double(NAN),
                                                                     NAN, NAN, NAN };
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 FollowMeImpl::~FollowMeImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void FollowMeImpl::init()
 {
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&FollowMeImpl::process_heartbeat, this, _1), static_cast<void *>(this));
     set_default_config();
@@ -32,7 +32,7 @@ void FollowMeImpl::init()
 
 void FollowMeImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void FollowMeImpl::enable() {}
@@ -64,27 +64,27 @@ FollowMe::Result FollowMeImpl::set_config(const FollowMe::Config &config)
 
     // Send configuration to Vehicle
     if (_config.min_height_m != height) {
-        _parent->set_param_float_async("NAV_MIN_FT_HT", height,
-                                       std::bind(&FollowMeImpl::receive_param_min_height,
-                                                 this, _1, height));
+        _parent.set_param_float_async("NAV_MIN_FT_HT", height,
+                                      std::bind(&FollowMeImpl::receive_param_min_height,
+                                                this, _1, height));
         _config_change_requested |= ConfigParameter::MIN_HEIGHT;
     }
     if (_config.follow_distance_m != distance) {
-        _parent->set_param_float_async("NAV_FT_DST", distance,
-                                       std::bind(&FollowMeImpl::receive_param_follow_distance,
-                                                 this, _1, distance));
+        _parent.set_param_float_async("NAV_FT_DST", distance,
+                                      std::bind(&FollowMeImpl::receive_param_follow_distance,
+                                                this, _1, distance));
         _config_change_requested |= ConfigParameter::DISTANCE;
     }
     if (_config.follow_direction != config.follow_direction) {
-        _parent->set_param_int_async("NAV_FT_FS", direction,
-                                     std::bind(&FollowMeImpl::receive_param_follow_direction,
-                                               this, _1, direction));
+        _parent.set_param_int_async("NAV_FT_FS", direction,
+                                    std::bind(&FollowMeImpl::receive_param_follow_direction,
+                                              this, _1, direction));
         _config_change_requested |= ConfigParameter::FOLLOW_DIRECTION;
     }
     if (_config.responsiveness != responsiveness) {
-        _parent->set_param_float_async("NAV_FT_RS", responsiveness,
-                                       std::bind(&FollowMeImpl::receive_param_responsiveness,
-                                                 this, _1, responsiveness));
+        _parent.set_param_float_async("NAV_FT_RS", responsiveness,
+                                      std::bind(&FollowMeImpl::receive_param_responsiveness,
+                                                this, _1, responsiveness));
         _config_change_requested |= ConfigParameter::RESPONSIVENESS;
     }
 
@@ -122,11 +122,11 @@ void FollowMeImpl::set_target_location(const FollowMe::TargetLocation &location)
     }
     // If set already, reschedule it.
     if (_target_location_cookie) {
-        _parent->reset_call_every(_target_location_cookie);
+        _parent.reset_call_every(_target_location_cookie);
         _target_location_cookie = nullptr;
     } else {
         // Regiter now for sending in the next cycle.
-        _parent->add_call_every([this]() { send_target_location(); },
+        _parent.add_call_every([this]() { send_target_location(); },
         SENDER_RATE,
         &_target_location_cookie);
     }
@@ -151,7 +151,7 @@ bool FollowMeImpl::is_active() const
 FollowMe::Result FollowMeImpl::start()
 {
     FollowMe::Result result = to_follow_me_result(
-                                  _parent->set_flight_mode(
+                                  _parent.set_flight_mode(
                                       Device::FlightMode::FOLLOW_ME));
 
     if (result == FollowMe::Result::SUCCESS) {
@@ -159,7 +159,7 @@ FollowMe::Result FollowMeImpl::start()
         std::lock_guard<std::mutex> lock(
             _mutex); // locking is not necessary here but lets do it for integrity
         if (is_target_location_set()) {
-            _parent->add_call_every([this]() { send_target_location(); },
+            _parent.add_call_every([this]() { send_target_location(); },
             SENDER_RATE,
             &_target_location_cookie);
         }
@@ -176,7 +176,7 @@ FollowMe::Result FollowMeImpl::stop()
         }
     }
     return to_follow_me_result(
-               _parent->set_flight_mode(
+               _parent.set_flight_mode(
                    Device::FlightMode::HOLD));
 }
 
@@ -192,18 +192,18 @@ void FollowMeImpl::set_default_config()
     auto responsiveness = default_config.responsiveness;
 
     // Send configuration to Vehicle
-    _parent->set_param_float_async("NAV_MIN_FT_HT", height,
-                                   std::bind(&FollowMeImpl::receive_param_min_height,
-                                             this, _1, height));
-    _parent->set_param_float_async("NAV_FT_DST", distance,
-                                   std::bind(&FollowMeImpl::receive_param_follow_distance,
-                                             this, _1, distance));
-    _parent->set_param_int_async("NAV_FT_FS", direction,
-                                 std::bind(&FollowMeImpl::receive_param_follow_direction,
-                                           this, _1, direction));
-    _parent->set_param_float_async("NAV_FT_RS", responsiveness,
-                                   std::bind(&FollowMeImpl::receive_param_responsiveness,
-                                             this, _1, responsiveness));
+    _parent.set_param_float_async("NAV_MIN_FT_HT", height,
+                                  std::bind(&FollowMeImpl::receive_param_min_height,
+                                            this, _1, height));
+    _parent.set_param_float_async("NAV_FT_DST", distance,
+                                  std::bind(&FollowMeImpl::receive_param_follow_distance,
+                                            this, _1, distance));
+    _parent.set_param_int_async("NAV_FT_FS", direction,
+                                std::bind(&FollowMeImpl::receive_param_follow_direction,
+                                          this, _1, direction));
+    _parent.set_param_float_async("NAV_FT_RS", responsiveness,
+                                  std::bind(&FollowMeImpl::receive_param_responsiveness,
+                                            this, _1, responsiveness));
 }
 
 bool FollowMeImpl::is_config_ok(const FollowMe::Config &config) const
@@ -332,8 +332,8 @@ void FollowMeImpl::send_target_location()
     uint64_t custom_state = 0;
 
     mavlink_message_t msg {};
-    mavlink_msg_follow_target_pack(_parent->get_own_system_id(),
-                                   _parent->get_own_component_id(),
+    mavlink_msg_follow_target_pack(_parent.get_own_system_id(),
+                                   _parent.get_own_component_id(),
                                    &msg,
                                    elapsed_msec,
                                    _estimatation_capabilities,
@@ -347,7 +347,7 @@ void FollowMeImpl::send_target_location()
                                    pos_std_dev,
                                    custom_state);
 
-    if (!_parent->send_message(msg)) {
+    if (!_parent.send_message(msg)) {
         LogErr() << debug_str <<  "send_target_location() failed..";
     } else {
         std::lock_guard<std::mutex> lock(_mutex);
@@ -359,7 +359,7 @@ void FollowMeImpl::stop_sending_target_location()
 {
     // We assume that mutex was acquired by the caller
     if (_target_location_cookie) {
-        _parent->remove_call_every(_target_location_cookie);
+        _parent.remove_call_every(_target_location_cookie);
         _target_location_cookie = nullptr;
     }
     _mode = Mode::NOT_ACTIVE;

--- a/plugins/follow_me/follow_me_impl.h
+++ b/plugins/follow_me/follow_me_impl.h
@@ -13,7 +13,7 @@ namespace dronecore {
 class FollowMeImpl : public PluginImplBase
 {
 public:
-    FollowMeImpl(Device *device);
+    FollowMeImpl(Device &device);
     ~FollowMeImpl();
 
     void init() override;

--- a/plugins/gimbal/gimbal.cpp
+++ b/plugins/gimbal/gimbal.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Gimbal::Gimbal(Device *device) :
+Gimbal::Gimbal(Device &device) :
     PluginBase()
 {
     _impl = new GimbalImpl(device);

--- a/plugins/gimbal/gimbal.cpp
+++ b/plugins/gimbal/gimbal.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 Gimbal::Gimbal(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new GimbalImpl(device) }
 {
-    _impl = new GimbalImpl(device);
 }
 
 Gimbal::~Gimbal()
 {
-    delete _impl;
 }
 
 Gimbal::Result Gimbal::set_pitch_and_yaw(float pitch_deg, float yaw_deg)

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -27,7 +27,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Gimbal(Device *device);
+    explicit Gimbal(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -95,7 +96,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    GimbalImpl *_impl;
+    std::unique_ptr<GimbalImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -23,7 +23,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto gimbal = std::make_shared<Gimbal>(&device);
+     *     auto gimbal = std::make_shared<Gimbal>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -6,15 +6,15 @@
 
 namespace dronecore {
 
-GimbalImpl::GimbalImpl(Device *device) :
+GimbalImpl::GimbalImpl(Device &device) :
     PluginImplBase(device)
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 GimbalImpl::~GimbalImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void GimbalImpl::init() {}
@@ -30,7 +30,7 @@ Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
     const float roll_deg = 0.0f;
 
     return gimbal_result_from_command_result(
-               _parent->send_command_with_ack(
+               _parent.send_command_with_ack(
                    MAV_CMD_DO_MOUNT_CONTROL,
                    MavlinkCommands::Params {pitch_deg, roll_deg, yaw_deg, NAN, NAN, NAN,
                                             MAV_MOUNT_MODE_MAVLINK_TARGETING},
@@ -41,7 +41,7 @@ void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
                                          Gimbal::result_callback_t callback)
 {
     const float roll_deg = 0.0f;
-    _parent->send_command_with_ack_async(
+    _parent.send_command_with_ack_async(
         MAV_CMD_DO_MOUNT_CONTROL,
         MavlinkCommands::Params {pitch_deg, roll_deg, yaw_deg, NAN, NAN, NAN,
                                  MAV_MOUNT_MODE_MAVLINK_TARGETING},

--- a/plugins/gimbal/gimbal_impl.h
+++ b/plugins/gimbal/gimbal_impl.h
@@ -9,7 +9,7 @@ namespace dronecore {
 class GimbalImpl : public PluginImplBase
 {
 public:
-    GimbalImpl(Device *device);
+    GimbalImpl(Device &device);
     ~GimbalImpl();
 
     void init() override;

--- a/plugins/info/info.cpp
+++ b/plugins/info/info.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Info::Info(Device *device) :
+Info::Info(Device &device) :
     PluginBase()
 {
     _impl = new InfoImpl(device);

--- a/plugins/info/info.cpp
+++ b/plugins/info/info.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 Info::Info(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new InfoImpl(device) }
 {
-    _impl = new InfoImpl(device);
 }
 
 Info::~Info()
 {
-    delete _impl;
 }
 
 uint64_t Info::uuid() const

--- a/plugins/info/info.h
+++ b/plugins/info/info.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -108,7 +109,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    InfoImpl *_impl;
+    std::unique_ptr<InfoImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/info/info.h
+++ b/plugins/info/info.h
@@ -21,7 +21,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto info = std::make_shared<Info>(&device);
+     *     auto info = std::make_shared<Info>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/info/info.h
+++ b/plugins/info/info.h
@@ -25,7 +25,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Info(Device *device);
+    explicit Info(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -5,35 +5,35 @@
 
 namespace dronecore {
 
-InfoImpl::InfoImpl(Device *device) :
+InfoImpl::InfoImpl(Device &device) :
     PluginImplBase(device),
     _version_mutex(),
     _version()
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 InfoImpl::~InfoImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void InfoImpl::init()
 {
     using namespace std::placeholders; // for `_1`
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&InfoImpl::process_heartbeat, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_AUTOPILOT_VERSION,
         std::bind(&InfoImpl::process_autopilot_version, this, _1), this);
 }
 
 void InfoImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void InfoImpl::enable() {}
@@ -48,7 +48,7 @@ void InfoImpl::process_heartbeat(const mavlink_message_t &message)
         // We try to request more info if not all info is available.
         // We can't rely on Device to request the autopilot_version,
         // so we do it here, anyway.
-        _parent->request_autopilot_version();
+        _parent.request_autopilot_version();
     }
 }
 
@@ -126,7 +126,7 @@ void InfoImpl::translate_binary_to_str(uint8_t *binary, unsigned binary_len,
 
 uint64_t InfoImpl::get_uuid() const
 {
-    return _parent->get_target_uuid();
+    return _parent.get_target_uuid();
 }
 
 bool InfoImpl::is_complete() const

--- a/plugins/info/info_impl.h
+++ b/plugins/info/info_impl.h
@@ -10,7 +10,7 @@ namespace dronecore {
 class InfoImpl : public PluginImplBase
 {
 public:
-    InfoImpl(Device *device);
+    InfoImpl(Device &device);
     ~InfoImpl();
 
     void init() override;

--- a/plugins/logging/logging.cpp
+++ b/plugins/logging/logging.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Logging::Logging(Device *device) :
+Logging::Logging(Device &device) :
     PluginBase()
 {
     _impl = new LoggingImpl(device);

--- a/plugins/logging/logging.cpp
+++ b/plugins/logging/logging.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 Logging::Logging(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new LoggingImpl(device) }
 {
-    _impl = new LoggingImpl(device);
 }
 
 Logging::~Logging()
 {
-    delete _impl;
 }
 
 Logging::Result Logging::start_logging() const

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -23,7 +23,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto logging = std::make_shared<Logging>(&device);
+     *     auto logging = std::make_shared<Logging>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -108,7 +109,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    LoggingImpl *_impl;
+    std::unique_ptr<LoggingImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/logging/logging.h
+++ b/plugins/logging/logging.h
@@ -27,7 +27,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Logging(Device *device);
+    explicit Logging(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -5,33 +5,33 @@
 
 namespace dronecore {
 
-LoggingImpl::LoggingImpl(Device *device) :
+LoggingImpl::LoggingImpl(Device &device) :
     PluginImplBase(device)
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 LoggingImpl::~LoggingImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void LoggingImpl::init()
 {
     using namespace std::placeholders; // for `_1`
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_LOGGING_DATA,
         std::bind(&LoggingImpl::process_logging_data, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_LOGGING_DATA_ACKED,
         std::bind(&LoggingImpl::process_logging_data_acked, this, _1), this);
 }
 
 void LoggingImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void LoggingImpl::enable() {}
@@ -41,7 +41,7 @@ void LoggingImpl::disable() {}
 Logging::Result LoggingImpl::start_logging() const
 {
     return logging_result_from_command_result(
-               _parent->send_command_with_ack(
+               _parent.send_command_with_ack(
                    MAV_CMD_LOGGING_START,
                    MavlinkCommands::Params {0.0f, // Format: ULog
                                             0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}));
@@ -50,14 +50,14 @@ Logging::Result LoggingImpl::start_logging() const
 Logging::Result LoggingImpl::stop_logging() const
 {
     return logging_result_from_command_result(
-               _parent->send_command_with_ack(
+               _parent.send_command_with_ack(
                    MAV_CMD_LOGGING_STOP,
                    MavlinkCommands::Params {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}));
 }
 
 void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback)
 {
-    _parent->send_command_with_ack_async(
+    _parent.send_command_with_ack_async(
         MAV_CMD_LOGGING_START,
         MavlinkCommands::Params {0.0f, // Format: ULog
                                  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
@@ -68,7 +68,7 @@ void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback
 
 void LoggingImpl::stop_logging_async(const Logging::result_callback_t &callback)
 {
-    _parent->send_command_with_ack_async(
+    _parent.send_command_with_ack_async(
         MAV_CMD_LOGGING_STOP,
         MavlinkCommands::Params {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
         std::bind(&LoggingImpl::command_result_callback,
@@ -89,12 +89,12 @@ void LoggingImpl::process_logging_data_acked(const mavlink_message_t &message)
 
     mavlink_message_t answer;
     mavlink_msg_logging_ack_pack(
-        _parent->get_own_system_id(), _parent->get_own_component_id(),
+        _parent.get_own_system_id(), _parent.get_own_component_id(),
         &answer,
-        _parent->get_target_system_id(), _parent->get_target_component_id(),
+        _parent.get_target_system_id(), _parent.get_target_component_id(),
         logging_data_acked.sequence);
 
-    _parent->send_message(answer);
+    _parent.send_message(answer);
 }
 
 Logging::Result

--- a/plugins/logging/logging_impl.h
+++ b/plugins/logging/logging_impl.h
@@ -10,7 +10,7 @@ namespace dronecore {
 class LoggingImpl : public PluginImplBase
 {
 public:
-    LoggingImpl(Device *device);
+    LoggingImpl(Device &device);
     ~LoggingImpl();
 
     void init() override;

--- a/plugins/mission/mission.cpp
+++ b/plugins/mission/mission.cpp
@@ -5,7 +5,7 @@
 
 namespace dronecore {
 
-Mission::Mission(Device *device) :
+Mission::Mission(Device &device) :
     PluginBase()
 {
     _impl = new MissionImpl(device);

--- a/plugins/mission/mission.cpp
+++ b/plugins/mission/mission.cpp
@@ -6,14 +6,13 @@
 namespace dronecore {
 
 Mission::Mission(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new MissionImpl(device) }
 {
-    _impl = new MissionImpl(device);
 }
 
 Mission::~Mission()
 {
-    delete _impl;
 }
 
 

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -23,7 +23,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto mission = std::make_shared<Mission>(&device);
+     *     auto mission = std::make_shared<Mission>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -28,7 +28,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Mission(Device *device);
+    explicit Mission(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/mission/mission.h
+++ b/plugins/mission/mission.h
@@ -206,7 +206,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    MissionImpl *_impl;
+    std::unique_ptr<MissionImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -8,46 +8,46 @@
 
 namespace dronecore {
 
-MissionImpl::MissionImpl(Device *device) :
+MissionImpl::MissionImpl(Device &device) :
     PluginImplBase(device)
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 MissionImpl::~MissionImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void MissionImpl::init()
 {
     using namespace std::placeholders; // for `_1`
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_REQUEST,
         std::bind(&MissionImpl::process_mission_request, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_REQUEST_INT,
         std::bind(&MissionImpl::process_mission_request_int, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_ACK,
         std::bind(&MissionImpl::process_mission_ack, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_CURRENT,
         std::bind(&MissionImpl::process_mission_current, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_ITEM_REACHED,
         std::bind(&MissionImpl::process_mission_item_reached, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_COUNT,
         std::bind(&MissionImpl::process_mission_count, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MISSION_ITEM_INT,
         std::bind(&MissionImpl::process_mission_item_int, this, _1), this);
 }
@@ -56,12 +56,12 @@ void MissionImpl::enable() {}
 
 void MissionImpl::disable()
 {
-    _parent->unregister_timeout_handler(_timeout_cookie);
+    _parent.unregister_timeout_handler(_timeout_cookie);
 }
 
 void MissionImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void MissionImpl::process_mission_request(const mavlink_message_t &unused)
@@ -70,18 +70,18 @@ void MissionImpl::process_mission_request(const mavlink_message_t &unused)
     UNUSED(unused);
 
     mavlink_message_t message;
-    mavlink_msg_mission_ack_pack(_parent->get_own_system_id(),
-                                 _parent->get_own_component_id(),
+    mavlink_msg_mission_ack_pack(_parent.get_own_system_id(),
+                                 _parent.get_own_component_id(),
                                  &message,
-                                 _parent->get_target_system_id(),
-                                 _parent->get_target_component_id(),
+                                 _parent.get_target_system_id(),
+                                 _parent.get_target_component_id(),
                                  MAV_MISSION_UNSUPPORTED,
                                  MAV_MISSION_TYPE_MISSION);
 
-    _parent->send_message(message);
+    _parent.send_message(message);
 
     // Reset the timeout because we're still communicating.
-    _parent->refresh_timeout_handler(_timeout_cookie);
+    _parent.refresh_timeout_handler(_timeout_cookie);
 }
 
 void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
@@ -91,8 +91,8 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
     mavlink_mission_request_int_t mission_request_int;
     mavlink_msg_mission_request_int_decode(&message, &mission_request_int);
 
-    if (mission_request_int.target_system != _parent->get_own_system_id() &&
-        mission_request_int.target_component != _parent->get_own_component_id()) {
+    if (mission_request_int.target_system != _parent.get_own_system_id() &&
+        mission_request_int.target_component != _parent.get_own_component_id()) {
 
         LogWarn() << "Ignore mission request int that is not for us";
         return;
@@ -108,7 +108,7 @@ void MissionImpl::process_mission_request_int(const mavlink_message_t &message)
 
 
     // Reset the timeout because we're still communicating.
-    _parent->refresh_timeout_handler(_timeout_cookie);
+    _parent.refresh_timeout_handler(_timeout_cookie);
 }
 
 void MissionImpl::process_mission_ack(const mavlink_message_t &message)
@@ -123,15 +123,15 @@ void MissionImpl::process_mission_ack(const mavlink_message_t &message)
     mavlink_mission_ack_t mission_ack;
     mavlink_msg_mission_ack_decode(&message, &mission_ack);
 
-    if (mission_ack.target_system != _parent->get_own_system_id() &&
-        mission_ack.target_component != _parent->get_own_component_id()) {
+    if (mission_ack.target_system != _parent.get_own_system_id() &&
+        mission_ack.target_component != _parent.get_own_component_id()) {
 
         LogWarn() << "Ignore mission ack that is not for us";
         return;
     }
 
     // We got some response, so it wasn't a timeout and we can remove it.
-    _parent->unregister_timeout_handler(_timeout_cookie);
+    _parent.unregister_timeout_handler(_timeout_cookie);
 
     if (mission_ack.type == MAV_MISSION_ACCEPTED) {
 
@@ -170,7 +170,7 @@ void MissionImpl::process_mission_current(const mavlink_message_t &message)
         _last_current_mavlink_mission_item == mission_current.seq) {
         report_mission_result(_result_callback, Mission::Result::SUCCESS);
         _last_current_mavlink_mission_item = -1;
-        _parent->unregister_timeout_handler(_timeout_cookie);
+        _parent.unregister_timeout_handler(_timeout_cookie);
         _activity = Activity::NONE;
     }
 }
@@ -202,10 +202,10 @@ void MissionImpl::process_mission_count(const mavlink_message_t &message)
     _num_mission_items_to_download = mission_count.count;
     _next_mission_item_to_download = 0;
     // We are now requesting mission items and use a lower timeout for this.
-    _parent->unregister_timeout_handler(_timeout_cookie);
+    _parent.unregister_timeout_handler(_timeout_cookie);
 
-    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
-                                      RETRY_TIMEOUT_S, &_timeout_cookie);
+    _parent.register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                     RETRY_TIMEOUT_S, &_timeout_cookie);
     download_next_mission_item();
 }
 
@@ -225,25 +225,25 @@ void MissionImpl::process_mission_item_int(const mavlink_message_t &message)
         if (_next_mission_item_to_download + 1 == _num_mission_items_to_download) {
 
             // Wrap things up if we're finished.
-            _parent->unregister_timeout_handler(_timeout_cookie);
+            _parent.unregister_timeout_handler(_timeout_cookie);
 
             mavlink_message_t ack_message;
-            mavlink_msg_mission_ack_pack(_parent->get_own_system_id(),
-                                         _parent->get_own_component_id(),
+            mavlink_msg_mission_ack_pack(_parent.get_own_system_id(),
+                                         _parent.get_own_component_id(),
                                          &ack_message,
-                                         _parent->get_target_system_id(),
-                                         _parent->get_target_component_id(),
+                                         _parent.get_target_system_id(),
+                                         _parent.get_target_component_id(),
                                          MAV_MISSION_ACCEPTED,
                                          MAV_MISSION_TYPE_MISSION);
 
-            _parent->send_message(ack_message);
+            _parent.send_message(ack_message);
 
             assemble_mission_items();
 
         } else {
             // Otherwise keep going.
             ++_next_mission_item_to_download;
-            _parent->refresh_timeout_handler(_timeout_cookie);
+            _parent.refresh_timeout_handler(_timeout_cookie);
             download_next_mission_item();
         }
 
@@ -252,7 +252,7 @@ void MissionImpl::process_mission_item_int(const mavlink_message_t &message)
                    << " instead of " << _next_mission_item_to_download << " (ignored)";
 
         // Refresh because we at least still seem to be active.
-        _parent->refresh_timeout_handler(_timeout_cookie);
+        _parent.refresh_timeout_handler(_timeout_cookie);
 
         // And request it again in case our request got lost.
         download_next_mission_item();
@@ -272,7 +272,7 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
         return;
     }
 
-    if (!_parent->target_supports_mission_int()) {
+    if (!_parent.target_supports_mission_int()) {
         LogWarn() << "Mission int messages not supported";
         report_mission_result(callback, Mission::Result::ERROR);
         return;
@@ -283,23 +283,23 @@ void MissionImpl::upload_mission_async(const std::vector<std::shared_ptr<Mission
     assemble_mavlink_messages();
 
     mavlink_message_t message;
-    mavlink_msg_mission_count_pack(_parent->get_own_system_id(),
-                                   _parent->get_own_component_id(),
+    mavlink_msg_mission_count_pack(_parent.get_own_system_id(),
+                                   _parent.get_own_component_id(),
                                    &message,
-                                   _parent->get_target_system_id(),
-                                   _parent->get_target_component_id(),
+                                   _parent.get_target_system_id(),
+                                   _parent.get_target_component_id(),
                                    _mavlink_mission_item_messages.size(),
                                    MAV_MISSION_TYPE_MISSION);
 
-    if (!_parent->send_message(message)) {
+    if (!_parent.send_message(message)) {
         report_mission_result(callback, Mission::Result::ERROR);
         return;
     }
 
     // We use the longer process timeout here because essentially the autopilot needs to pull
     // the items up.
-    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
-                                      PROCESS_TIMEOUT_S, &_timeout_cookie);
+    _parent.register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                     PROCESS_TIMEOUT_S, &_timeout_cookie);
 
     _activity = Activity::SET_MISSION;
     _result_callback = callback;
@@ -316,21 +316,21 @@ void MissionImpl::download_mission_async(const Mission::mission_items_and_result
     }
 
     mavlink_message_t message;
-    mavlink_msg_mission_request_list_pack(_parent->get_own_system_id(),
-                                          _parent->get_own_component_id(),
+    mavlink_msg_mission_request_list_pack(_parent.get_own_system_id(),
+                                          _parent.get_own_component_id(),
                                           &message,
-                                          _parent->get_target_system_id(),
-                                          _parent->get_target_component_id(),
+                                          _parent.get_target_system_id(),
+                                          _parent.get_target_component_id(),
                                           MAV_MISSION_TYPE_MISSION);
 
-    if (!_parent->send_message(message)) {
+    if (!_parent.send_message(message)) {
         report_mission_items_and_result(callback, Mission::Result::ERROR);
         return;
     }
 
     // We retry the list request and mission item request, so we use the lower timeout.
-    _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
-                                      RETRY_TIMEOUT_S, &_timeout_cookie);
+    _parent.register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                     RETRY_TIMEOUT_S, &_timeout_cookie);
 
     // Clear our internal cache and re-populate it.
     _mavlink_mission_items_downloaded.clear();
@@ -359,11 +359,11 @@ void MissionImpl::assemble_mavlink_messages()
             uint8_t current = ((_mavlink_mission_item_messages.size() == 0) ? 1 : 0);
 
             auto message = std::make_shared<mavlink_message_t>();
-            mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
-                                              _parent->get_own_component_id(),
+            mavlink_msg_mission_item_int_pack(_parent.get_own_system_id(),
+                                              _parent.get_own_component_id(),
                                               message.get(),
-                                              _parent->get_target_system_id(),
-                                              _parent->get_target_component_id(),
+                                              _parent.get_target_system_id(),
+                                              _parent.get_target_component_id(),
                                               _mavlink_mission_item_messages.size(),
                                               mission_item_impl.get_mavlink_frame(),
                                               mission_item_impl.get_mavlink_cmd(),
@@ -400,11 +400,11 @@ void MissionImpl::assemble_mavlink_messages()
             uint8_t autocontinue = 1;
 
             auto message_speed = std::make_shared<mavlink_message_t>();
-            mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
-                                              _parent->get_own_component_id(),
+            mavlink_msg_mission_item_int_pack(_parent.get_own_system_id(),
+                                              _parent.get_own_component_id(),
                                               message_speed.get(),
-                                              _parent->get_target_system_id(),
-                                              _parent->get_target_component_id(),
+                                              _parent.get_target_system_id(),
+                                              _parent.get_target_component_id(),
                                               _mavlink_mission_item_messages.size(),
                                               MAV_FRAME_MISSION,
                                               MAV_CMD_DO_CHANGE_SPEED,
@@ -435,11 +435,11 @@ void MissionImpl::assemble_mavlink_messages()
             uint8_t autocontinue = 1;
 
             auto message_gimbal = std::make_shared<mavlink_message_t>();
-            mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
-                                              _parent->get_own_component_id(),
+            mavlink_msg_mission_item_int_pack(_parent.get_own_system_id(),
+                                              _parent.get_own_component_id(),
                                               message_gimbal.get(),
-                                              _parent->get_target_system_id(),
-                                              _parent->get_target_component_id(),
+                                              _parent.get_target_system_id(),
+                                              _parent.get_target_component_id(),
                                               _mavlink_mission_item_messages.size(),
                                               MAV_FRAME_MISSION,
                                               MAV_CMD_DO_MOUNT_CONTROL,
@@ -477,11 +477,11 @@ void MissionImpl::assemble_mavlink_messages()
                 uint8_t autocontinue = 1;
 
                 std::shared_ptr<mavlink_message_t> message_delay(new mavlink_message_t());
-                mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
-                                                  _parent->get_own_component_id(),
+                mavlink_msg_mission_item_int_pack(_parent.get_own_system_id(),
+                                                  _parent.get_own_component_id(),
                                                   message_delay.get(),
-                                                  _parent->get_target_system_id(),
-                                                  _parent->get_target_component_id(),
+                                                  _parent.get_target_system_id(),
+                                                  _parent.get_target_component_id(),
                                                   _mavlink_mission_item_messages.size(),
                                                   last_frame,
                                                   MAV_CMD_NAV_LOITER_TIME,
@@ -546,11 +546,11 @@ void MissionImpl::assemble_mavlink_messages()
             }
 
             auto message_camera = std::make_shared<mavlink_message_t>();
-            mavlink_msg_mission_item_int_pack(_parent->get_own_system_id(),
-                                              _parent->get_own_component_id(),
+            mavlink_msg_mission_item_int_pack(_parent.get_own_system_id(),
+                                              _parent.get_own_component_id(),
                                               message_camera.get(),
-                                              _parent->get_target_system_id(),
-                                              _parent->get_target_component_id(),
+                                              _parent.get_target_system_id(),
+                                              _parent.get_target_component_id(),
                                               _mavlink_mission_item_messages.size(),
                                               MAV_FRAME_MISSION,
                                               cmd,
@@ -682,17 +682,17 @@ void MissionImpl::assemble_mission_items()
 void MissionImpl::download_next_mission_item()
 {
     mavlink_message_t message;
-    mavlink_msg_mission_request_int_pack(_parent->get_own_system_id(),
-                                         _parent->get_own_component_id(),
+    mavlink_msg_mission_request_int_pack(_parent.get_own_system_id(),
+                                         _parent.get_own_component_id(),
                                          &message,
-                                         _parent->get_target_system_id(),
-                                         _parent->get_target_component_id(),
+                                         _parent.get_target_system_id(),
+                                         _parent.get_target_component_id(),
                                          _next_mission_item_to_download,
                                          MAV_MISSION_TYPE_MISSION);
 
     LogDebug() << "Requested mission item " << _next_mission_item_to_download;
 
-    _parent->send_message(message);
+    _parent.send_message(message);
 }
 
 void MissionImpl::start_mission_async(const Mission::result_callback_t &callback)
@@ -706,7 +706,7 @@ void MissionImpl::start_mission_async(const Mission::result_callback_t &callback
 
     _activity = Activity::SEND_COMMAND;
 
-    _parent->set_flight_mode_async(
+    _parent.set_flight_mode_async(
         Device::FlightMode::MISSION,
         std::bind(&MissionImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
@@ -725,7 +725,7 @@ void MissionImpl::pause_mission_async(const Mission::result_callback_t &callback
 
     _activity = Activity::SEND_COMMAND;
 
-    _parent->set_flight_mode_async(
+    _parent.set_flight_mode_async(
         Device::FlightMode::HOLD,
         std::bind(&MissionImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
@@ -760,14 +760,14 @@ void MissionImpl::set_current_mission_item_async(int current, Mission::result_ca
     }
 
     mavlink_message_t message;
-    mavlink_msg_mission_set_current_pack(_parent->get_own_system_id(),
-                                         _parent->get_own_component_id(),
+    mavlink_msg_mission_set_current_pack(_parent.get_own_system_id(),
+                                         _parent.get_own_component_id(),
                                          &message,
-                                         _parent->get_target_system_id(),
-                                         _parent->get_target_component_id(),
+                                         _parent.get_target_system_id(),
+                                         _parent.get_target_component_id(),
                                          mavlink_index);
 
-    if (!_parent->send_message(message)) {
+    if (!_parent.send_message(message)) {
         report_mission_result(callback, Mission::Result::ERROR);
         return;
     }
@@ -784,7 +784,7 @@ void MissionImpl::upload_mission_item(uint16_t seq)
         return;
     }
 
-    _parent->send_message(*_mavlink_mission_item_messages.at(seq));
+    _parent.send_message(*_mavlink_mission_item_messages.at(seq));
 }
 
 void MissionImpl::copy_mission_item_vector(const std::vector<std::shared_ptr<MissionItem>>
@@ -844,7 +844,7 @@ void MissionImpl::receive_command_result(MavlinkCommands::Result result,
     }
 
     // We got a command back, so we can get rid of the timeout handler.
-    _parent->unregister_timeout_handler(_timeout_cookie);
+    _parent.unregister_timeout_handler(_timeout_cookie);
 
     if (result == MavlinkCommands::Result::SUCCESS) {
         report_mission_result(callback, Mission::Result::SUCCESS);
@@ -925,8 +925,8 @@ void MissionImpl::process_timeout()
         } else {
             LogWarn() << "Retrying requesting mission item...";
             // We are retrying, so we use the lower timeout.
-            _parent->register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
-                                              RETRY_TIMEOUT_S, &_timeout_cookie);
+            _parent.register_timeout_handler(std::bind(&MissionImpl::process_timeout, this),
+                                             RETRY_TIMEOUT_S, &_timeout_cookie);
             download_next_mission_item();
         }
     } else {

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -17,7 +17,7 @@ namespace dronecore {
 class MissionImpl : public PluginImplBase
 {
 public:
-    MissionImpl(Device *device);
+    MissionImpl(Device &device);
     ~MissionImpl();
 
     void init() override;

--- a/plugins/mission/mission_item.cpp
+++ b/plugins/mission/mission_item.cpp
@@ -5,13 +5,12 @@
 namespace dronecore {
 
 MissionItem::MissionItem() :
-    _impl(new MissionItemImpl())
+    _impl { new MissionItemImpl() }
 {
 }
 
 MissionItem::~MissionItem()
 {
-    delete _impl;
 }
 
 

--- a/plugins/mission/mission_item.h
+++ b/plugins/mission/mission_item.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <memory>
 
 namespace dronecore {
 
@@ -197,7 +198,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    MissionItemImpl *_impl;
+    std::unique_ptr<MissionItemImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/offboard/offboard.cpp
+++ b/plugins/offboard/offboard.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Offboard::Offboard(Device *device) :
+Offboard::Offboard(Device &device) :
     PluginBase()
 {
     _impl = new OffboardImpl(device);

--- a/plugins/offboard/offboard.cpp
+++ b/plugins/offboard/offboard.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 Offboard::Offboard(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new OffboardImpl(device) }
 {
-    _impl = new OffboardImpl(device);
 }
 
 Offboard::~Offboard()
 {
-    delete _impl;
 }
 
 Offboard::Result Offboard::start()

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -163,7 +164,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    OffboardImpl *_impl;
+    std::unique_ptr<OffboardImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -33,7 +33,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto offboard = std::make_shared<Offboard>(&device);
+     *     auto offboard = std::make_shared<Offboard>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -37,7 +37,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Offboard(Device *device);
+    explicit Offboard(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -5,21 +5,21 @@
 
 namespace dronecore {
 
-OffboardImpl::OffboardImpl(Device *device) :
+OffboardImpl::OffboardImpl(Device &device) :
     PluginImplBase(device)
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 OffboardImpl::~OffboardImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void OffboardImpl::init()
 {
     // We need the system state.
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&OffboardImpl::process_heartbeat, this, std::placeholders::_1),
         this);
@@ -27,7 +27,7 @@ void OffboardImpl::init()
 
 void OffboardImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void OffboardImpl::enable() {}
@@ -44,7 +44,7 @@ Offboard::Result OffboardImpl::start()
     }
 
     return offboard_result_from_command_result(
-               _parent->set_flight_mode(Device::FlightMode::OFFBOARD));
+               _parent.set_flight_mode(Device::FlightMode::OFFBOARD));
 }
 
 Offboard::Result OffboardImpl::stop()
@@ -57,7 +57,7 @@ Offboard::Result OffboardImpl::stop()
     }
 
     return offboard_result_from_command_result(
-               _parent->set_flight_mode(Device::FlightMode::HOLD));
+               _parent.set_flight_mode(Device::FlightMode::HOLD));
 }
 
 void OffboardImpl::start_async(Offboard::result_callback_t callback)
@@ -73,7 +73,7 @@ void OffboardImpl::start_async(Offboard::result_callback_t callback)
         }
     }
 
-    _parent->set_flight_mode_async(
+    _parent.set_flight_mode_async(
         Device::FlightMode::OFFBOARD,
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
@@ -88,7 +88,7 @@ void OffboardImpl::stop_async(Offboard::result_callback_t callback)
         }
     }
 
-    _parent->set_flight_mode_async(
+    _parent.set_flight_mode_async(
         Device::FlightMode::HOLD,
         std::bind(&OffboardImpl::receive_command_result, this,
                   std::placeholders::_1, callback));
@@ -117,11 +117,11 @@ void OffboardImpl::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)
     if (_mode != Mode::VELOCITY_NED) {
         if (_call_every_cookie) {
             // If we're already sending other setpoints, stop that now.
-            _parent->remove_call_every(_call_every_cookie);
+            _parent.remove_call_every(_call_every_cookie);
             _call_every_cookie = nullptr;
         }
         // We automatically send NED setpoints from now on.
-        _parent->add_call_every([this]() { send_velocity_ned(); },
+        _parent.add_call_every([this]() { send_velocity_ned(); },
         SEND_INTERVAL_S,
         &_call_every_cookie);
 
@@ -129,7 +129,7 @@ void OffboardImpl::set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw)
     } else {
         // We're already sending these kind of setpoints. Since the setpoint change, let's
         // reschedule the next call, so we don't send setpoints too often.
-        _parent->reset_call_every(_call_every_cookie);
+        _parent.reset_call_every(_call_every_cookie);
     }
     _mutex.unlock();
 
@@ -145,11 +145,11 @@ void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_bod
     if (_mode != Mode::VELOCITY_BODY) {
         if (_call_every_cookie) {
             // If we're already sending other setpoints, stop that now.
-            _parent->remove_call_every(_call_every_cookie);
+            _parent.remove_call_every(_call_every_cookie);
             _call_every_cookie = nullptr;
         }
         // We automatically send body setpoints from now on.
-        _parent->add_call_every([this]() { send_velocity_body(); },
+        _parent.add_call_every([this]() { send_velocity_body(); },
         SEND_INTERVAL_S,
         &_call_every_cookie);
 
@@ -157,7 +157,7 @@ void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_bod
     } else {
         // We're already sending these kind of setpoints. Since the setpoint change, let's
         // reschedule the next call, so we don't send setpoints too often.
-        _parent->reset_call_every(_call_every_cookie);
+        _parent.reset_call_every(_call_every_cookie);
     }
     _mutex.unlock();
 
@@ -195,19 +195,19 @@ void OffboardImpl::send_velocity_ned()
     _mutex.unlock();
 
     mavlink_message_t message;
-    mavlink_msg_set_position_target_local_ned_pack(_parent->get_own_system_id(),
-                                                   _parent->get_own_component_id(),
+    mavlink_msg_set_position_target_local_ned_pack(_parent.get_own_system_id(),
+                                                   _parent.get_own_component_id(),
                                                    &message,
-                                                   static_cast<uint32_t>(_parent->get_time().elapsed_s() * 1e3),
-                                                   _parent->get_target_system_id(),
-                                                   _parent->get_target_component_id(),
+                                                   static_cast<uint32_t>(_parent.get_time().elapsed_s() * 1e3),
+                                                   _parent.get_target_system_id(),
+                                                   _parent.get_target_component_id(),
                                                    MAV_FRAME_LOCAL_NED,
                                                    IGNORE_X | IGNORE_Y | IGNORE_Z |
                                                    IGNORE_AX | IGNORE_AY | IGNORE_AZ |
                                                    IGNORE_YAW_RATE,
                                                    x, y, z, vx, vy, vz, afx, afy, afz,
                                                    yaw, yaw_rate);
-    _parent->send_message(message);
+    _parent.send_message(message);
 }
 
 void OffboardImpl::send_velocity_body()
@@ -242,19 +242,19 @@ void OffboardImpl::send_velocity_body()
     _mutex.unlock();
 
     mavlink_message_t message;
-    mavlink_msg_set_position_target_local_ned_pack(_parent->get_own_system_id(),
-                                                   _parent->get_own_component_id(),
+    mavlink_msg_set_position_target_local_ned_pack(_parent.get_own_system_id(),
+                                                   _parent.get_own_component_id(),
                                                    &message,
-                                                   static_cast<uint32_t>(_parent->get_time().elapsed_s() * 1e3),
-                                                   _parent->get_target_system_id(),
-                                                   _parent->get_target_component_id(),
+                                                   static_cast<uint32_t>(_parent.get_time().elapsed_s() * 1e3),
+                                                   _parent.get_target_system_id(),
+                                                   _parent.get_target_component_id(),
                                                    MAV_FRAME_BODY_NED,
                                                    IGNORE_X | IGNORE_Y | IGNORE_Z |
                                                    IGNORE_AX | IGNORE_AY | IGNORE_AZ |
                                                    IGNORE_YAW,
                                                    x, y, z, vx, vy, vz, afx, afy, afz,
                                                    yaw, yaw_rate);
-    _parent->send_message(message);
+    _parent.send_message(message);
 }
 
 void OffboardImpl::process_heartbeat(const mavlink_message_t &message)
@@ -288,7 +288,7 @@ void OffboardImpl::stop_sending_setpoints()
     // We assume that we already acquired the mutex in this function.
 
     if (_call_every_cookie != nullptr) {
-        _parent->remove_call_every(_call_every_cookie);
+        _parent.remove_call_every(_call_every_cookie);
         _call_every_cookie = nullptr;
     }
     _mode = Mode::NOT_ACTIVE;

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -11,7 +11,7 @@ namespace dronecore {
 class OffboardImpl : public PluginImplBase
 {
 public:
-    OffboardImpl(Device *device);
+    OffboardImpl(Device &device);
     ~OffboardImpl();
 
     void init() override;

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -4,14 +4,13 @@
 namespace dronecore {
 
 Telemetry::Telemetry(Device &device) :
-    PluginBase()
+    PluginBase(),
+    _impl { new TelemetryImpl(device) }
 {
-    _impl = new TelemetryImpl(device);
 }
 
 Telemetry::~Telemetry()
 {
-    delete _impl;
 }
 
 Telemetry::Result Telemetry::set_rate_position(double rate_hz)

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -3,7 +3,7 @@
 
 namespace dronecore {
 
-Telemetry::Telemetry(Device *device) :
+Telemetry::Telemetry(Device &device) :
     PluginBase()
 {
     _impl = new TelemetryImpl(device);

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -22,7 +22,7 @@ public:
      * The plugin is typically created as shown below:
      *
      *     ```cpp
-     *     auto telemetry = std::make_shared<Telemetry>(&device);
+     *     auto telemetry = std::make_shared<Telemetry>(device);
      *     ```
      *
      * @param device The specific device associated with this plugin.

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -633,7 +634,7 @@ public:
 
 private:
     /** @private Underlying implementation, set at instantiation */
-    TelemetryImpl *_impl;
+    std::unique_ptr<TelemetryImpl> _impl;
 };
 
 } // namespace dronecore

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -26,7 +26,7 @@ public:
      *
      * @param device The specific device associated with this plugin.
      */
-    explicit Telemetry(Device *device);
+    explicit Telemetry(Device &device);
 
     /**
      * @brief Destructor (internal use only).

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -8,7 +8,7 @@
 
 namespace dronecore {
 
-TelemetryImpl::TelemetryImpl(Device *device) :
+TelemetryImpl::TelemetryImpl(Device &device) :
     PluginImplBase(device),
     _position_mutex(),
     _position(Telemetry::Position {double(NAN), double(NAN), NAN, NAN}),
@@ -50,93 +50,93 @@ TelemetryImpl::TelemetryImpl(Device *device) :
     _ground_speed_ned_rate_hz(0.0),
     _position_rate_hz(-1.0)
 {
-    _parent->register_plugin(this);
+    _parent.register_plugin(this);
 }
 
 TelemetryImpl::~TelemetryImpl()
 {
-    _parent->unregister_plugin(this);
+    _parent.unregister_plugin(this);
 }
 
 void TelemetryImpl::init()
 {
     using namespace std::placeholders; // for `_1`
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
         std::bind(&TelemetryImpl::process_global_position_int, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_HOME_POSITION,
         std::bind(&TelemetryImpl::process_home_position, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_ATTITUDE_QUATERNION,
         std::bind(&TelemetryImpl::process_attitude_quaternion, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_MOUNT_ORIENTATION,
         std::bind(&TelemetryImpl::process_mount_orientation, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_GPS_RAW_INT,
         std::bind(&TelemetryImpl::process_gps_raw_int, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_EXTENDED_SYS_STATE,
         std::bind(&TelemetryImpl::process_extended_sys_state, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_SYS_STATUS,
         std::bind(&TelemetryImpl::process_sys_status, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_HEARTBEAT,
         std::bind(&TelemetryImpl::process_heartbeat, this, _1), this);
 
-    _parent->register_mavlink_message_handler(
+    _parent.register_mavlink_message_handler(
         MAVLINK_MSG_ID_RC_CHANNELS,
         std::bind(&TelemetryImpl::process_rc_channels, this, _1), this);
 }
 
 void TelemetryImpl::deinit()
 {
-    _parent->unregister_all_mavlink_message_handlers(this);
+    _parent.unregister_all_mavlink_message_handlers(this);
 }
 
 void TelemetryImpl::enable()
 {
 
-    _parent->register_timeout_handler(
+    _parent.register_timeout_handler(
         std::bind(&TelemetryImpl::receive_rc_channels_timeout, this), 1.0, &_timeout_cookie);
 
     // FIXME: The calibration check should eventually be better than this.
     //        For now, we just do the same as QGC does.
 
-    _parent->get_param_int_async(std::string("CAL_GYRO0_ID"),
-                                 std::bind(&TelemetryImpl::receive_param_cal_gyro,
-                                           this,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2));
+    _parent.get_param_int_async(std::string("CAL_GYRO0_ID"),
+                                std::bind(&TelemetryImpl::receive_param_cal_gyro,
+                                          this,
+                                          std::placeholders::_1,
+                                          std::placeholders::_2));
 
-    _parent->get_param_int_async(std::string("CAL_ACC0_ID"),
-                                 std::bind(&TelemetryImpl::receive_param_cal_accel,
-                                           this,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2));
+    _parent.get_param_int_async(std::string("CAL_ACC0_ID"),
+                                std::bind(&TelemetryImpl::receive_param_cal_accel,
+                                          this,
+                                          std::placeholders::_1,
+                                          std::placeholders::_2));
 
-    _parent->get_param_int_async(std::string("CAL_MAG0_ID"),
-                                 std::bind(&TelemetryImpl::receive_param_cal_mag,
-                                           this,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2));
+    _parent.get_param_int_async(std::string("CAL_MAG0_ID"),
+                                std::bind(&TelemetryImpl::receive_param_cal_mag,
+                                          this,
+                                          std::placeholders::_1,
+                                          std::placeholders::_2));
 
 #ifdef LEVEL_CALIBRATION
-    _parent->get_param_float_async(std::string("SENS_BOARD_X_OFF"),
-                                   std::bind(&TelemetryImpl::receive_param_cal_level,
-                                             this,
-                                             std::placeholders::_1,
-                                             std::placeholders::_2));
+    _parent.get_param_float_async(std::string("SENS_BOARD_X_OFF"),
+                                  std::bind(&TelemetryImpl::receive_param_cal_level,
+                                            this,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2));
 #else
     // If not available, just hardcode it to true.
     set_health_level_calibration(true);
@@ -145,7 +145,7 @@ void TelemetryImpl::enable()
 
 void TelemetryImpl::disable()
 {
-    _parent->unregister_timeout_handler(_timeout_cookie);
+    _parent.unregister_timeout_handler(_timeout_cookie);
 }
 
 Telemetry::Result TelemetryImpl::set_rate_position(double rate_hz)
@@ -154,31 +154,31 @@ Telemetry::Result TelemetryImpl::set_rate_position(double rate_hz)
     double max_rate_hz = std::max(_position_rate_hz, _ground_speed_ned_rate_hz);
 
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, max_rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, max_rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_home_position(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_HOME_POSITION, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_HOME_POSITION, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_in_air(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_EXTENDED_SYS_STATE, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_EXTENDED_SYS_STATE, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_attitude(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_ATTITUDE_QUATERNION, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_ATTITUDE_QUATERNION, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_camera_attitude(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_MOUNT_ORIENTATION, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_MOUNT_ORIENTATION, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_ground_speed_ned(double rate_hz)
@@ -187,25 +187,25 @@ Telemetry::Result TelemetryImpl::set_rate_ground_speed_ned(double rate_hz)
     double max_rate_hz = std::max(_position_rate_hz, _ground_speed_ned_rate_hz);
 
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, max_rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, max_rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_gps_info(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_GPS_RAW_INT, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_GPS_RAW_INT, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_battery(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_SYS_STATUS, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_SYS_STATUS, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_rc_status(double rate_hz)
 {
     return telemetry_result_from_command_result(
-               _parent->set_msg_rate(MAVLINK_MSG_ID_RC_CHANNELS, rate_hz));
+               _parent.set_msg_rate(MAVLINK_MSG_ID_RC_CHANNELS, rate_hz));
 }
 
 void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::result_callback_t callback)
@@ -213,7 +213,7 @@ void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::result_ca
     _position_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _ground_speed_ned_rate_hz);
 
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
         max_rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -223,7 +223,7 @@ void TelemetryImpl::set_rate_position_async(double rate_hz, Telemetry::result_ca
 void TelemetryImpl::set_rate_home_position_async(double rate_hz,
                                                  Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_HOME_POSITION,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -231,7 +231,7 @@ void TelemetryImpl::set_rate_home_position_async(double rate_hz,
 
 void TelemetryImpl::set_rate_in_air_async(double rate_hz, Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_EXTENDED_SYS_STATE,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -239,7 +239,7 @@ void TelemetryImpl::set_rate_in_air_async(double rate_hz, Telemetry::result_call
 
 void TelemetryImpl::set_rate_attitude_async(double rate_hz, Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_ATTITUDE_QUATERNION,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -248,7 +248,7 @@ void TelemetryImpl::set_rate_attitude_async(double rate_hz, Telemetry::result_ca
 void TelemetryImpl::set_rate_camera_attitude_async(double rate_hz,
                                                    Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_MOUNT_ORIENTATION,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -260,7 +260,7 @@ void TelemetryImpl::set_rate_ground_speed_ned_async(double rate_hz,
     _ground_speed_ned_rate_hz = rate_hz;
     double max_rate_hz = std::max(_position_rate_hz, _ground_speed_ned_rate_hz);
 
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
         max_rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -268,7 +268,7 @@ void TelemetryImpl::set_rate_ground_speed_ned_async(double rate_hz,
 
 void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_GPS_RAW_INT,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -276,7 +276,7 @@ void TelemetryImpl::set_rate_gps_info_async(double rate_hz, Telemetry::result_ca
 
 void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_SYS_STATUS,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -284,7 +284,7 @@ void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::result_cal
 
 void TelemetryImpl::set_rate_rc_status_async(double rate_hz, Telemetry::result_callback_t callback)
 {
-    _parent->set_msg_rate_async(
+    _parent.set_msg_rate_async(
         MAVLINK_MSG_ID_RC_CHANNELS,
         rate_hz,
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
@@ -500,7 +500,7 @@ void TelemetryImpl::process_rc_channels(const mavlink_message_t &message)
         _rc_status_subscription(get_rc_status());
     }
 
-    _parent->refresh_timeout_handler(_timeout_cookie);
+    _parent.refresh_timeout_handler(_timeout_cookie);
 }
 
 Telemetry::FlightMode TelemetryImpl::to_flight_mode_from_custom_mode(uint32_t custom_mode)

--- a/plugins/telemetry/telemetry_impl.h
+++ b/plugins/telemetry/telemetry_impl.h
@@ -18,7 +18,7 @@ class Device;
 class TelemetryImpl : public PluginImplBase
 {
 public:
-    TelemetryImpl(Device *device);
+    TelemetryImpl(Device &device);
     ~TelemetryImpl();
 
     void init() override;


### PR DESCRIPTION
This commit replaces raw pointers by smart pointers and references as applicable.
We have to use references when we can, and pointers when we have to.

Smart pointers provide automatic resource management. In other words, they implement **Resource Acquisition Is Initialization** programming idiom. The main goal of this idiom is to ensure that resource acquisition occurs at the same time that the object is initialized, so that all resources for the object are created and made ready in one line of code.

 `std::unique_ptr` is a smart pointer that owns and manages another object through a pointer and disposes of that object when the unique_ptr goes out of scope.

`std::shared_ptr` is a smart pointer that retains shared ownership of an object through a pointer. Several shared_ptr objects may own the same object. The object is destroyed and its memory deallocated when either of the following happens:
- the last remaining `shared_ptr` owning the object is destroyed;
- the last remaining `shared_ptr` owning the object is assigned another pointer via `operator=` or `reset()`. 

    
**References:**
- https://isocpp.org/wiki/faq/references#refs-vs-ptrs
- https://docs.microsoft.com/en-us/cpp/cpp/smart-pointers-modern-cpp
- http://en.cppreference.com/w/cpp/memory/unique_ptr
- http://en.cppreference.com/w/cpp/memory/shared_ptr

Fixes #314 