### PR TITLE
mission plugin: Clear old mission items

### DIFF
--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -954,6 +954,9 @@ MissionImpl::import_qgroundcontrol_mission(Mission::mission_items_t &mission_ite
         return Mission::Result::FAILED_TO_PARSE_QGC_PLAN;
     }
 
+    // Clear old mission items
+    mission_items.clear();
+
     // Import mission items
     return import_mission_items(mission_items, parsed_plan);
 }


### PR DESCRIPTION
Before importing mission items from a QGroundControl plan, we've to clear old ones; otherwise they would reside along with new mission items, which is not expected. This commit clears them before importing mission items.
Connects to #348.