### PR TITLE
Gimbal: add ROI command

### DIFF
--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -8,12 +8,15 @@
 #include "plugins/telemetry/telemetry.h"
 #include "plugins/action/action.h"
 #include "plugins/gimbal/gimbal.h"
+#include "plugins/offboard/offboard.h"
 
 using namespace std::placeholders; // for `_1`
 using namespace dronecore;
 
 
 void send_new_gimbal_command(std::shared_ptr<Gimbal> gimbal, int i);
+void send_gimbal_roi_location(std::shared_ptr<Gimbal> gimbal, double latitude_deg,
+                              double longitude_deg, float altitude_m);
 void receive_gimbal_result(Gimbal::Result result);
 void receive_gimbal_attitude_euler_angles(Telemetry::EulerAngle euler_angle);
 
@@ -82,6 +85,78 @@ TEST_F(SitlTest, GimbalTakeoffAndMove)
     std::this_thread::sleep_for(std::chrono::seconds(3));
 }
 
+TEST_F(SitlTest, GimbalROIOffboard)
+{
+    DroneCore dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::SUCCESS);
+
+    // Wait for device to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    Device &device = dc.device();
+    auto telemetry = std::make_shared<Telemetry>(device);
+    auto gimbal = std::make_shared<Gimbal>(device);
+    auto action = std::make_shared<Action>(device);
+    auto offboard = std::make_shared<Offboard>(device);
+
+    while (!telemetry->health_all_ok()) {
+        LogInfo() << "waiting for device to be ready";
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    const Telemetry::Position &position = telemetry->position();
+
+    // set the ROI location: a bit to the north of the vehicle's location
+    const double latitude_offset_deg = 3. / 111111.; // this is about 3 m
+    send_gimbal_roi_location(gimbal, position.latitude_deg + latitude_offset_deg,
+                             position.longitude_deg, position.absolute_altitude_m + 1.f);
+
+    action->arm();
+    action->takeoff();
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    telemetry->set_rate_camera_attitude(10.0);
+
+    telemetry->camera_attitude_euler_angle_async(
+        std::bind(&receive_gimbal_attitude_euler_angles, _1));
+
+    // Send it once before starting offboard, otherwise it will be rejected.
+    offboard->set_velocity_ned({0.0f, 0.0f, 0.0f, 0.0f});
+    offboard->start();
+
+    auto fly_straight = [&offboard](int step_count, float max_speed) {
+        for (int i = 0; i < step_count; ++i) {
+            int k = (i <= step_count / 2) ? i : step_count - i;
+            float vy = static_cast<float>(k) / (step_count / 2) * max_speed;
+            offboard->set_velocity_ned({0.0f, vy, 0.0f, 90.0f});
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    };
+
+    // fly east for a bit
+    fly_straight(300, 2.f);
+
+    // fly in north-south direction (back & forth a few times)
+    const float step_size = 0.01f;
+    const float one_cycle = 2.0f * M_PI_F;
+    const unsigned steps = 2.5f * one_cycle / step_size;
+
+    for (unsigned i = 0; i < steps; ++i) {
+        float vx = 5.0f * sinf(i * step_size);
+        offboard->set_velocity_ned({vx, 0.0f, 0.0f, 90.0f});
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // fly west for a bit
+    fly_straight(600, -4.f);
+
+    action->land();
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
 void send_new_gimbal_command(std::shared_ptr<Gimbal> gimbal, int i)
 {
     float pitch_deg = 30.0f * cosf(i / 360.0f * 2 * M_PI_F);
@@ -89,6 +164,13 @@ void send_new_gimbal_command(std::shared_ptr<Gimbal> gimbal, int i)
 
     gimbal->set_pitch_and_yaw_async(pitch_deg, yaw_deg,
                                     std::bind(&receive_gimbal_result, _1));
+}
+
+void send_gimbal_roi_location(std::shared_ptr<Gimbal> gimbal, double latitude_deg,
+                              double longitude_deg, float altitude_m)
+{
+    gimbal->set_roi_location_async(latitude_deg, longitude_deg, altitude_m,
+                                   std::bind(&receive_gimbal_result, _1));
 }
 
 void receive_gimbal_result(Gimbal::Result result)

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -66,8 +66,11 @@ TEST_F(SitlTest, GimbalTakeoffAndMove)
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    action->arm();
-    action->takeoff();
+    Action::Result action_result = action->arm();
+    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+
+    action_result = action->takeoff();
+    EXPECT_EQ(action_result, Action::Result::SUCCESS);
 
     telemetry->set_rate_camera_attitude(10.0);
 
@@ -112,8 +115,11 @@ TEST_F(SitlTest, GimbalROIOffboard)
     send_gimbal_roi_location(gimbal, position.latitude_deg + latitude_offset_deg,
                              position.longitude_deg, position.absolute_altitude_m + 1.f);
 
-    action->arm();
-    action->takeoff();
+    Action::Result action_result = action->arm();
+    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+
+    action_result = action->takeoff();
+    EXPECT_EQ(action_result, Action::Result::SUCCESS);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -124,7 +130,8 @@ TEST_F(SitlTest, GimbalROIOffboard)
 
     // Send it once before starting offboard, otherwise it will be rejected.
     offboard->set_velocity_ned({0.0f, 0.0f, 0.0f, 0.0f});
-    offboard->start();
+    Offboard::Result offboard_result = offboard->start();
+    EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     auto fly_straight = [&offboard](int step_count, float max_speed) {
         for (int i = 0; i < step_count; ++i) {

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -141,7 +141,7 @@ TEST_F(SitlTest, GimbalROIOffboard)
     // fly in north-south direction (back & forth a few times)
     const float step_size = 0.01f;
     const float one_cycle = 2.0f * M_PI_F;
-    const unsigned steps = 2.5f * one_cycle / step_size;
+    const unsigned steps = static_cast<unsigned>(2.5f * one_cycle / step_size);
 
     for (unsigned i = 0; i < steps; ++i) {
         float vx = 5.0f * sinf(i * step_size);

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -1,14 +1,16 @@
-#include <iostream>
-#include <functional>
-#include <memory>
 #include <atomic>
 #include <cmath>
-#include "integration_test_helper.h"
+#include <functional>
+#include <iostream>
+#include <memory>
+
 #include "dronecore.h"
-#include "plugins/telemetry/telemetry.h"
+#include "integration_test_helper.h"
 #include "plugins/action/action.h"
+#include "plugins/action/action_result.h"
 #include "plugins/gimbal/gimbal.h"
 #include "plugins/offboard/offboard.h"
+#include "plugins/telemetry/telemetry.h"
 
 using namespace dronecore;
 
@@ -66,11 +68,11 @@ TEST_F(SitlTest, GimbalTakeoffAndMove)
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    Action::Result action_result = action->arm();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    ActionResult action_result = action->arm();
+    EXPECT_EQ(action_result, ActionResult::SUCCESS);
 
     action_result = action->takeoff();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    EXPECT_EQ(action_result, ActionResult::SUCCESS);
 
     telemetry->set_rate_camera_attitude(10.0);
 
@@ -115,11 +117,11 @@ TEST_F(SitlTest, GimbalROIOffboard)
     send_gimbal_roi_location(gimbal, position.latitude_deg + latitude_offset_deg,
                              position.longitude_deg, position.absolute_altitude_m + 1.f);
 
-    Action::Result action_result = action->arm();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    ActionResult action_result = action->arm();
+    EXPECT_EQ(action_result, ActionResult::SUCCESS);
 
     action_result = action->takeoff();
-    EXPECT_EQ(action_result, Action::Result::SUCCESS);
+    EXPECT_EQ(action_result, ActionResult::SUCCESS);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 

--- a/integration_tests/gimbal.cpp
+++ b/integration_tests/gimbal.cpp
@@ -10,7 +10,6 @@
 #include "plugins/gimbal/gimbal.h"
 #include "plugins/offboard/offboard.h"
 
-using namespace std::placeholders; // for `_1`
 using namespace dronecore;
 
 
@@ -38,7 +37,7 @@ TEST_F(SitlTest, GimbalMove)
     telemetry->set_rate_camera_attitude(10.0);
 
     telemetry->camera_attitude_euler_angle_async(
-        std::bind(&receive_gimbal_attitude_euler_angles, _1));
+        &receive_gimbal_attitude_euler_angles);
 
     for (int i = 0; i < 500; i += 1) {
 
@@ -73,7 +72,7 @@ TEST_F(SitlTest, GimbalTakeoffAndMove)
     telemetry->set_rate_camera_attitude(10.0);
 
     telemetry->camera_attitude_euler_angle_async(
-        std::bind(&receive_gimbal_attitude_euler_angles, _1));
+        &receive_gimbal_attitude_euler_angles);
 
     for (int i = 0; i < 500; i += 1) {
 
@@ -121,7 +120,7 @@ TEST_F(SitlTest, GimbalROIOffboard)
     telemetry->set_rate_camera_attitude(10.0);
 
     telemetry->camera_attitude_euler_angle_async(
-        std::bind(&receive_gimbal_attitude_euler_angles, _1));
+        &receive_gimbal_attitude_euler_angles);
 
     // Send it once before starting offboard, otherwise it will be rejected.
     offboard->set_velocity_ned({0.0f, 0.0f, 0.0f, 0.0f});
@@ -162,15 +161,14 @@ void send_new_gimbal_command(std::shared_ptr<Gimbal> gimbal, int i)
     float pitch_deg = 30.0f * cosf(i / 360.0f * 2 * M_PI_F);
     float yaw_deg = 45.0f * sinf(i / 360.0f * 2 * M_PI_F);
 
-    gimbal->set_pitch_and_yaw_async(pitch_deg, yaw_deg,
-                                    std::bind(&receive_gimbal_result, _1));
+    gimbal->set_pitch_and_yaw_async(pitch_deg, yaw_deg, &receive_gimbal_result);
 }
 
 void send_gimbal_roi_location(std::shared_ptr<Gimbal> gimbal, double latitude_deg,
                               double longitude_deg, float altitude_m)
 {
     gimbal->set_roi_location_async(latitude_deg, longitude_deg, altitude_m,
-                                   std::bind(&receive_gimbal_result, _1));
+                                   &receive_gimbal_result);
 }
 
 void receive_gimbal_result(Gimbal::Result result)

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -70,7 +70,7 @@ TEST_F(SitlTest, OffboardVelocityNED)
     // This needs some time to propagate.
     std::this_thread::sleep_for(std::chrono::seconds(2));
     // Now it should be inactive.
-    EXPECT_TRUE(offboard->is_active());
+    EXPECT_FALSE(offboard->is_active());
 
     // So we start it yet again.
     offboard_result = offboard->start();

--- a/plugins/gimbal/gimbal.cpp
+++ b/plugins/gimbal/gimbal.cpp
@@ -23,6 +23,17 @@ void Gimbal::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, result_call
     _impl->set_pitch_and_yaw_async(pitch_deg, yaw_deg, callback);
 }
 
+Gimbal::Result Gimbal::set_roi_location(double latitude_deg, double longitude_deg, float altitude_m)
+{
+    return _impl->set_roi_location(latitude_deg, longitude_deg, altitude_m);
+}
+
+void Gimbal::set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
+                                    result_callback_t callback)
+{
+    _impl->set_roi_location_async(latitude_deg, longitude_deg, altitude_m, callback);
+}
+
 const char *Gimbal::result_str(Result result)
 {
     switch (result) {

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -84,6 +84,39 @@ public:
      */
     void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg, result_callback_t callback);
 
+
+    /**
+     * @brief Set gimbal region of interest (ROI).
+     *
+     * This sets a region of interest that the gimbal will point to.
+     * The gimbal will continue to point to the specified region until it
+     * receives a new command.
+     * The function will return when the command is accepted, however, it might
+     * take the gimbal longer to actually rotate to the ROI.
+     *
+     * @param latitude_deg Latitude in degrees
+     * @param longitude_deg Longitude in degrees
+     * @param altitude_m Altitude in meters (ASML)
+     */
+    Result set_roi_location(double latitude_deg, double longitude_deg, float altitude_m);
+
+    /**
+     * @brief Set gimbal region of interest (ROI) (asynchronous).
+     *
+     * This sets a region of interest that the gimbal will point to.
+     * The gimbal will continue to point to the specified region until it
+     * receives a new command.
+     * The callback will be called when the command is accepted, however, it might
+     * take the gimbal longer to actually be set to the new angles.
+     *
+     * @param latitude_deg Latitude in degrees
+     * @param longitude_deg Longitude in degrees
+     * @param altitude_m Altitude in meters (ASML)
+     * @param callback Function to call with result of request.
+     */
+    void set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
+                                result_callback_t callback);
+
     /**
      * @brief Copy constructor (object is not copyable).
      */

--- a/plugins/gimbal/gimbal.h
+++ b/plugins/gimbal/gimbal.h
@@ -94,9 +94,10 @@ public:
      * The function will return when the command is accepted, however, it might
      * take the gimbal longer to actually rotate to the ROI.
      *
-     * @param latitude_deg Latitude in degrees
-     * @param longitude_deg Longitude in degrees
-     * @param altitude_m Altitude in meters (ASML)
+     * @param latitude_deg Latitude in degrees.
+     * @param longitude_deg Longitude in degrees.
+     * @param altitude_m Altitude in meters (ASML).
+     * @return Result of request.
      */
     Result set_roi_location(double latitude_deg, double longitude_deg, float altitude_m);
 
@@ -109,9 +110,9 @@ public:
      * The callback will be called when the command is accepted, however, it might
      * take the gimbal longer to actually be set to the new angles.
      *
-     * @param latitude_deg Latitude in degrees
-     * @param longitude_deg Longitude in degrees
-     * @param altitude_m Altitude in meters (ASML)
+     * @param latitude_deg Latitude in degrees.
+     * @param longitude_deg Longitude in degrees.
+     * @param altitude_m Altitude in meters (ASML).
      * @param callback Function to call with result of request.
      */
     void set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -49,6 +49,28 @@ void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
         MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
+Gimbal::Result GimbalImpl::set_roi_location(double latitude_deg, double longitude_deg,
+                                            float altitude_m)
+{
+    return gimbal_result_from_command_result(
+               _parent.send_command_with_ack(
+                   MAV_CMD_DO_SET_ROI_LOCATION,
+                   MavlinkCommands::Params {NAN, NAN, NAN, NAN, (float)latitude_deg, (float)longitude_deg,
+                                            altitude_m},
+                   MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+}
+
+void GimbalImpl::set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
+                                        Gimbal::result_callback_t callback)
+{
+    _parent.send_command_with_ack_async(
+        MAV_CMD_DO_SET_ROI_LOCATION,
+        MavlinkCommands::Params {NAN, NAN, NAN, NAN, (float)latitude_deg, (float)longitude_deg,
+                                 altitude_m},
+        std::bind(&GimbalImpl::receive_command_result, std::placeholders::_1, callback),
+        MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+}
+
 void GimbalImpl::receive_command_result(MavlinkCommands::Result command_result,
                                         const Gimbal::result_callback_t &callback)
 {

--- a/plugins/gimbal/gimbal_impl.h
+++ b/plugins/gimbal/gimbal_impl.h
@@ -23,6 +23,11 @@ public:
     void set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
                                  Gimbal::result_callback_t callback);
 
+    Gimbal::Result set_roi_location(double latitude_deg, double longitude_deg, float altitude_m);
+
+    void set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
+                                Gimbal::result_callback_t callback);
+
     // Non-copyable
     GimbalImpl(const GimbalImpl &) = delete;
     const GimbalImpl &operator=(const GimbalImpl &) = delete;


### PR DESCRIPTION
This implements ROI to let the gimbal point to a region of interest (lon, lat, alt) with an integration test. The test uses offboard to control the drone's position. @julianoes did I see this correctly, there is no 'fly 3 meters to the right' interface?

The integration test can be run with `make &&./build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.GimbalROIOffboard"`

It actually looks pretty cool.
Nice work on the SDK @julianoes!