### PR TITLE
Function parameter reference/pointer types fix

### DIFF
--- a/generate_markdown_from_doxygen_xml.py
+++ b/generate_markdown_from_doxygen_xml.py
@@ -748,8 +748,18 @@ class cppFunction:
             for param in self.params:
                 declname_string=markdown_any_tag(param.declname).strip()
                 if declname_string: #render declname string in bold, if it exists.
-                    declname_string=' **%s**' % declname_string
-                params_string+='\n* %s%s - %s' % (markdown_any_tag(param.type).strip(),declname_string,markdown_any_tag(param.description).strip())
+                    declname_string='**%s**' % declname_string
+
+                # Fix spacing for ref/pointer and ensure pointer symbol (*) escaped
+                param.type=markdown_any_tag(param.type).strip()
+                if param.type.endswith('*') or param.type.endswith('&'): # A ref or pointer
+                    temp=param.type.rsplit(' ',1)
+                    escape_text=''
+                    if param.type.endswith('*'):
+                        escape_text='\\'
+                    temp=temp[0]+escape_text+temp[1]
+                    param.type=temp
+                params_string+='\n* %s %s - %s' % (markdown_any_tag(param.type).strip(),declname_string,markdown_any_tag(param.description).strip())
 
             functionstring+=params_string
 


### PR DESCRIPTION
Addresses https://github.com/dronecore/DroneCore/issues/321. Basically a function parameter type for a reference or pointer will now render with the * or & immediately next to the type.
```
#old
Device * somedevice
Device & somedevice
#new
Device* somedevice
Device& somedevice
```
IFF the type is a pointer, then the "*" is escaped (so markdown doesn't think we want to change case to italic).

Note, I decided on aligning symbol to type rather than name, because this works better in more cases.