### PR TITLE
backend: fix protobuf to a specific git commit

### DIFF
--- a/backend/cmake/third_party/protobuf/CMakeLists.txt
+++ b/backend/cmake/third_party/protobuf/CMakeLists.txt
@@ -5,7 +5,7 @@ project(external-protobuf)
 include(ExternalProject)
 
 set(ARG_GIT_REPOSITORY https://github.com/google/protobuf.git)
-set(ARG_GIT_TAG master)
+set(ARG_GIT_TAG ab95b1bc1eb964ee5f1fb48297344c5d37d35191)
 
 if(ANDROID)
     message(STATUS "Preparing external project \"protobuf\" for Android...")


### PR DESCRIPTION
It should be fixed anyway, and recent commits break the build of the backend right now.