### PR TITLE
action: move Action::Result out of action.h

### DIFF
--- a/backend/src/plugins/action/action_service_impl.h
+++ b/backend/src/plugins/action/action_service_impl.h
@@ -20,7 +20,7 @@ public:
 
         auto *rpc_action_result = new dronecore::rpc::action::ActionResult();
         rpc_action_result->set_result(rpc_result);
-        rpc_action_result->set_result_str(dronecore::Action::result_str(action_result));
+        rpc_action_result->set_result_str(dronecore::action_result_str(action_result));
 
         response->set_allocated_action_result(rpc_action_result);
 
@@ -36,7 +36,7 @@ public:
 
         auto *rpc_action_result = new dronecore::rpc::action::ActionResult();
         rpc_action_result->set_result(rpc_result);
-        rpc_action_result->set_result_str(dronecore::Action::result_str(action_result));
+        rpc_action_result->set_result_str(dronecore::action_result_str(action_result));
 
         response->set_allocated_action_result(rpc_action_result);
 
@@ -52,7 +52,7 @@ public:
 
         auto *rpc_action_result = new dronecore::rpc::action::ActionResult();
         rpc_action_result->set_result(rpc_result);
-        rpc_action_result->set_result_str(dronecore::Action::result_str(action_result));
+        rpc_action_result->set_result_str(dronecore::action_result_str(action_result));
 
         response->set_allocated_action_result(rpc_action_result);
 

--- a/backend/test/action_service_impl_test.cpp
+++ b/backend/test/action_service_impl_test.cpp
@@ -1,8 +1,6 @@
 #include <gmock/gmock.h>
 #include <string>
 
-// TODO remove this include
-#include "action/action.h"
 #include "action/action_service_impl.h"
 #include "action/mocks/action_mock.h"
 
@@ -15,12 +13,12 @@ using MockAction = NiceMock<dronecore::testing::MockAction>;
 using ActionServiceImpl = dronecore::backend::ActionServiceImpl<MockAction>;
 
 using ActionResult = dronecore::rpc::action::ActionResult;
-using InputPair = std::pair<std::string, dronecore::Action::Result>;
+using InputPair = std::pair<std::string, dronecore::ActionResult>;
 
 std::vector<InputPair> generateInputPairs();
-std::string armAndGetTranslatedResult(dronecore::Action::Result arm_result);
-std::string takeoffAndGetTranslatedResult(dronecore::Action::Result takeoff_result);
-std::string landAndGetTranslatedResult(dronecore::Action::Result land_result);
+std::string armAndGetTranslatedResult(dronecore::ActionResult arm_result);
+std::string takeoffAndGetTranslatedResult(dronecore::ActionResult takeoff_result);
+std::string landAndGetTranslatedResult(dronecore::ActionResult land_result);
 
 class ActionServiceImplTest : public ::testing::TestWithParam<InputPair> {};
 
@@ -30,7 +28,7 @@ TEST_P(ActionServiceImplTest, armResultIsTranslatedCorrectly)
     EXPECT_EQ(rpc_result, GetParam().first);
 }
 
-std::string armAndGetTranslatedResult(const dronecore::Action::Result arm_result)
+std::string armAndGetTranslatedResult(const dronecore::ActionResult arm_result)
 {
     MockAction action;
     ON_CALL(action, arm())
@@ -49,7 +47,7 @@ TEST_P(ActionServiceImplTest, takeoffResultIsTranslatedCorrectly)
     EXPECT_EQ(rpc_result, GetParam().first);
 }
 
-std::string takeoffAndGetTranslatedResult(const dronecore::Action::Result takeoff_result)
+std::string takeoffAndGetTranslatedResult(const dronecore::ActionResult takeoff_result)
 {
     MockAction action;
     ON_CALL(action, takeoff())
@@ -68,7 +66,7 @@ TEST_P(ActionServiceImplTest, landResultIsTranslatedCorrectly)
     EXPECT_EQ(rpc_result, GetParam().first);
 }
 
-std::string landAndGetTranslatedResult(const dronecore::Action::Result land_result)
+std::string landAndGetTranslatedResult(const dronecore::ActionResult land_result)
 {
     MockAction action;
     ON_CALL(action, land())
@@ -89,22 +87,22 @@ INSTANTIATE_TEST_CASE_P(ActionResultCorrespondences,
 std::vector<InputPair> generateInputPairs()
 {
     std::vector<InputPair> input_pairs;
-    input_pairs.push_back(std::make_pair("SUCCESS", dronecore::Action::Result::SUCCESS));
-    input_pairs.push_back(std::make_pair("NO_DEVICE", dronecore::Action::Result::NO_DEVICE));
+    input_pairs.push_back(std::make_pair("SUCCESS", dronecore::ActionResult::SUCCESS));
+    input_pairs.push_back(std::make_pair("NO_DEVICE", dronecore::ActionResult::NO_DEVICE));
     input_pairs.push_back(std::make_pair("CONNECTION_ERROR",
-                                         dronecore::Action::Result::CONNECTION_ERROR));
-    input_pairs.push_back(std::make_pair("BUSY", dronecore::Action::Result::BUSY));
-    input_pairs.push_back(std::make_pair("COMMAND_DENIED", dronecore::Action::Result::COMMAND_DENIED));
+                                         dronecore::ActionResult::CONNECTION_ERROR));
+    input_pairs.push_back(std::make_pair("BUSY", dronecore::ActionResult::BUSY));
+    input_pairs.push_back(std::make_pair("COMMAND_DENIED", dronecore::ActionResult::COMMAND_DENIED));
     input_pairs.push_back(std::make_pair("COMMAND_DENIED_LANDED_STATE_UNKNOWN",
-                                         dronecore::Action::Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN));
+                                         dronecore::ActionResult::COMMAND_DENIED_LANDED_STATE_UNKNOWN));
     input_pairs.push_back(std::make_pair("COMMAND_DENIED_NOT_LANDED",
-                                         dronecore::Action::Result::COMMAND_DENIED_NOT_LANDED));
-    input_pairs.push_back(std::make_pair("TIMEOUT", dronecore::Action::Result::TIMEOUT));
+                                         dronecore::ActionResult::COMMAND_DENIED_NOT_LANDED));
+    input_pairs.push_back(std::make_pair("TIMEOUT", dronecore::ActionResult::TIMEOUT));
     input_pairs.push_back(std::make_pair("VTOL_TRANSITION_SUPPORT_UNKNOWN",
-                                         dronecore::Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN));
+                                         dronecore::ActionResult::VTOL_TRANSITION_SUPPORT_UNKNOWN));
     input_pairs.push_back(std::make_pair("NO_VTOL_TRANSITION_SUPPORT",
-                                         dronecore::Action::Result::NO_VTOL_TRANSITION_SUPPORT));
-    input_pairs.push_back(std::make_pair("UNKNOWN", dronecore::Action::Result::UNKNOWN));
+                                         dronecore::ActionResult::NO_VTOL_TRANSITION_SUPPORT));
+    input_pairs.push_back(std::make_pair("UNKNOWN", dronecore::ActionResult::UNKNOWN));
 
     return input_pairs;
 }

--- a/core/connection_result.h
+++ b/core/connection_result.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 /**
  * @brief Namespace for all dronecore types.
  */

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -32,7 +32,7 @@ using namespace std::chrono; // for seconds(), milliseconds()
 using namespace std::this_thread; // for sleep_for()
 
 // Handles Action's result
-inline void handle_action_err_exit(Action::Result result, const std::string &message);
+inline void handle_action_err_exit(ActionResult result, const std::string &message);
 // Handles Mission's result
 inline void handle_mission_err_exit(Mission::Result result, const std::string &message);
 // Handles Connection result
@@ -153,7 +153,7 @@ int main(int /*argc*/, char ** /*argv*/)
     }
 
     std::cout << "Arming..." << std::endl;
-    const Action::Result arm_result = action->arm();
+    const ActionResult arm_result = action->arm();
     handle_action_err_exit(arm_result, "Arm failed: ");
     std::cout << "Armed." << std::endl;
 
@@ -235,9 +235,9 @@ int main(int /*argc*/, char ** /*argv*/)
     {
         // We are done, and can do RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
-        const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
-            std::cout << "Failed to command RTL (" << Action::result_str(result) << ")" << std::endl;
+        const ActionResult result = action->return_to_launch();
+        if (result != ActionResult::SUCCESS) {
+            std::cout << "Failed to command RTL (" << action_result_str(result) << ")" << std::endl;
         } else {
             std::cout << "Commanded RTL." << std::endl;
         }
@@ -272,10 +272,10 @@ std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
     return new_item;
 }
 
-inline void handle_action_err_exit(Action::Result result, const std::string &message)
+inline void handle_action_err_exit(ActionResult result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(
+    if (result != ActionResult::SUCCESS) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << action_result_str(
                       result) << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -39,7 +39,7 @@ using namespace std::chrono; // for seconds(), milliseconds()
 using namespace std::this_thread; // for sleep_for()
 
 // Handles Action's result
-inline void handle_action_err_exit(Action::Result result, const std::string &message);
+inline void handle_action_err_exit(ActionResult result, const std::string &message);
 // Handles Mission's result
 inline void handle_mission_err_exit(Mission::Result result, const std::string &message);
 // Handles Connection result
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
     }
 
     std::cout << "Arming..." << std::endl;
-    const Action::Result arm_result = action->arm();
+    const ActionResult arm_result = action->arm();
     handle_action_err_exit(arm_result, "Arm failed: ");
     std::cout << "Armed." << std::endl;
 
@@ -160,9 +160,9 @@ int main(int argc, char **argv)
     {
         // Mission complete. Command RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
-        const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
-            std::cout << "Failed to command RTL (" << Action::result_str(result) << ")" << std::endl;
+        const ActionResult result = action->return_to_launch();
+        if (result != ActionResult::SUCCESS) {
+            std::cout << "Failed to command RTL (" << action_result_str(result) << ")" << std::endl;
         } else {
             std::cout << "Commanded RTL." << std::endl;
         }
@@ -171,10 +171,10 @@ int main(int argc, char **argv)
     return 0;
 }
 
-inline void handle_action_err_exit(Action::Result result, const std::string &message)
+inline void handle_action_err_exit(ActionResult result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(
+    if (result != ActionResult::SUCCESS) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << action_result_str(
                       result) << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -31,7 +31,7 @@ using namespace std::this_thread;  // for sleep_for()
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
-inline void action_error_exit(Action::Result result, const std::string &message);
+inline void action_error_exit(ActionResult result, const std::string &message);
 inline void follow_me_error_exit(FollowMe::Result result, const std::string &message);
 inline void connection_error_exit(ConnectionResult result, const std::string &message);
 
@@ -61,7 +61,7 @@ int main(int, char **)
     std::cout << "Device is ready" << std::endl;
 
     // Arm
-    Action::Result arm_result = action->arm();
+    ActionResult arm_result = action->arm();
     action_error_exit(arm_result, "Arming failed");
     std::cout << "Armed" << std::endl;
 
@@ -75,7 +75,7 @@ int main(int, char **)
     }, std::placeholders::_1));
 
     // Takeoff
-    Action::Result takeoff_result = action->takeoff();
+    ActionResult takeoff_result = action->takeoff();
     action_error_exit(takeoff_result, "Takeoff failed");
     std::cout << "In Air..." << std::endl;
     sleep_for(seconds(5)); // Wait for drone to reach takeoff altitude
@@ -106,7 +106,7 @@ int main(int, char **)
     telemetry->flight_mode_async(nullptr);
 
     // Land
-    const Action::Result land_result = action->land();
+    const ActionResult land_result = action->land();
     action_error_exit(land_result, "Landing failed");
     while (telemetry->in_air()) {
         std::cout << "waiting until landed" << std::endl;
@@ -117,10 +117,10 @@ int main(int, char **)
 }
 
 // Handles Action's result
-inline void action_error_exit(Action::Result result, const std::string &message)
+inline void action_error_exit(ActionResult result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(
+    if (result != ActionResult::SUCCESS) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << action_result_str(
                       result) << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -26,10 +26,10 @@ using std::chrono::seconds;
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
 // Handles Action's result
-inline void action_error_exit(Action::Result result, const std::string &message)
+inline void action_error_exit(ActionResult result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(
+    if (result != ActionResult::SUCCESS) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << action_result_str(
                       result) << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
@@ -192,11 +192,11 @@ int main(int, char **)
     }
     std::cout << "Device is ready" << std::endl;
 
-    Action::Result arm_result = action->arm();
+    ActionResult arm_result = action->arm();
     action_error_exit(arm_result, "Arming failed");
     std::cout << "Armed" << std::endl;
 
-    Action::Result takeoff_result = action->takeoff();
+    ActionResult takeoff_result = action->takeoff();
     action_error_exit(takeoff_result, "Takeoff failed");
     std::cout << "In Air..." << std::endl;
     sleep_for(seconds(5));
@@ -214,7 +214,7 @@ int main(int, char **)
         return EXIT_FAILURE;
     }
 
-    const Action::Result land_result = action->land();
+    const ActionResult land_result = action->land();
     action_error_exit(land_result, "Landing failed");
 
     // We are relying on auto-disarming but let's keep watching the telemetry for a bit longer.

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -91,19 +91,19 @@ int main(int argc, char **argv)
 
     // Arm vehicle
     std::cout << "Arming..." << std::endl;
-    const Action::Result arm_result = action->arm();
+    const ActionResult arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(
+    if (arm_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << action_result_str(
                       arm_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
     // Take off
     std::cout << "Taking off..." << std::endl;
-    const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(
+    const ActionResult takeoff_result = action->takeoff();
+    if (takeoff_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << action_result_str(
                       takeoff_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -112,9 +112,9 @@ int main(int argc, char **argv)
     sleep_for(seconds(10));
 
     std::cout << "Landing..." << std::endl;
-    const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(
+    const ActionResult land_result = action->land();
+    if (land_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << action_result_str(
                       land_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -78,19 +78,19 @@ int main(int /*argc*/, char ** /*argv*/)
 
     // Arm vehicle
     std::cout << "Arming..." << std::endl;
-    const Action::Result arm_result = action->arm();
+    const ActionResult arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(
+    if (arm_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << action_result_str(
                       arm_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
     // Take off
     std::cout << "Taking off..." << std::endl;
-    const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(
+    const ActionResult takeoff_result = action->takeoff();
+    if (takeoff_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << action_result_str(
                       takeoff_result) << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -99,10 +99,10 @@ int main(int /*argc*/, char ** /*argv*/)
     std::this_thread::sleep_for(std::chrono::seconds(10));
 
     std::cout << "Transition to fixedwing..." << std::endl;
-    const Action::Result fw_result = action->transition_to_fixedwing();
+    const ActionResult fw_result = action->transition_to_fixedwing();
 
-    if (fw_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Transition to fixed wing failed: " << Action::result_str(
+    if (fw_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Transition to fixed wing failed: " << action_result_str(
                       fw_result) << NORMAL_CONSOLE_TEXT << std::endl;
         //return 1;
     }
@@ -111,9 +111,9 @@ int main(int /*argc*/, char ** /*argv*/)
     std::this_thread::sleep_for(std::chrono::seconds(10));
 
     std::cout << "Transition back to multicopter..." << std::endl;
-    const Action::Result mc_result = action->transition_to_multicopter();
-    if (mc_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Transition to multi copter failed:" << Action::result_str(
+    const ActionResult mc_result = action->transition_to_multicopter();
+    if (mc_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Transition to multi copter failed:" << action_result_str(
                       mc_result) << NORMAL_CONSOLE_TEXT << std::endl;
         //    return 1;
     }
@@ -123,9 +123,9 @@ int main(int /*argc*/, char ** /*argv*/)
 
     // Return to launch
     std::cout << "Return to launch..." << std::endl;
-    const Action::Result rtl_result = action->return_to_launch();
-    if (rtl_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Returning to launch failed:" << Action::result_str(
+    const ActionResult rtl_result = action->return_to_launch();
+    if (rtl_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Returning to launch failed:" << action_result_str(
                       rtl_result) << NORMAL_CONSOLE_TEXT << std::endl;
         //    return 1;
     }
@@ -135,9 +135,9 @@ int main(int /*argc*/, char ** /*argv*/)
 
     // Land
     std::cout << "Landing..." << std::endl;
-    const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(
+    const ActionResult land_result = action->land();
+    if (land_result != ActionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << action_result_str(
                       land_result) << NORMAL_CONSOLE_TEXT << std::endl;
         //    return 1;
     }

--- a/integration_tests/async_hover.cpp
+++ b/integration_tests/async_hover.cpp
@@ -8,7 +8,7 @@
 using namespace dronecore;
 using namespace std::placeholders; // for `_1`
 
-void receive_result(Action::Result result);
+void receive_result(ActionResult result);
 void receive_health_all_ok(bool all_ok);
 void receive_in_air(bool in_air);
 
@@ -59,10 +59,10 @@ TEST_F(SitlTest, ActionAsyncHover)
 }
 
 
-void receive_result(Action::Result result)
+void receive_result(ActionResult result)
 {
     LogDebug() << "got result: " << unsigned(result);
-    EXPECT_EQ(result, Action::Result::SUCCESS);
+    EXPECT_EQ(result, ActionResult::SUCCESS);
 }
 
 void receive_health_all_ok(bool all_ok)

--- a/integration_tests/follow_me.cpp
+++ b/integration_tests/follow_me.cpp
@@ -40,8 +40,8 @@ TEST_F(SitlTest, FollowMeOneLocation)
         sleep_for(seconds(1));
     }
 
-    Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ActionResult action_ret = action->arm();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     telemetry->flight_mode_async(
     std::bind([&](Telemetry::FlightMode flight_mode) {
@@ -53,7 +53,7 @@ TEST_F(SitlTest, FollowMeOneLocation)
     }, std::placeholders::_1));
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     sleep_for(seconds(5)); // let it reach takeoff altitude
 
@@ -77,7 +77,7 @@ TEST_F(SitlTest, FollowMeOneLocation)
     sleep_for(seconds(2)); // to watch flight mode change from "FollowMe" to default "HOLD"
 
     action_ret = action->land();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
     sleep_for(seconds(2)); // let the device land
 }
 
@@ -100,8 +100,8 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
         sleep_for(seconds(1));
     }
 
-    Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ActionResult action_ret = action->arm();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     telemetry->flight_mode_async(
     std::bind([&](Telemetry::FlightMode flight_mode) {
@@ -114,7 +114,7 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
     }, std::placeholders::_1));
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     sleep_for(seconds(5));
 
@@ -143,7 +143,7 @@ TEST_F(SitlTest, FollowMeMultiLocationWithConfig)
     sleep_for(seconds(2)); // to watch flight mode change from "FollowMe" to default "HOLD"
 
     action_ret = action->land();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
     sleep_for(seconds(2)); // let it land
 }
 

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -161,8 +161,8 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
     }
 
     LogInfo() << "Arming...";
-    const Action::Result arm_result = action->arm();
-    EXPECT_EQ(arm_result, Action::Result::SUCCESS);
+    const ActionResult arm_result = action->arm();
+    EXPECT_EQ(arm_result, ActionResult::SUCCESS);
     LogInfo() << "Armed.";
 
 
@@ -237,8 +237,8 @@ TEST_F(SitlTest, MissionAddWaypointsAndFly)
     {
         // We are done, and can do RTL to go home.
         LogInfo() << "Commanding RTL...";
-        const Action::Result result = action->return_to_launch();
-        EXPECT_EQ(result, Action::Result::SUCCESS);
+        const ActionResult result = action->return_to_launch();
+        EXPECT_EQ(result, ActionResult::SUCCESS);
         LogInfo() << "Commanded RTL.";
     }
 

--- a/integration_tests/mission_change_speed.cpp
+++ b/integration_tests/mission_change_speed.cpp
@@ -64,8 +64,8 @@ TEST_F(SitlTest, MissionChangeSpeed)
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_TRUE(_mission_sent_ok);
 
-    Action::Result result = action->arm();
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ActionResult result = action->arm();
+    ASSERT_EQ(result, ActionResult::SUCCESS);
 
     mission->subscribe_progress(std::bind(&receive_mission_progress, _1, _2));
 
@@ -96,7 +96,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     LogInfo() << "mission done";
 
     result = action->return_to_launch();
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, ActionResult::SUCCESS);
 
     while (!mission->mission_finished()) {
         std::cout << "waiting until mission is done" << std::endl;
@@ -109,7 +109,7 @@ TEST_F(SitlTest, MissionChangeSpeed)
     }
 
     result = action->disarm();
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, ActionResult::SUCCESS);
 }
 
 void receive_upload_mission_result(Mission::Result result)

--- a/integration_tests/mission_survey.cpp
+++ b/integration_tests/mission_survey.cpp
@@ -33,9 +33,9 @@ static MissionState _mission_state = MissionState::INIT;
 static void receive_upload_mission_result(Mission::Result result);
 static void receive_start_mission_result(Mission::Result result);
 static void receive_mission_progress(int current, int total);
-static void receive_arm_result(Action::Result result);
-static void receive_return_to_launch_result(Action::Result result);
-static void receive_disarm_result(Action::Result result);
+static void receive_arm_result(ActionResult result);
+static void receive_return_to_launch_result(ActionResult result);
+static void receive_disarm_result(ActionResult result);
 
 static std::shared_ptr<MissionItem> add_waypoint(double latitude_deg,
                                                  double longitude_deg,
@@ -238,11 +238,11 @@ void receive_mission_progress(int current, int total)
     }
 }
 
-void receive_arm_result(Action::Result result)
+void receive_arm_result(ActionResult result)
 {
-    EXPECT_EQ(result, Action::Result::SUCCESS);
+    EXPECT_EQ(result, ActionResult::SUCCESS);
 
-    if (result == Action::Result::SUCCESS) {
+    if (result == ActionResult::SUCCESS) {
         _mission_state = MissionState::ARMING_DONE;
     } else {
         std::cerr << "Error: arming result: " << unsigned(result) << std::endl;
@@ -250,11 +250,11 @@ void receive_arm_result(Action::Result result)
     }
 }
 
-void receive_return_to_launch_result(Action::Result result)
+void receive_return_to_launch_result(ActionResult result)
 {
-    EXPECT_EQ(result, Action::Result::SUCCESS);
+    EXPECT_EQ(result, ActionResult::SUCCESS);
 
-    if (result == Action::Result::SUCCESS) {
+    if (result == ActionResult::SUCCESS) {
     } else {
         std::cerr << "Error: return to land result: " << unsigned(result) << std::endl;
         _mission_state = MissionState::ERROR;
@@ -262,11 +262,11 @@ void receive_return_to_launch_result(Action::Result result)
 }
 
 
-void receive_disarm_result(Action::Result result)
+void receive_disarm_result(ActionResult result)
 {
-    EXPECT_EQ(result, Action::Result::SUCCESS);
+    EXPECT_EQ(result, ActionResult::SUCCESS);
 
-    if (result == Action::Result::SUCCESS) {
+    if (result == ActionResult::SUCCESS) {
     } else {
         std::cerr << "Error: disarming result: " << unsigned(result) << std::endl;
     }

--- a/integration_tests/offboard_velocity.cpp
+++ b/integration_tests/offboard_velocity.cpp
@@ -31,11 +31,11 @@ TEST_F(SitlTest, OffboardVelocityNED)
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ActionResult action_ret = action->arm();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -103,7 +103,7 @@ TEST_F(SitlTest, OffboardVelocityNED)
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
 }
 
 
@@ -127,11 +127,11 @@ TEST_F(SitlTest, OffboardVelocityBody)
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    Action::Result action_ret = action->arm();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ActionResult action_ret = action->arm();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     action_ret = action->takeoff();
-    ASSERT_EQ(Action::Result::SUCCESS, action_ret);
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -174,5 +174,5 @@ TEST_F(SitlTest, OffboardVelocityBody)
     EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
 }

--- a/integration_tests/simple_hover.cpp
+++ b/integration_tests/simple_hover.cpp
@@ -49,8 +49,8 @@ void takeoff_and_hover_at_altitude(float altitude_m)
         ASSERT_LT(++iteration, 10);
     }
 
-    Action::Result action_ret = action->arm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    ActionResult action_ret = action->arm();
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     if (std::isfinite(altitude_m)) {
@@ -61,7 +61,7 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     }
 
     action_ret = action->takeoff();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
     // We wait 1.5s / m plus a margin of 3s.
     const int wait_time_s = static_cast<int>(altitude_m * 1.5f + 3.0f);
     std::this_thread::sleep_for(std::chrono::seconds(wait_time_s));
@@ -71,7 +71,7 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     EXPECT_LT(telemetry->position().relative_altitude_m, altitude_m + 0.25f);
 
     action_ret = action->land();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
 
     iteration = 0;
     while (telemetry->in_air()) {
@@ -83,5 +83,5 @@ void takeoff_and_hover_at_altitude(float altitude_m)
     }
 
     action_ret = action->disarm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
 }

--- a/integration_tests/takeoff_and_kill.cpp
+++ b/integration_tests/takeoff_and_kill.cpp
@@ -15,25 +15,25 @@ static bool _received_arm_result = false;
 static bool _received_takeoff_result = false;
 static bool _received_kill_result = false;
 
-static void receive_arm_result(Action::Result result);
-static void receive_takeoff_result(Action::Result result);
-static void receive_kill_result(Action::Result result);
+static void receive_arm_result(ActionResult result);
+static void receive_takeoff_result(ActionResult result);
+static void receive_kill_result(ActionResult result);
 
-void receive_arm_result(Action::Result result)
+void receive_arm_result(ActionResult result)
 {
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, ActionResult::SUCCESS);
     _received_arm_result = true;
 }
 
-void receive_takeoff_result(Action::Result result)
+void receive_takeoff_result(ActionResult result)
 {
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, ActionResult::SUCCESS);
     _received_takeoff_result = true;
 }
 
-void receive_kill_result(Action::Result result)
+void receive_kill_result(ActionResult result)
 {
-    ASSERT_EQ(result, Action::Result::SUCCESS);
+    ASSERT_EQ(result, ActionResult::SUCCESS);
     _received_kill_result = true;
 }
 

--- a/integration_tests/transition_multicopter_fixedwing.cpp
+++ b/integration_tests/transition_multicopter_fixedwing.cpp
@@ -39,8 +39,8 @@ void takeoff_and_transition_to_fixedwing()
     takeoff(action, telemetry);
 
     LogInfo() << "Transitioning to fixedwing";
-    Action::Result transition_result = action->transition_to_fixedwing();
-    EXPECT_EQ(transition_result, Action::Result::SUCCESS);
+    ActionResult transition_result = action->transition_to_fixedwing();
+    EXPECT_EQ(transition_result, ActionResult::SUCCESS);
 
     // Wait a little before the transition back to multicopter,
     // so we can actually see it fly
@@ -48,7 +48,7 @@ void takeoff_and_transition_to_fixedwing()
 
     LogInfo() << "Transitioning to multicopter";
     transition_result = action->transition_to_multicopter();
-    EXPECT_EQ(transition_result, Action::Result::SUCCESS);
+    EXPECT_EQ(transition_result, ActionResult::SUCCESS);
 
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
@@ -75,15 +75,15 @@ void takeoff(std::shared_ptr<Action> action, std::shared_ptr<Telemetry> telemetr
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    Action::Result action_ret = action->arm();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    ActionResult action_ret = action->arm();
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     float altitude_m = 10.0f;
     action->set_takeoff_altitude(altitude_m);
 
     action_ret = action->takeoff();
-    EXPECT_EQ(action_ret, Action::Result::SUCCESS);
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
     const int wait_time_s = 10;
     std::this_thread::sleep_for(std::chrono::seconds(wait_time_s));
 

--- a/plugins/action/CMakeLists.txt
+++ b/plugins/action/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(dronecore_action
 
 install(FILES
     action.h
+    action_result.h
     DESTINATION ${dronecore_install_include_dir}
 )
 

--- a/plugins/action/action.cpp
+++ b/plugins/action/action.cpp
@@ -13,42 +13,42 @@ Action::~Action()
 {
 }
 
-Action::Result Action::arm() const
+ActionResult Action::arm() const
 {
     return _impl->arm();
 }
 
-Action::Result Action::disarm() const
+ActionResult Action::disarm() const
 {
     return _impl->disarm();
 }
 
-Action::Result Action::kill() const
+ActionResult Action::kill() const
 {
     return _impl->kill();
 }
 
-Action::Result Action::takeoff() const
+ActionResult Action::takeoff() const
 {
     return _impl->takeoff();
 }
 
-Action::Result Action::land() const
+ActionResult Action::land() const
 {
     return _impl->land();
 }
 
-Action::Result Action::return_to_launch() const
+ActionResult Action::return_to_launch() const
 {
     return _impl->return_to_launch();
 }
 
-Action::Result Action::transition_to_fixedwing() const
+ActionResult Action::transition_to_fixedwing() const
 {
     return _impl->transition_to_fixedwing();
 }
 
-Action::Result Action::transition_to_multicopter() const
+ActionResult Action::transition_to_multicopter() const
 {
     return _impl->transition_to_multicopter();
 }
@@ -112,35 +112,5 @@ float Action::get_max_speed_m_s() const
 {
     return _impl->get_max_speed_m_s();
 }
-
-const char *Action::result_str(Result result)
-{
-    switch (result) {
-        case Result::SUCCESS:
-            return "Success";
-        case Result::NO_DEVICE:
-            return "No device";
-        case Result::CONNECTION_ERROR:
-            return "Connection error";
-        case Result::BUSY:
-            return "Busy";
-        case Result::COMMAND_DENIED:
-            return "Command denied";
-        case Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN:
-            return "Command denied, landed state is unknown";
-        case Result::COMMAND_DENIED_NOT_LANDED:
-            return "Command denied, not landed";
-        case Result::TIMEOUT:
-            return "Timeout";
-        case Result::VTOL_TRANSITION_SUPPORT_UNKNOWN:
-            return "VTOL transition unknown";
-        case Result::NO_VTOL_TRANSITION_SUPPORT:
-            return "No VTOL transition support";
-        case Result::UNKNOWN:
-        default:
-            return "Unknown";
-    }
-}
-
 
 } // namespace dronecore

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -2,6 +2,8 @@
 
 #include <functional>
 #include <memory>
+
+#include "action_result.h"
 #include "plugin_base.h"
 
 namespace dronecore {
@@ -16,7 +18,7 @@ class ActionImpl;
  * Synchronous and asynchronous variants of the action methods are supplied.
  *
  * The action methods send their associated MAVLink commands to the vehicle and complete
- * (return synchronously or callback asynchronously) with an Action::Result value
+ * (return synchronously or callback asynchronously) with an ActionResult value
  * indicating whether the vehicle has accepted or rejected the command, or that there has been some
  * error.
  * If the command is accepted, the vehicle will then start to perform the associated action.
@@ -43,39 +45,14 @@ public:
     ~Action();
 
     /**
-     * @brief Possible results returned for commanded actions.
-     */
-    enum class Result {
-        UNKNOWN, /**< @brief Unspecified error. */
-        SUCCESS, /**< @brief Success. The action command was accepted by the vehicle. */
-        NO_DEVICE, /**< @brief No device is connected error. */
-        CONNECTION_ERROR, /**< @brief %Connection error. */
-        BUSY, /**< @brief Vehicle busy error. */
-        COMMAND_DENIED, /**< @brief Command refused by vehicle. */
-        COMMAND_DENIED_LANDED_STATE_UNKNOWN, /**< @brief Command refused because landed state is unknown. */
-        COMMAND_DENIED_NOT_LANDED, /**< @brief Command refused because vehicle not landed. */
-        TIMEOUT, /**< @brief Timeout waiting for command acknowledgement from vehicle. */
-        VTOL_TRANSITION_SUPPORT_UNKNOWN, /**< @brief hybrid/VTOL transition refused because VTOL support is unknown. */
-        NO_VTOL_TRANSITION_SUPPORT /**< @brief Vehicle does not support hybrid/VTOL transitions. */
-    };
-
-    /**
-     * @brief Returns a human-readable English string for an Action::Result.
-     *
-     * @param result The enum value for which a human readable string is required.
-     * @return Human readable string for the Action::Result.
-     */
-    static const char *result_str(Result result);
-
-    /**
      * @brief Send command to *arm* the drone (synchronous).
      *
      * **Note** Arming a drone normally causes motors to spin at idle.
      * Before arming take all safety precautions and stand clear of the drone!
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result arm() const;
+    ActionResult arm() const;
 
     /**
      * @brief Send command to *disarm* the drone (synchronous).
@@ -83,9 +60,9 @@ public:
      * This will disarm a drone that considers itself landed. If flying, the drone should
      * reject the disarm command. Disarming means that all motors will stop.
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result disarm() const;
+    ActionResult disarm() const;
 
     /**
      * @brief Send command to *kill* the drone (synchronous).
@@ -93,9 +70,9 @@ public:
      * This will disarm a drone irrespective of whether it is landed or flying.
      * Note that the drone will fall out of the sky if this command is used while flying.
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result kill() const;
+    ActionResult kill() const;
 
     /**
      * @brief Send command to *take off and hover* (synchronous).
@@ -105,9 +82,9 @@ public:
      *
      * Note that the vehicle must be armed before it can take off.
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result takeoff() const;
+    ActionResult takeoff() const;
 
     /**
      * @brief Send command to *land* at the current position (synchronous).
@@ -115,9 +92,9 @@ public:
      * This switches the drone to
      * [Land mode](https://docs.px4.io/en/flight_modes/land.html).
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result land() const;
+    ActionResult land() const;
 
     /**
      * @brief Send command to *return to the launch* (takeoff) position and *land* (asynchronous).
@@ -126,36 +103,36 @@ public:
      * generally means it will rise up to a certain altitude to clear any obstacles before heading
      * back to the launch (takeoff) position and land there.
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result return_to_launch() const;
+    ActionResult return_to_launch() const;
 
     /**
      * @brief Send command to transition the drone to fixedwing.
      *
      * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with a Result). The command will succeed if called when the vehicle is
+     * command will fail with an ActionResult). The command will succeed if called when the vehicle is
      * already in fixedwing mode.
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result transition_to_fixedwing() const;
+    ActionResult transition_to_fixedwing() const;
 
     /**
      * @brief Send command to transition the drone to multicopter.
      *
      * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with a Result). The command will succeed if called when the vehicle is
+     * command will fail with an ActionResult). The command will succeed if called when the vehicle is
      * already in multicopter mode.
      *
-     * @return Result of request.
+     * @return ActionResult of request.
      */
-    Result transition_to_multicopter() const;
+    ActionResult transition_to_multicopter() const;
 
     /**
      * @brief Callback type for asynchronous Action calls.
      */
-    typedef std::function<void(Result)> result_callback_t;
+    typedef std::function<void(ActionResult)> result_callback_t;
 
     /**
      * @brief Send command to *arm* the drone (asynchronous).
@@ -224,7 +201,7 @@ public:
      * @brief Send command to transition the drone to fixedwing (asynchronous).
      *
      * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with a Result). The command will succeed if called when the vehicle is
+     * command will fail with an ActionResult). The command will succeed if called when the vehicle is
      * already in fixedwing mode.
      *
      * @param callback Function to call with result of request.
@@ -235,7 +212,7 @@ public:
      * @brief Send command to transition the drone to multicopter (asynchronous).
      *
      * The associated action will only be executed for VTOL vehicles (on other vehicle types the
-     * command will fail with a Result). The command will succeed if called when the vehicle is
+     * command will fail with an ActionResult). The command will succeed if called when the vehicle is
      * already in multicopter mode.
      *
      * @param callback Function to call with result of request.

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -1,6 +1,6 @@
-#include "global_include.h"
 #include "action_impl.h"
 #include "dronecore_impl.h"
+#include "global_include.h"
 #include "px4_custom_mode.h"
 
 namespace dronecore {
@@ -43,10 +43,10 @@ void ActionImpl::enable()
 
 void ActionImpl::disable() {}
 
-Action::Result ActionImpl::arm() const
+ActionResult ActionImpl::arm() const
 {
-    Action::Result ret = arming_allowed();
-    if (ret != Action::Result::SUCCESS) {
+    ActionResult ret = arming_allowed();
+    if (ret != ActionResult::SUCCESS) {
         return ret;
     }
 
@@ -54,7 +54,7 @@ Action::Result ActionImpl::arm() const
     ret = action_result_from_command_result(
               _parent.set_flight_mode(Device::FlightMode::HOLD));
 
-    if (ret != Action::Result::SUCCESS) {
+    if (ret != ActionResult::SUCCESS) {
         return ret;
     }
 
@@ -65,10 +65,10 @@ Action::Result ActionImpl::arm() const
                    MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
 }
 
-Action::Result ActionImpl::disarm() const
+ActionResult ActionImpl::disarm() const
 {
-    Action::Result ret = disarming_allowed();
-    if (ret != Action::Result::SUCCESS) {
+    ActionResult ret = disarming_allowed();
+    if (ret != ActionResult::SUCCESS) {
         return ret;
     }
 
@@ -79,7 +79,7 @@ Action::Result ActionImpl::disarm() const
                    MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
 }
 
-Action::Result ActionImpl::kill() const
+ActionResult ActionImpl::kill() const
 {
     return action_result_from_command_result(
                _parent.send_command_with_ack(
@@ -88,10 +88,10 @@ Action::Result ActionImpl::kill() const
                    MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
 }
 
-Action::Result ActionImpl::takeoff() const
+ActionResult ActionImpl::takeoff() const
 {
-    Action::Result ret = taking_off_allowed();
-    if (ret != Action::Result::SUCCESS) {
+    ActionResult ret = taking_off_allowed();
+    if (ret != ActionResult::SUCCESS) {
         return ret;
     }
 
@@ -107,7 +107,7 @@ Action::Result ActionImpl::takeoff() const
                    MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
 }
 
-Action::Result ActionImpl::land() const
+ActionResult ActionImpl::land() const
 {
     return action_result_from_command_result(
                _parent.send_command_with_ack(
@@ -116,20 +116,20 @@ Action::Result ActionImpl::land() const
                    MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
 }
 
-Action::Result ActionImpl::return_to_launch() const
+ActionResult ActionImpl::return_to_launch() const
 {
     return action_result_from_command_result(
                _parent.set_flight_mode(Device::FlightMode::RETURN_TO_LAUNCH));
 }
 
-Action::Result ActionImpl::transition_to_fixedwing() const
+ActionResult ActionImpl::transition_to_fixedwing() const
 {
     if (!_vtol_transition_support_known) {
-        return Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN;
+        return ActionResult::VTOL_TRANSITION_SUPPORT_UNKNOWN;
     }
 
     if (!_vtol_transition_possible) {
-        return Action::Result::NO_VTOL_TRANSITION_SUPPORT;
+        return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
     return action_result_from_command_result(
@@ -143,14 +143,14 @@ void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &
 {
     if (!_vtol_transition_support_known) {
         if (callback) {
-            callback(Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN);
+            callback(ActionResult::VTOL_TRANSITION_SUPPORT_UNKNOWN);
         }
         return;
     }
 
     if (!_vtol_transition_possible) {
         if (callback) {
-            callback(Action::Result::NO_VTOL_TRANSITION_SUPPORT);
+            callback(ActionResult::NO_VTOL_TRANSITION_SUPPORT);
         }
         return;
     }
@@ -164,14 +164,14 @@ void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &
         MavlinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
 }
 
-Action::Result ActionImpl::transition_to_multicopter() const
+ActionResult ActionImpl::transition_to_multicopter() const
 {
     if (!_vtol_transition_support_known) {
-        return Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN;
+        return ActionResult::VTOL_TRANSITION_SUPPORT_UNKNOWN;
     }
 
     if (!_vtol_transition_possible) {
-        return Action::Result::NO_VTOL_TRANSITION_SUPPORT;
+        return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
     return action_result_from_command_result(
@@ -185,14 +185,14 @@ void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t
 {
     if (!_vtol_transition_support_known) {
         if (callback) {
-            callback(Action::Result::VTOL_TRANSITION_SUPPORT_UNKNOWN);
+            callback(ActionResult::VTOL_TRANSITION_SUPPORT_UNKNOWN);
         }
         return;
     }
 
     if (!_vtol_transition_possible) {
         if (callback) {
-            callback(Action::Result::NO_VTOL_TRANSITION_SUPPORT);
+            callback(ActionResult::NO_VTOL_TRANSITION_SUPPORT);
         }
         return;
     }
@@ -208,8 +208,8 @@ void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t
 
 void ActionImpl::arm_async(const Action::result_callback_t &callback)
 {
-    Action::Result ret = arming_allowed();
-    if (ret != Action::Result::SUCCESS) {
+    ActionResult ret = arming_allowed();
+    if (ret != ActionResult::SUCCESS) {
         if (callback) {
             callback(ret);
         }
@@ -239,8 +239,8 @@ void ActionImpl::arm_async_continued(MavlinkCommands::Result previous_result,
 
 void ActionImpl::disarm_async(const Action::result_callback_t &callback)
 {
-    Action::Result ret = disarming_allowed();
-    if (ret != Action::Result::SUCCESS) {
+    ActionResult ret = disarming_allowed();
+    if (ret != ActionResult::SUCCESS) {
         if (callback) {
             callback(ret);
         }
@@ -269,8 +269,8 @@ void ActionImpl::kill_async(const Action::result_callback_t &callback)
 
 void ActionImpl::takeoff_async(const Action::result_callback_t &callback)
 {
-    Action::Result ret = taking_off_allowed();
-    if (ret != Action::Result::SUCCESS) {
+    ActionResult ret = taking_off_allowed();
+    if (ret != ActionResult::SUCCESS) {
         if (callback) {
             callback(ret);
         }
@@ -317,43 +317,43 @@ void ActionImpl::return_to_launch_async(const Action::result_callback_t &callbac
         std::bind(&ActionImpl::command_result_callback, _1, callback));
 }
 
-Action::Result ActionImpl::arming_allowed() const
+ActionResult ActionImpl::arming_allowed() const
 {
     if (!_in_air_state_known) {
-        return Action::Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN;
+        return ActionResult::COMMAND_DENIED_LANDED_STATE_UNKNOWN;
     }
 
     if (_in_air) {
-        return Action::Result::COMMAND_DENIED_NOT_LANDED;
+        return ActionResult::COMMAND_DENIED_NOT_LANDED;
     }
 
-    return Action::Result::SUCCESS;
+    return ActionResult::SUCCESS;
 }
 
-Action::Result ActionImpl::taking_off_allowed() const
+ActionResult ActionImpl::taking_off_allowed() const
 {
     if (!_in_air_state_known) {
-        return Action::Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN;
+        return ActionResult::COMMAND_DENIED_LANDED_STATE_UNKNOWN;
     }
 
     if (_in_air) {
-        return Action::Result::COMMAND_DENIED_NOT_LANDED;
+        return ActionResult::COMMAND_DENIED_NOT_LANDED;
     }
 
-    return Action::Result::SUCCESS;
+    return ActionResult::SUCCESS;
 }
 
-Action::Result ActionImpl::disarming_allowed() const
+ActionResult ActionImpl::disarming_allowed() const
 {
     if (!_in_air_state_known) {
-        return Action::Result::COMMAND_DENIED_LANDED_STATE_UNKNOWN;
+        return ActionResult::COMMAND_DENIED_LANDED_STATE_UNKNOWN;
     }
 
     if (_in_air) {
-        return Action::Result::COMMAND_DENIED_NOT_LANDED;
+        return ActionResult::COMMAND_DENIED_NOT_LANDED;
     }
 
-    return Action::Result::SUCCESS;
+    return ActionResult::SUCCESS;
 }
 
 void ActionImpl::process_extended_sys_state(const mavlink_message_t &message)
@@ -435,31 +435,31 @@ float ActionImpl::get_max_speed_m_s() const
     return _max_speed_m_s;
 }
 
-Action::Result
+ActionResult
 ActionImpl::action_result_from_command_result(MavlinkCommands::Result result)
 {
     switch (result) {
         case MavlinkCommands::Result::SUCCESS:
-            return Action::Result::SUCCESS;
+            return ActionResult::SUCCESS;
         case MavlinkCommands::Result::NO_DEVICE:
-            return Action::Result::NO_DEVICE;
+            return ActionResult::NO_DEVICE;
         case MavlinkCommands::Result::CONNECTION_ERROR:
-            return Action::Result::CONNECTION_ERROR;
+            return ActionResult::CONNECTION_ERROR;
         case MavlinkCommands::Result::BUSY:
-            return Action::Result::BUSY;
+            return ActionResult::BUSY;
         case MavlinkCommands::Result::COMMAND_DENIED:
-            return Action::Result::COMMAND_DENIED;
+            return ActionResult::COMMAND_DENIED;
         case MavlinkCommands::Result::TIMEOUT:
-            return Action::Result::TIMEOUT;
+            return ActionResult::TIMEOUT;
         default:
-            return Action::Result::UNKNOWN;
+            return ActionResult::UNKNOWN;
     }
 }
 
 void ActionImpl::command_result_callback(MavlinkCommands::Result command_result,
                                          const Action::result_callback_t &callback)
 {
-    Action::Result action_result = action_result_from_command_result(command_result);
+    ActionResult action_result = action_result_from_command_result(command_result);
 
     if (callback) {
         callback(action_result);

--- a/plugins/action/action_impl.h
+++ b/plugins/action/action_impl.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "plugin_impl_base.h"
-#include "mavlink_include.h"
-#include "device.h"
-#include "action.h"
 #include <cstdint>
+
+#include "action.h"
+#include "action_result.h"
+#include "device.h"
+#include "mavlink_include.h"
+#include "plugin_impl_base.h"
 
 namespace dronecore {
 
@@ -20,14 +22,14 @@ public:
     void enable() override;
     void disable() override;
 
-    Action::Result arm() const;
-    Action::Result disarm() const;
-    Action::Result kill() const;
-    Action::Result takeoff() const;
-    Action::Result land() const;
-    Action::Result return_to_launch() const;
-    Action::Result transition_to_fixedwing() const;
-    Action::Result transition_to_multicopter() const;
+    ActionResult arm() const;
+    ActionResult disarm() const;
+    ActionResult kill() const;
+    ActionResult takeoff() const;
+    ActionResult land() const;
+    ActionResult return_to_launch() const;
+    ActionResult transition_to_fixedwing() const;
+    ActionResult transition_to_multicopter() const;
 
     void arm_async(const Action::result_callback_t &callback);
     void disarm_async(const Action::result_callback_t &callback);
@@ -53,9 +55,9 @@ private:
     void arm_async_continued(MavlinkCommands::Result previous_result,
                              const Action::result_callback_t &callback);
 
-    Action::Result arming_allowed() const;
-    Action::Result disarming_allowed() const;
-    Action::Result taking_off_allowed() const;
+    ActionResult arming_allowed() const;
+    ActionResult disarming_allowed() const;
+    ActionResult taking_off_allowed() const;
 
     void process_extended_sys_state(const mavlink_message_t &message);
 
@@ -63,7 +65,7 @@ private:
 
     void receive_takeoff_alt_param(bool success, float new_relative_altitude_m);
 
-    static Action::Result action_result_from_command_result(MavlinkCommands::Result result);
+    static ActionResult action_result_from_command_result(MavlinkCommands::Result result);
 
     static void command_result_callback(MavlinkCommands::Result command_result,
                                         const Action::result_callback_t &callback);

--- a/plugins/action/action_result.h
+++ b/plugins/action/action_result.h
@@ -1,0 +1,63 @@
+#pragma once
+
+/**
+ * @brief Namespace for all dronecore types.
+ */
+namespace dronecore {
+
+/**
+ * @brief Possible results returned for commanded actions.
+ *
+ * **Note**: DroneCore does not throw exceptions. Instead a result of this type will be
+ * returned when you execute actions.
+ */
+enum class ActionResult {
+    UNKNOWN, /**< @brief Unspecified error. */
+    SUCCESS, /**< @brief Success. The action command was accepted by the vehicle. */
+    NO_DEVICE, /**< @brief No device is connected error. */
+    CONNECTION_ERROR, /**< @brief %Connection error. */
+    BUSY, /**< @brief Vehicle busy error. */
+    COMMAND_DENIED, /**< @brief Command refused by vehicle. */
+    COMMAND_DENIED_LANDED_STATE_UNKNOWN, /**< @brief Command refused because landed state is unknown. */
+    COMMAND_DENIED_NOT_LANDED, /**< @brief Command refused because vehicle not landed. */
+    TIMEOUT, /**< @brief Timeout waiting for command acknowledgement from vehicle. */
+    VTOL_TRANSITION_SUPPORT_UNKNOWN, /**< @brief hybrid/VTOL transition refused because VTOL support is unknown. */
+    NO_VTOL_TRANSITION_SUPPORT /**< @brief Vehicle does not support hybrid/VTOL transitions. */
+};
+
+/**
+ * @brief Returns a human-readable English string for an ActionResult.
+ *
+ * @param result The enum value for which a human readable string is required.
+ * @return Human readable string for the ActionResult.
+ */
+inline const char *action_result_str(ActionResult result)
+{
+    switch (result) {
+        case ActionResult::SUCCESS:
+            return "Success";
+        case ActionResult::NO_DEVICE:
+            return "No device";
+        case ActionResult::CONNECTION_ERROR:
+            return "Connection error";
+        case ActionResult::BUSY:
+            return "Busy";
+        case ActionResult::COMMAND_DENIED:
+            return "Command denied";
+        case ActionResult::COMMAND_DENIED_LANDED_STATE_UNKNOWN:
+            return "Command denied, landed state is unknown";
+        case ActionResult::COMMAND_DENIED_NOT_LANDED:
+            return "Command denied, not landed";
+        case ActionResult::TIMEOUT:
+            return "Timeout";
+        case ActionResult::VTOL_TRANSITION_SUPPORT_UNKNOWN:
+            return "VTOL transition unknown";
+        case ActionResult::NO_VTOL_TRANSITION_SUPPORT:
+            return "No VTOL transition support";
+        case ActionResult::UNKNOWN:
+        default:
+            return "Unknown";
+    }
+}
+
+} // namespace dronecore

--- a/plugins/action/mocks/action_mock.h
+++ b/plugins/action/mocks/action_mock.h
@@ -1,7 +1,6 @@
 #include <gmock/gmock.h>
 
-// TODO remove this include!
-#include "action/action.h"
+#include "action/action_result.h"
 
 namespace dronecore {
 namespace testing {
@@ -9,9 +8,9 @@ namespace testing {
 class MockAction
 {
 public:
-    MOCK_CONST_METHOD0(arm, Action::Result());
-    MOCK_CONST_METHOD0(takeoff, Action::Result());
-    MOCK_CONST_METHOD0(land, Action::Result());
+    MOCK_CONST_METHOD0(arm, ActionResult());
+    MOCK_CONST_METHOD0(takeoff, ActionResult());
+    MOCK_CONST_METHOD0(land, ActionResult());
 };
 
 } // namespace testing


### PR DESCRIPTION
Just as for `ConnectionResult`, move `Action::Result` out of `Action` in order to make it available to others, like `MockAction`.