### PR TITLE
Add .ignore file to ignore everything third_party

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+**/third_party/*
+third_party/*


### PR DESCRIPTION
I would prefer it if ripgrep does not search through the third_party
directories but only in our source code. Therefore I've added this
.ignore file.