### PR TITLE
Add support for COMMAND_INT and abstraction for the same including `COMMAND_LONG`

### DIFF
--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -32,7 +32,7 @@ MAVLinkCommands::~MAVLinkCommands()
 }
 
 MAVLinkCommands::Result
-MAVLinkCommands::send_command(MAVLinkCommands::CmdInt &cmd)
+MAVLinkCommands::send_command(MAVLinkCommands::CommandInt &cmd)
 {
     struct PromiseResult {
         Result result;
@@ -67,7 +67,7 @@ MAVLinkCommands::send_command(MAVLinkCommands::CmdInt &cmd)
 }
 
 MAVLinkCommands::Result
-MAVLinkCommands::send_command(MAVLinkCommands::CmdLong &cmd)
+MAVLinkCommands::send_command(MAVLinkCommands::CommandLong &cmd)
 {
     struct PromiseResult {
         Result result;
@@ -106,7 +106,7 @@ MAVLinkCommands::send_command(MAVLinkCommands::CmdLong &cmd)
 
 
 void
-MAVLinkCommands::queue_command_async(CmdInt &cmd,
+MAVLinkCommands::queue_command_async(CommandInt &cmd,
                                      command_result_callback_t callback)
 {
     // LogDebug() << "Command " << (int)(cmd.command) << " to send to "
@@ -136,7 +136,7 @@ MAVLinkCommands::queue_command_async(CmdInt &cmd,
 }
 
 void
-MAVLinkCommands::queue_command_async(CmdLong &cmd,
+MAVLinkCommands::queue_command_async(CommandLong &cmd,
                                      command_result_callback_t callback)
 {
     // LogDebug() << "Command " << (int)(cmd.command) << " to send to "

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -32,7 +32,7 @@ MAVLinkCommands::~MAVLinkCommands()
 }
 
 MAVLinkCommands::Result
-MAVLinkCommands::send_command(MAVLinkCommands::CommandInt &cmd)
+MAVLinkCommands::send_command(MAVLinkCommands::CommandInt &command)
 {
     struct PromiseResult {
         Result result;
@@ -43,7 +43,7 @@ MAVLinkCommands::send_command(MAVLinkCommands::CommandInt &cmd)
     std::shared_ptr<std::promise<PromiseResult>> prom =
                                                   std::make_shared<std::promise<PromiseResult>>();
 
-    queue_command_async(cmd,
+    queue_command_async(command,
     [prom](Result result, float progress) {
         PromiseResult promise_result {};
         promise_result.result = result;
@@ -67,7 +67,7 @@ MAVLinkCommands::send_command(MAVLinkCommands::CommandInt &cmd)
 }
 
 MAVLinkCommands::Result
-MAVLinkCommands::send_command(MAVLinkCommands::CommandLong &cmd)
+MAVLinkCommands::send_command(MAVLinkCommands::CommandLong &command)
 {
     struct PromiseResult {
         Result result;
@@ -78,9 +78,9 @@ MAVLinkCommands::send_command(MAVLinkCommands::CommandLong &cmd)
     std::shared_ptr<std::promise<PromiseResult>> prom =
                                                   std::make_shared<std::promise<PromiseResult>>();
 
-    cmd.target_system_id = _parent.get_system_id();
+    command.target_system_id = _parent.get_system_id();
 
-    queue_command_async(cmd,
+    queue_command_async(command,
     [prom](Result result, float progress) {
         PromiseResult promise_result {};
         promise_result.result = result;
@@ -106,60 +106,60 @@ MAVLinkCommands::send_command(MAVLinkCommands::CommandLong &cmd)
 
 
 void
-MAVLinkCommands::queue_command_async(CommandInt &cmd,
+MAVLinkCommands::queue_command_async(CommandInt &command,
                                      command_result_callback_t callback)
 {
-    // LogDebug() << "Command " << (int)(cmd.command) << " to send to "
-    //  << (int)(cmd.target_system_id)<< ", " << (int)(cmd.target_component_id;
+    // LogDebug() << "Command " << (int)(command.command) << " to send to "
+    //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id;
 
     Work new_work {};
     mavlink_msg_command_int_pack(GCSClient::system_id,
                                  GCSClient::component_id,
                                  &new_work.mavlink_message,
-                                 cmd.target_system_id,
-                                 cmd.target_component_id,
-                                 cmd.frame,
-                                 cmd.command,
-                                 cmd.current,
-                                 cmd.autocontinue,
-                                 cmd.params.param1,
-                                 cmd.params.param2,
-                                 cmd.params.param3,
-                                 cmd.params.param4,
-                                 cmd.params.x,
-                                 cmd.params.y,
-                                 cmd.params.z);
+                                 command.target_system_id,
+                                 command.target_component_id,
+                                 command.frame,
+                                 command.command,
+                                 command.current,
+                                 command.autocontinue,
+                                 command.params.param1,
+                                 command.params.param2,
+                                 command.params.param3,
+                                 command.params.param4,
+                                 command.params.x,
+                                 command.params.y,
+                                 command.params.z);
 
     new_work.callback = callback;
-    new_work.mavlink_command = cmd.command;
+    new_work.mavlink_command = command.command;
     _work_queue.push_back(new_work);
 }
 
 void
-MAVLinkCommands::queue_command_async(CommandLong &cmd,
+MAVLinkCommands::queue_command_async(CommandLong &command,
                                      command_result_callback_t callback)
 {
-    // LogDebug() << "Command " << (int)(cmd.command) << " to send to "
-    //  << (int)(cmd.target_system_id)<< ", " << (int)(cmd.target_component_id;
+    // LogDebug() << "Command " << (int)(command.command) << " to send to "
+    //  << (int)(command.target_system_id)<< ", " << (int)(command.target_component_id;
 
     Work new_work {};
     mavlink_msg_command_long_pack(GCSClient::system_id,
                                   GCSClient::component_id,
                                   &new_work.mavlink_message,
-                                  cmd.target_system_id,
-                                  cmd.target_component_id,
-                                  cmd.command,
-                                  cmd.confirmation,
-                                  cmd.params.param1,
-                                  cmd.params.param2,
-                                  cmd.params.param3,
-                                  cmd.params.param4,
-                                  cmd.params.param5,
-                                  cmd.params.param6,
-                                  cmd.params.param7);
+                                  command.target_system_id,
+                                  command.target_component_id,
+                                  command.command,
+                                  command.confirmation,
+                                  command.params.param1,
+                                  command.params.param2,
+                                  command.params.param3,
+                                  command.params.param4,
+                                  command.params.param5,
+                                  command.params.param6,
+                                  command.params.param7);
 
     new_work.callback = callback;
-    new_work.mavlink_command = cmd.command;
+    new_work.mavlink_command = command.command;
     _work_queue.push_back(new_work);
 }
 

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -126,9 +126,9 @@ MAVLinkCommands::queue_command_async(CommandInt &cmd,
                                  cmd.params.param2,
                                  cmd.params.param3,
                                  cmd.params.param4,
-                                 cmd.params.lat_deg,
-                                 cmd.params.lon_deg,
-                                 cmd.params.alt_m);
+                                 cmd.params.x,
+                                 cmd.params.y,
+                                 cmd.params.z);
 
     new_work.callback = callback;
     new_work.mavlink_command = cmd.command;

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -43,19 +43,20 @@ public:
             float param2 = NAN;
             float param3 = NAN;
             float param4 = NAN;
-            int32_t lat_deg = 0;
-            int32_t lon_deg = 0;
-            float alt_m = NAN;
+            int32_t x = 0;
+            int32_t y = 0;
+            float z = NAN;
         } params;
+
         static void set_as_reserved(Params &params)
         {
             params.param1 = 0.f;
             params.param2 = 0.f;
             params.param3 = 0.f;
             params.param4 = 0.f;
-            params.lat_deg = 0;
-            params.lon_deg = 0;
-            params.alt_m = 0.f;
+            params.x = 0;
+            params.y = 0;
+            params.z = 0.f;
         }
     };
 
@@ -73,6 +74,7 @@ public:
             float param6 = NAN;
             float param7 = NAN;
         } params;
+
         static void set_as_reserved(Params &params)
         {
             params.param1 = 0.f;

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <functional>
 #include <mutex>
-#include <memory>
 
 namespace dronecore {
 
@@ -38,6 +37,7 @@ public:
         uint16_t command;
         bool current = 0;
         bool autocontinue = false;
+        // Most of the "Reserved" values in MAVLink spec are NAN.
         struct Params {
             float param1 = NAN;
             float param2 = NAN;
@@ -48,15 +48,18 @@ public:
             float z = NAN;
         } params;
 
-        static void set_as_reserved(Params &params)
+        // In some cases "Reserved" value could be "0".
+        // This utility method can be used in such case.
+        static
+        void set_as_reserved(Params &params, float reserve_val = NAN)
         {
-            params.param1 = 0.f;
-            params.param2 = 0.f;
-            params.param3 = 0.f;
-            params.param4 = 0.f;
+            params.param1 = reserve_val;
+            params.param2 = reserve_val;
+            params.param3 = reserve_val;
+            params.param4 = reserve_val;
             params.x = 0;
             params.y = 0;
-            params.z = 0.f;
+            params.z = reserve_val;
         }
     };
 
@@ -75,15 +78,16 @@ public:
             float param7 = NAN;
         } params;
 
-        static void set_as_reserved(Params &params)
+        static
+        void set_as_reserved(Params &params, float reserve_val = NAN)
         {
-            params.param1 = 0.f;
-            params.param2 = 0.f;
-            params.param3 = 0.f;
-            params.param4 = 0.f;
-            params.param5 = 0.f;
-            params.param6 = 0.f;
-            params.param7 = 0.f;
+            params.param1 = reserve_val;
+            params.param2 = reserve_val;
+            params.param3 = reserve_val;
+            params.param4 = reserve_val;
+            params.param5 = reserve_val;
+            params.param6 = reserve_val;
+            params.param7 = reserve_val;
         }
     };
 

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -31,7 +31,7 @@ public:
 
     typedef std::function<void(Result, float)> command_result_callback_t;
 
-    struct CmdInt {
+    struct CommandInt {
         uint8_t target_system_id;
         uint8_t target_component_id;
         MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
@@ -59,7 +59,7 @@ public:
         }
     };
 
-    struct CmdLong {
+    struct CommandLong {
         uint8_t target_system_id;
         uint8_t target_component_id;
         uint16_t command;
@@ -85,11 +85,11 @@ public:
         }
     };
 
-    Result send_command(CmdInt &cmd);
-    Result send_command(CmdLong &cmd);
+    Result send_command(CommandInt &cmd);
+    Result send_command(CommandLong &cmd);
 
-    void queue_command_async(CmdInt &cmd, command_result_callback_t callback);
-    void queue_command_async(CmdLong &cmd, command_result_callback_t callback);
+    void queue_command_async(CommandInt &cmd, command_result_callback_t callback);
+    void queue_command_async(CommandLong &cmd, command_result_callback_t callback);
 
     void do_work();
 

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -51,15 +51,15 @@ public:
         // In some cases "Reserved" value could be "0".
         // This utility method can be used in such case.
         static
-        void set_as_reserved(Params &params, float reserve_val = NAN)
+        void set_as_reserved(Params &params, float reserved_value = NAN)
         {
-            params.param1 = reserve_val;
-            params.param2 = reserve_val;
-            params.param3 = reserve_val;
-            params.param4 = reserve_val;
+            params.param1 = reserved_value;
+            params.param2 = reserved_value;
+            params.param3 = reserved_value;
+            params.param4 = reserved_value;
             params.x = 0;
             params.y = 0;
-            params.z = reserve_val;
+            params.z = reserved_value;
         }
     };
 
@@ -79,23 +79,23 @@ public:
         } params;
 
         static
-        void set_as_reserved(Params &params, float reserve_val = NAN)
+        void set_as_reserved(Params &params, float reserved_value = NAN)
         {
-            params.param1 = reserve_val;
-            params.param2 = reserve_val;
-            params.param3 = reserve_val;
-            params.param4 = reserve_val;
-            params.param5 = reserve_val;
-            params.param6 = reserve_val;
-            params.param7 = reserve_val;
+            params.param1 = reserved_value;
+            params.param2 = reserved_value;
+            params.param3 = reserved_value;
+            params.param4 = reserved_value;
+            params.param5 = reserved_value;
+            params.param6 = reserved_value;
+            params.param7 = reserved_value;
         }
     };
 
-    Result send_command(CommandInt &cmd);
-    Result send_command(CommandLong &cmd);
+    Result send_command(CommandInt &command);
+    Result send_command(CommandLong &command);
 
-    void queue_command_async(CommandInt &cmd, command_result_callback_t callback);
-    void queue_command_async(CommandLong &cmd, command_result_callback_t callback);
+    void queue_command_async(CommandInt &command, command_result_callback_t callback);
+    void queue_command_async(CommandLong &command, command_result_callback_t callback);
 
     void do_work();
 

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <functional>
 #include <mutex>
+#include <memory>
 
 namespace dronecore {
 
@@ -30,20 +31,65 @@ public:
 
     typedef std::function<void(Result, float)> command_result_callback_t;
 
-    struct Params {
-        float v[7];
+    struct CmdInt {
+        uint8_t target_system_id;
+        uint8_t target_component_id;
+        MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        uint16_t command;
+        bool current = 0;
+        bool autocontinue = false;
+        struct Params {
+            float param1 = NAN;
+            float param2 = NAN;
+            float param3 = NAN;
+            float param4 = NAN;
+            int32_t lat_deg = 0;
+            int32_t lon_deg = 0;
+            float alt_m = NAN;
+        } params;
+        static void set_as_reserved(Params &params)
+        {
+            params.param1 = 0.f;
+            params.param2 = 0.f;
+            params.param3 = 0.f;
+            params.param4 = 0.f;
+            params.lat_deg = 0;
+            params.lon_deg = 0;
+            params.alt_m = 0.f;
+        }
     };
 
-    Result send_command(uint16_t command,
-                        const Params params,
-                        uint8_t target_system_id,
-                        uint8_t target_component_id);
+    struct CmdLong {
+        uint8_t target_system_id;
+        uint8_t target_component_id;
+        uint16_t command;
+        uint8_t confirmation = 0;
+        struct Params {
+            float param1 = NAN;
+            float param2 = NAN;
+            float param3 = NAN;
+            float param4 = NAN;
+            float param5 = NAN;
+            float param6 = NAN;
+            float param7 = NAN;
+        } params;
+        static void set_as_reserved(Params &params)
+        {
+            params.param1 = 0.f;
+            params.param2 = 0.f;
+            params.param3 = 0.f;
+            params.param4 = 0.f;
+            params.param5 = 0.f;
+            params.param6 = 0.f;
+            params.param7 = 0.f;
+        }
+    };
 
-    void queue_command_async(uint16_t command,
-                             const Params params,
-                             uint8_t target_system_id,
-                             uint8_t target_component_id,
-                             command_result_callback_t callback);
+    Result send_command(CmdInt &cmd);
+    Result send_command(CmdLong &cmd);
+
+    void queue_command_async(CmdInt &cmd, command_result_callback_t callback);
+    void queue_command_async(CmdLong &cmd, command_result_callback_t callback);
 
     void do_work();
 

--- a/core/mavlink_system.cpp
+++ b/core/mavlink_system.cpp
@@ -424,12 +424,13 @@ void MAVLinkSystem::request_autopilot_version()
     _autopilot_version_pending = true;
 
     // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
-    send_command_with_ack_async(
-        MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
-        MAVLinkCommands::Params {1.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-        nullptr,
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT
-    );
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
+    cmd.params.param1 = 1.0f;
+    cmd.target_component_id = get_autopilot_id();
+
+    send_command_async(cmd, nullptr);
     ++_uuid_retries;
 
     // We set a timeout to stay "pending" for half a second. This way, we don't give up too
@@ -594,15 +595,15 @@ MAVLinkCommands::Result MAVLinkSystem::set_flight_mode(FlightMode system_mode)
 
     }
 
-    MAVLinkCommands::Result ret = send_command_with_ack(
-                                      MAV_CMD_DO_SET_MODE,
-                                      MAVLinkCommands::Params {float(mode),
-                                                               float(custom_mode),
-                                                               float(custom_sub_mode),
-                                                               NAN, NAN, NAN, NAN},
-                                      MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
 
-    return ret;
+    cmd.command = MAV_CMD_DO_SET_MODE;
+    cmd.params.param1 = float(mode);
+    cmd.params.param2 = float(custom_mode);
+    cmd.params.param3 = float(custom_sub_mode);
+    cmd.target_component_id = get_autopilot_id();
+
+    return send_command(cmd);
 }
 
 void MAVLinkSystem::set_flight_mode_async(FlightMode system_mode,
@@ -650,14 +651,15 @@ void MAVLinkSystem::set_flight_mode_async(FlightMode system_mode,
             return ;
     }
 
+    MAVLinkCommands::CmdLong cmd {};
 
-    send_command_with_ack_async(MAV_CMD_DO_SET_MODE,
-                                MAVLinkCommands::Params {float(mode),
-                                                         float(custom_mode),
-                                                         float(custom_sub_mode),
-                                                         NAN, NAN, NAN, NAN},
-                                callback,
-                                MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    cmd.command = MAV_CMD_DO_SET_MODE;
+    cmd.params.param1 = float(mode);
+    cmd.params.param2 = float(custom_mode);
+    cmd.params.param3 = float(custom_sub_mode);
+    cmd.target_component_id = get_autopilot_id();
+
+    send_command_async(cmd, callback);
 }
 
 void MAVLinkSystem::get_param_int_async(const std::string &name,
@@ -727,23 +729,28 @@ uint8_t MAVLinkSystem::get_gimbal_id() const
     return uint8_t(0);
 }
 
-MAVLinkCommands::Result MAVLinkSystem::send_command_with_ack(
-    uint16_t command, const MAVLinkCommands::Params &params, uint8_t component_id)
+MAVLinkCommands::Result
+MAVLinkSystem::send_command(MAVLinkCommands::CmdLong &cmd)
 {
     if (_system_id == 0 && _components.size() == 0) {
         return MAVLinkCommands::Result::NO_SYSTEM;
     }
-
-    const uint8_t component_id_to_use =
-        ((component_id != 0) ? component_id : get_autopilot_id());
-
-    return _commands.send_command(command, params, _system_id, component_id_to_use);
+    cmd.target_system_id = get_system_id();
+    return _commands.send_command(cmd);
 }
 
-void MAVLinkSystem::send_command_with_ack_async(uint16_t command,
-                                                const MAVLinkCommands::Params &params,
-                                                command_result_callback_t callback,
-                                                uint8_t component_id)
+MAVLinkCommands::Result
+MAVLinkSystem::send_command(MAVLinkCommands::CmdInt &cmd)
+{
+    if (_system_id == 0 && _components.size() == 0) {
+        return MAVLinkCommands::Result::NO_SYSTEM;
+    }
+    cmd.target_system_id = get_system_id();
+    return _commands.send_command(cmd);
+}
+
+void MAVLinkSystem::send_command_async(MAVLinkCommands::CmdLong &cmd,
+                                       command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
         if (callback) {
@@ -751,12 +758,23 @@ void MAVLinkSystem::send_command_with_ack_async(uint16_t command,
         }
         return;
     }
+    cmd.target_system_id = get_system_id();
 
-    const uint8_t component_id_to_use =
-        ((component_id != 0) ? component_id : _components.size() == 0);
+    _commands.queue_command_async(cmd, callback);
+}
 
-    _commands.queue_command_async(command, params, _system_id, component_id_to_use,
-                                  callback);
+void MAVLinkSystem::send_command_async(MAVLinkCommands::CmdInt &cmd,
+                                       command_result_callback_t callback)
+{
+    if (_system_id == 0 && _components.size() == 0) {
+        if (callback) {
+            callback(MAVLinkCommands::Result::NO_SYSTEM, NAN);
+        }
+        return;
+    }
+    cmd.target_system_id = get_system_id();
+
+    _commands.queue_command_async(cmd, callback);
 }
 
 MAVLinkCommands::Result MAVLinkSystem::set_msg_rate(uint16_t message_id, double rate_hz,
@@ -768,16 +786,18 @@ MAVLinkCommands::Result MAVLinkSystem::set_msg_rate(uint16_t message_id, double 
         interval_us = 1e6f / static_cast<float>(rate_hz);
     }
 
-    if (component_id != 0) {
-        return send_command_with_ack(
-                   MAV_CMD_SET_MESSAGE_INTERVAL,
-                   MAVLinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
-                   component_id);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_SET_MESSAGE_INTERVAL;
+    cmd.params.param1 = float(message_id);
+    cmd.params.param2 = interval_us;
+    if (component_id) {
+        cmd.target_component_id = component_id;
     } else {
-        return send_command_with_ack(
-                   MAV_CMD_SET_MESSAGE_INTERVAL,
-                   MAVLinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN});
+        cmd.target_component_id = get_autopilot_id();
     }
+
+    return send_command(cmd);
 }
 
 void MAVLinkSystem::set_msg_rate_async(uint16_t message_id, double rate_hz,
@@ -789,18 +809,18 @@ void MAVLinkSystem::set_msg_rate_async(uint16_t message_id, double rate_hz,
         interval_us = 1e6f / static_cast<float>(rate_hz);
     }
 
-    if (component_id != 0) {
-        send_command_with_ack_async(
-            MAV_CMD_SET_MESSAGE_INTERVAL,
-            MAVLinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
-            callback,
-            component_id);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_SET_MESSAGE_INTERVAL;
+    cmd.params.param1 = float(message_id);
+    cmd.params.param2 = interval_us;
+    if (component_id) {
+        cmd.target_component_id = component_id;
     } else {
-        send_command_with_ack_async(
-            MAV_CMD_SET_MESSAGE_INTERVAL,
-            MAVLinkCommands::Params {float(message_id), interval_us, NAN, NAN, NAN, NAN, NAN},
-            callback);
+        cmd.target_component_id = get_autopilot_id();
     }
+
+    send_command_async(cmd, callback);
 }
 
 void MAVLinkSystem::register_plugin(PluginImplBase *plugin_impl)

--- a/core/mavlink_system.cpp
+++ b/core/mavlink_system.cpp
@@ -424,7 +424,7 @@ void MAVLinkSystem::request_autopilot_version()
     _autopilot_version_pending = true;
 
     // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
     cmd.params.param1 = 1.0f;
@@ -595,7 +595,7 @@ MAVLinkCommands::Result MAVLinkSystem::set_flight_mode(FlightMode system_mode)
 
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_SET_MODE;
     cmd.params.param1 = float(mode);
@@ -651,7 +651,7 @@ void MAVLinkSystem::set_flight_mode_async(FlightMode system_mode,
             return ;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_SET_MODE;
     cmd.params.param1 = float(mode);
@@ -730,7 +730,7 @@ uint8_t MAVLinkSystem::get_gimbal_id() const
 }
 
 MAVLinkCommands::Result
-MAVLinkSystem::send_command(MAVLinkCommands::CmdLong &cmd)
+MAVLinkSystem::send_command(MAVLinkCommands::CommandLong &cmd)
 {
     if (_system_id == 0 && _components.size() == 0) {
         return MAVLinkCommands::Result::NO_SYSTEM;
@@ -740,7 +740,7 @@ MAVLinkSystem::send_command(MAVLinkCommands::CmdLong &cmd)
 }
 
 MAVLinkCommands::Result
-MAVLinkSystem::send_command(MAVLinkCommands::CmdInt &cmd)
+MAVLinkSystem::send_command(MAVLinkCommands::CommandInt &cmd)
 {
     if (_system_id == 0 && _components.size() == 0) {
         return MAVLinkCommands::Result::NO_SYSTEM;
@@ -749,7 +749,7 @@ MAVLinkSystem::send_command(MAVLinkCommands::CmdInt &cmd)
     return _commands.send_command(cmd);
 }
 
-void MAVLinkSystem::send_command_async(MAVLinkCommands::CmdLong &cmd,
+void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandLong &cmd,
                                        command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
@@ -763,7 +763,7 @@ void MAVLinkSystem::send_command_async(MAVLinkCommands::CmdLong &cmd,
     _commands.queue_command_async(cmd, callback);
 }
 
-void MAVLinkSystem::send_command_async(MAVLinkCommands::CmdInt &cmd,
+void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandInt &cmd,
                                        command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
@@ -786,7 +786,7 @@ MAVLinkCommands::Result MAVLinkSystem::set_msg_rate(uint16_t message_id, double 
         interval_us = 1e6f / static_cast<float>(rate_hz);
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_SET_MESSAGE_INTERVAL;
     cmd.params.param1 = float(message_id);
@@ -809,7 +809,7 @@ void MAVLinkSystem::set_msg_rate_async(uint16_t message_id, double rate_hz,
         interval_us = 1e6f / static_cast<float>(rate_hz);
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_SET_MESSAGE_INTERVAL;
     cmd.params.param1 = float(message_id);

--- a/core/mavlink_system.cpp
+++ b/core/mavlink_system.cpp
@@ -424,13 +424,13 @@ void MAVLinkSystem::request_autopilot_version()
     _autopilot_version_pending = true;
 
     // We don't care about an answer, we mostly care about receiving AUTOPILOT_VERSION.
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
-    cmd.params.param1 = 1.0f;
-    cmd.target_component_id = get_autopilot_id();
+    command.command = MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
+    command.params.param1 = 1.0f;
+    command.target_component_id = get_autopilot_id();
 
-    send_command_async(cmd, nullptr);
+    send_command_async(command, nullptr);
     ++_uuid_retries;
 
     // We set a timeout to stay "pending" for half a second. This way, we don't give up too
@@ -595,15 +595,15 @@ MAVLinkCommands::Result MAVLinkSystem::set_flight_mode(FlightMode system_mode)
 
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_SET_MODE;
-    cmd.params.param1 = float(mode);
-    cmd.params.param2 = float(custom_mode);
-    cmd.params.param3 = float(custom_sub_mode);
-    cmd.target_component_id = get_autopilot_id();
+    command.command = MAV_CMD_DO_SET_MODE;
+    command.params.param1 = float(mode);
+    command.params.param2 = float(custom_mode);
+    command.params.param3 = float(custom_sub_mode);
+    command.target_component_id = get_autopilot_id();
 
-    return send_command(cmd);
+    return send_command(command);
 }
 
 void MAVLinkSystem::set_flight_mode_async(FlightMode system_mode,
@@ -651,15 +651,15 @@ void MAVLinkSystem::set_flight_mode_async(FlightMode system_mode,
             return ;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_SET_MODE;
-    cmd.params.param1 = float(mode);
-    cmd.params.param2 = float(custom_mode);
-    cmd.params.param3 = float(custom_sub_mode);
-    cmd.target_component_id = get_autopilot_id();
+    command.command = MAV_CMD_DO_SET_MODE;
+    command.params.param1 = float(mode);
+    command.params.param2 = float(custom_mode);
+    command.params.param3 = float(custom_sub_mode);
+    command.target_component_id = get_autopilot_id();
 
-    send_command_async(cmd, callback);
+    send_command_async(command, callback);
 }
 
 void MAVLinkSystem::get_param_int_async(const std::string &name,
@@ -730,26 +730,26 @@ uint8_t MAVLinkSystem::get_gimbal_id() const
 }
 
 MAVLinkCommands::Result
-MAVLinkSystem::send_command(MAVLinkCommands::CommandLong &cmd)
+MAVLinkSystem::send_command(MAVLinkCommands::CommandLong &command)
 {
     if (_system_id == 0 && _components.size() == 0) {
         return MAVLinkCommands::Result::NO_SYSTEM;
     }
-    cmd.target_system_id = get_system_id();
-    return _commands.send_command(cmd);
+    command.target_system_id = get_system_id();
+    return _commands.send_command(command);
 }
 
 MAVLinkCommands::Result
-MAVLinkSystem::send_command(MAVLinkCommands::CommandInt &cmd)
+MAVLinkSystem::send_command(MAVLinkCommands::CommandInt &command)
 {
     if (_system_id == 0 && _components.size() == 0) {
         return MAVLinkCommands::Result::NO_SYSTEM;
     }
-    cmd.target_system_id = get_system_id();
-    return _commands.send_command(cmd);
+    command.target_system_id = get_system_id();
+    return _commands.send_command(command);
 }
 
-void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandLong &cmd,
+void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandLong &command,
                                        command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
@@ -758,12 +758,12 @@ void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandLong &cmd,
         }
         return;
     }
-    cmd.target_system_id = get_system_id();
+    command.target_system_id = get_system_id();
 
-    _commands.queue_command_async(cmd, callback);
+    _commands.queue_command_async(command, callback);
 }
 
-void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandInt &cmd,
+void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandInt &command,
                                        command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
@@ -772,9 +772,9 @@ void MAVLinkSystem::send_command_async(MAVLinkCommands::CommandInt &cmd,
         }
         return;
     }
-    cmd.target_system_id = get_system_id();
+    command.target_system_id = get_system_id();
 
-    _commands.queue_command_async(cmd, callback);
+    _commands.queue_command_async(command, callback);
 }
 
 MAVLinkCommands::Result MAVLinkSystem::set_msg_rate(uint16_t message_id, double rate_hz,
@@ -786,18 +786,18 @@ MAVLinkCommands::Result MAVLinkSystem::set_msg_rate(uint16_t message_id, double 
         interval_us = 1e6f / static_cast<float>(rate_hz);
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_SET_MESSAGE_INTERVAL;
-    cmd.params.param1 = float(message_id);
-    cmd.params.param2 = interval_us;
+    command.command = MAV_CMD_SET_MESSAGE_INTERVAL;
+    command.params.param1 = float(message_id);
+    command.params.param2 = interval_us;
     if (component_id) {
-        cmd.target_component_id = component_id;
+        command.target_component_id = component_id;
     } else {
-        cmd.target_component_id = get_autopilot_id();
+        command.target_component_id = get_autopilot_id();
     }
 
-    return send_command(cmd);
+    return send_command(command);
 }
 
 void MAVLinkSystem::set_msg_rate_async(uint16_t message_id, double rate_hz,
@@ -809,18 +809,18 @@ void MAVLinkSystem::set_msg_rate_async(uint16_t message_id, double rate_hz,
         interval_us = 1e6f / static_cast<float>(rate_hz);
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_SET_MESSAGE_INTERVAL;
-    cmd.params.param1 = float(message_id);
-    cmd.params.param2 = interval_us;
+    command.command = MAV_CMD_SET_MESSAGE_INTERVAL;
+    command.params.param1 = float(message_id);
+    command.params.param2 = interval_us;
     if (component_id) {
-        cmd.target_component_id = component_id;
+        command.target_component_id = component_id;
     } else {
-        cmd.target_component_id = get_autopilot_id();
+        command.target_component_id = get_autopilot_id();
     }
 
-    send_command_async(cmd, callback);
+    send_command_async(command, callback);
 }
 
 void MAVLinkSystem::register_plugin(PluginImplBase *plugin_impl)

--- a/core/mavlink_system.h
+++ b/core/mavlink_system.h
@@ -77,14 +77,14 @@ public:
 
     // FIXME: I tried to use templates for these;
     // but I get undefined reference. Need to dig it later.
-    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandLong &cmd);
-    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandInt &cmd);
+    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandLong &command);
+    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandInt &command);
 
     // FIXME: I tried to use templates for these;
     // but I get undefined reference. Need to dig it later.
-    void send_command_async(MAVLinkCommands::CommandLong &cmd,
+    void send_command_async(MAVLinkCommands::CommandLong &command,
                             command_result_callback_t callback);
-    void send_command_async(MAVLinkCommands::CommandInt &cmd,
+    void send_command_async(MAVLinkCommands::CommandInt &command,
                             command_result_callback_t callback);
 
     MAVLinkCommands::Result set_msg_rate(uint16_t message_id,

--- a/core/mavlink_system.h
+++ b/core/mavlink_system.h
@@ -77,14 +77,14 @@ public:
 
     // FIXME: I tried to use templates for these;
     // but I get undefined reference. Need to dig it later.
-    MAVLinkCommands::Result send_command(MAVLinkCommands::CmdLong &cmd);
-    MAVLinkCommands::Result send_command(MAVLinkCommands::CmdInt &cmd);
+    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandLong &cmd);
+    MAVLinkCommands::Result send_command(MAVLinkCommands::CommandInt &cmd);
 
     // FIXME: I tried to use templates for these;
     // but I get undefined reference. Need to dig it later.
-    void send_command_async(MAVLinkCommands::CmdLong &cmd,
+    void send_command_async(MAVLinkCommands::CommandLong &cmd,
                             command_result_callback_t callback);
-    void send_command_async(MAVLinkCommands::CmdInt &cmd,
+    void send_command_async(MAVLinkCommands::CommandInt &cmd,
                             command_result_callback_t callback);
 
     MAVLinkCommands::Result set_msg_rate(uint16_t message_id,

--- a/core/mavlink_system.h
+++ b/core/mavlink_system.h
@@ -73,16 +73,19 @@ public:
 
     bool send_message(const mavlink_message_t &message);
 
-    MAVLinkCommands::Result send_command_with_ack(uint16_t command,
-                                                  const MAVLinkCommands::Params &params,
-                                                  uint8_t component_id = 0);
-
     typedef std::function<void(MAVLinkCommands::Result, float)> command_result_callback_t;
 
-    void send_command_with_ack_async(uint16_t command,
-                                     const MAVLinkCommands::Params &params,
-                                     command_result_callback_t callback,
-                                     uint8_t component_id = 0);
+    // FIXME: I tried to use templates for these;
+    // but I get undefined reference. Need to dig it later.
+    MAVLinkCommands::Result send_command(MAVLinkCommands::CmdLong &cmd);
+    MAVLinkCommands::Result send_command(MAVLinkCommands::CmdInt &cmd);
+
+    // FIXME: I tried to use templates for these;
+    // but I get undefined reference. Need to dig it later.
+    void send_command_async(MAVLinkCommands::CmdLong &cmd,
+                            command_result_callback_t callback);
+    void send_command_async(MAVLinkCommands::CmdInt &cmd,
+                            command_result_callback_t callback);
 
     MAVLinkCommands::Result set_msg_rate(uint16_t message_id,
                                          double rate_hz,

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -58,11 +58,13 @@ ActionResult ActionImpl::arm() const
         return ret;
     }
 
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_COMPONENT_ARM_DISARM,
-                   MAVLinkCommands::Params {1.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    cmd.params.param1 = 1.0f; // arm
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 ActionResult ActionImpl::disarm() const
@@ -72,20 +74,24 @@ ActionResult ActionImpl::disarm() const
         return ret;
     }
 
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_COMPONENT_ARM_DISARM,
-                   MAVLinkCommands::Params {0.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    cmd.params.param1 = 0.0f; // disarm
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 ActionResult ActionImpl::kill() const
 {
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_COMPONENT_ARM_DISARM,
-                   MAVLinkCommands::Params {0.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    cmd.params.param1 = 0.0f; // kill
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 ActionResult ActionImpl::takeoff() const
@@ -99,21 +105,23 @@ ActionResult ActionImpl::takeoff() const
     ret = action_result_from_command_result(
               _parent->set_flight_mode(MAVLinkSystem::FlightMode::HOLD));
 
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_NAV_TAKEOFF,
-                   MAVLinkCommands::Params {NAN, NAN, NAN, NAN, NAN, NAN,
-                                            _relative_takeoff_altitude_m},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_NAV_TAKEOFF;
+    cmd.params.param7 = _relative_takeoff_altitude_m;
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 ActionResult ActionImpl::land() const
 {
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_NAV_LAND,
-                   MAVLinkCommands::Params {NAN, NAN, NAN, NAN, NAN, NAN, NAN},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_NAV_LAND;
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 ActionResult ActionImpl::return_to_launch() const
@@ -132,11 +140,13 @@ ActionResult ActionImpl::transition_to_fixedwing() const
         return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_VTOL_TRANSITION,
-                   MAVLinkCommands::Params {float(MAV_VTOL_STATE_FW)},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
+    cmd.params.param1 = float(MAV_VTOL_STATE_FW);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &callback)
@@ -155,13 +165,14 @@ void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &
         return;
     }
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_VTOL_TRANSITION,
-        MAVLinkCommands::Params {float(MAV_VTOL_STATE_FW)},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
+    cmd.params.param1 = float(MAV_VTOL_STATE_FW);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 ActionResult ActionImpl::transition_to_multicopter() const
@@ -174,11 +185,13 @@ ActionResult ActionImpl::transition_to_multicopter() const
         return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
-    return action_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_VTOL_TRANSITION,
-                   MAVLinkCommands::Params {float(MAV_VTOL_STATE_MC)},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
+    cmd.params.param1 = float(MAV_VTOL_STATE_MC);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return action_result_from_command_result(_parent->send_command(cmd));
 }
 
 void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t &callback)
@@ -196,14 +209,14 @@ void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t
         }
         return;
     }
+    MAVLinkCommands::CmdLong cmd {};
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_VTOL_TRANSITION,
-        MAVLinkCommands::Params {float(MAV_VTOL_STATE_MC)},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
+    cmd.params.param1 = float(MAV_VTOL_STATE_MC);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 void ActionImpl::arm_async(const Action::result_callback_t &callback)
@@ -228,13 +241,14 @@ void ActionImpl::arm_async_continued(MAVLinkCommands::Result previous_result,
         return;
     }
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_COMPONENT_ARM_DISARM,
-        MAVLinkCommands::Params {1.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    cmd.params.param1 = 1.0f; // arm
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 void ActionImpl::disarm_async(const Action::result_callback_t &callback)
@@ -246,25 +260,26 @@ void ActionImpl::disarm_async(const Action::result_callback_t &callback)
         }
         return;
     }
+    MAVLinkCommands::CmdLong cmd {};
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_COMPONENT_ARM_DISARM,
-        MAVLinkCommands::Params {0.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    cmd.params.param1 = 0.0f; // disarm
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 void ActionImpl::kill_async(const Action::result_callback_t &callback)
 {
-    _parent->send_command_with_ack_async(
-        MAV_CMD_COMPONENT_ARM_DISARM,
-        MAVLinkCommands::Params {0.0f, NAN, NAN, NAN, NAN, NAN, NAN},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    cmd.params.param1 = 0.0f; // kill
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 void ActionImpl::takeoff_async(const Action::result_callback_t &callback)
@@ -280,7 +295,6 @@ void ActionImpl::takeoff_async(const Action::result_callback_t &callback)
     loiter_before_takeoff_async(callback);
 }
 
-
 void ActionImpl::takeoff_async_continued(MAVLinkCommands::Result previous_result,
                                          const Action::result_callback_t &callback)
 {
@@ -289,25 +303,25 @@ void ActionImpl::takeoff_async_continued(MAVLinkCommands::Result previous_result
         return;
     }
 
-    _parent->send_command_with_ack_async(
-        MAV_CMD_NAV_TAKEOFF,
-        MAVLinkCommands::Params {NAN, NAN, NAN, NAN, NAN, NAN,
-                                 _relative_takeoff_altitude_m},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_NAV_TAKEOFF;
+    cmd.params.param7 = _relative_takeoff_altitude_m;
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 void ActionImpl::land_async(const Action::result_callback_t &callback)
 {
-    _parent->send_command_with_ack_async(
-        MAV_CMD_NAV_LAND,
-        MAVLinkCommands::Params {NAN, NAN, NAN, NAN, NAN, NAN, NAN},
-        std::bind(&ActionImpl::command_result_callback,
-                  _1,
-                  callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_NAV_LAND;
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
+                                               _1, callback));
 }
 
 void ActionImpl::return_to_launch_async(const Action::result_callback_t &callback)

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -58,13 +58,13 @@ ActionResult ActionImpl::arm() const
         return ret;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
-    cmd.params.param1 = 1.0f; // arm
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    command.params.param1 = 1.0f; // arm
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 ActionResult ActionImpl::disarm() const
@@ -74,24 +74,24 @@ ActionResult ActionImpl::disarm() const
         return ret;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
-    cmd.params.param1 = 0.0f; // disarm
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    command.params.param1 = 0.0f; // disarm
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 ActionResult ActionImpl::kill() const
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
-    cmd.params.param1 = 0.0f; // kill
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    command.params.param1 = 0.0f; // kill
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 ActionResult ActionImpl::takeoff() const
@@ -105,23 +105,23 @@ ActionResult ActionImpl::takeoff() const
     ret = action_result_from_command_result(
               _parent->set_flight_mode(MAVLinkSystem::FlightMode::HOLD));
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_NAV_TAKEOFF;
-    cmd.params.param7 = _relative_takeoff_altitude_m;
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_NAV_TAKEOFF;
+    command.params.param7 = _relative_takeoff_altitude_m;
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 ActionResult ActionImpl::land() const
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_NAV_LAND;
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_NAV_LAND;
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 ActionResult ActionImpl::return_to_launch() const
@@ -140,13 +140,13 @@ ActionResult ActionImpl::transition_to_fixedwing() const
         return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
-    cmd.params.param1 = float(MAV_VTOL_STATE_FW);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_VTOL_TRANSITION;
+    command.params.param1 = float(MAV_VTOL_STATE_FW);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &callback)
@@ -165,14 +165,14 @@ void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &
         return;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
-    cmd.params.param1 = float(MAV_VTOL_STATE_FW);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_VTOL_TRANSITION;
+    command.params.param1 = float(MAV_VTOL_STATE_FW);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 ActionResult ActionImpl::transition_to_multicopter() const
@@ -185,13 +185,13 @@ ActionResult ActionImpl::transition_to_multicopter() const
         return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
-    cmd.params.param1 = float(MAV_VTOL_STATE_MC);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_VTOL_TRANSITION;
+    command.params.param1 = float(MAV_VTOL_STATE_MC);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return action_result_from_command_result(_parent->send_command(cmd));
+    return action_result_from_command_result(_parent->send_command(command));
 }
 
 void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t &callback)
@@ -209,14 +209,14 @@ void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t
         }
         return;
     }
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
-    cmd.params.param1 = float(MAV_VTOL_STATE_MC);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_VTOL_TRANSITION;
+    command.params.param1 = float(MAV_VTOL_STATE_MC);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 void ActionImpl::arm_async(const Action::result_callback_t &callback)
@@ -241,14 +241,14 @@ void ActionImpl::arm_async_continued(MAVLinkCommands::Result previous_result,
         return;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
-    cmd.params.param1 = 1.0f; // arm
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    command.params.param1 = 1.0f; // arm
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 void ActionImpl::disarm_async(const Action::result_callback_t &callback)
@@ -260,26 +260,26 @@ void ActionImpl::disarm_async(const Action::result_callback_t &callback)
         }
         return;
     }
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
-    cmd.params.param1 = 0.0f; // disarm
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    command.params.param1 = 0.0f; // disarm
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 void ActionImpl::kill_async(const Action::result_callback_t &callback)
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
-    cmd.params.param1 = 0.0f; // kill
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_COMPONENT_ARM_DISARM;
+    command.params.param1 = 0.0f; // kill
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 void ActionImpl::takeoff_async(const Action::result_callback_t &callback)
@@ -303,25 +303,25 @@ void ActionImpl::takeoff_async_continued(MAVLinkCommands::Result previous_result
         return;
     }
 
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_NAV_TAKEOFF;
-    cmd.params.param7 = _relative_takeoff_altitude_m;
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_NAV_TAKEOFF;
+    command.params.param7 = _relative_takeoff_altitude_m;
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 void ActionImpl::land_async(const Action::result_callback_t &callback)
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_NAV_LAND;
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_NAV_LAND;
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&ActionImpl::command_result_callback,
-                                               _1, callback));
+    _parent->send_command_async(command, std::bind(&ActionImpl::command_result_callback,
+                                                   _1, callback));
 }
 
 void ActionImpl::return_to_launch_async(const Action::result_callback_t &callback)

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -58,7 +58,7 @@ ActionResult ActionImpl::arm() const
         return ret;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
     cmd.params.param1 = 1.0f; // arm
@@ -74,7 +74,7 @@ ActionResult ActionImpl::disarm() const
         return ret;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
     cmd.params.param1 = 0.0f; // disarm
@@ -85,7 +85,7 @@ ActionResult ActionImpl::disarm() const
 
 ActionResult ActionImpl::kill() const
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
     cmd.params.param1 = 0.0f; // kill
@@ -105,7 +105,7 @@ ActionResult ActionImpl::takeoff() const
     ret = action_result_from_command_result(
               _parent->set_flight_mode(MAVLinkSystem::FlightMode::HOLD));
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_NAV_TAKEOFF;
     cmd.params.param7 = _relative_takeoff_altitude_m;
@@ -116,7 +116,7 @@ ActionResult ActionImpl::takeoff() const
 
 ActionResult ActionImpl::land() const
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_NAV_LAND;
     cmd.target_component_id = _parent->get_autopilot_id();
@@ -140,7 +140,7 @@ ActionResult ActionImpl::transition_to_fixedwing() const
         return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
     cmd.params.param1 = float(MAV_VTOL_STATE_FW);
@@ -165,7 +165,7 @@ void ActionImpl::transition_to_fixedwing_async(const Action::result_callback_t &
         return;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
     cmd.params.param1 = float(MAV_VTOL_STATE_FW);
@@ -185,7 +185,7 @@ ActionResult ActionImpl::transition_to_multicopter() const
         return ActionResult::NO_VTOL_TRANSITION_SUPPORT;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
     cmd.params.param1 = float(MAV_VTOL_STATE_MC);
@@ -209,7 +209,7 @@ void ActionImpl::transition_to_multicopter_async(const Action::result_callback_t
         }
         return;
     }
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_VTOL_TRANSITION;
     cmd.params.param1 = float(MAV_VTOL_STATE_MC);
@@ -241,7 +241,7 @@ void ActionImpl::arm_async_continued(MAVLinkCommands::Result previous_result,
         return;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
     cmd.params.param1 = 1.0f; // arm
@@ -260,7 +260,7 @@ void ActionImpl::disarm_async(const Action::result_callback_t &callback)
         }
         return;
     }
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
     cmd.params.param1 = 0.0f; // disarm
@@ -272,7 +272,7 @@ void ActionImpl::disarm_async(const Action::result_callback_t &callback)
 
 void ActionImpl::kill_async(const Action::result_callback_t &callback)
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_COMPONENT_ARM_DISARM;
     cmd.params.param1 = 0.0f; // kill
@@ -303,7 +303,7 @@ void ActionImpl::takeoff_async_continued(MAVLinkCommands::Result previous_result
         return;
     }
 
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_NAV_TAKEOFF;
     cmd.params.param7 = _relative_takeoff_altitude_m;
@@ -315,7 +315,7 @@ void ActionImpl::takeoff_async_continued(MAVLinkCommands::Result previous_result
 
 void ActionImpl::land_async(const Action::result_callback_t &callback)
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_NAV_LAND;
     cmd.target_component_id = _parent->get_autopilot_id();

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -28,47 +28,62 @@ void GimbalImpl::disable() {}
 Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     const float roll_deg = 0.0f;
+    MAVLinkCommands::CmdLong cmd {};
 
-    return gimbal_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_MOUNT_CONTROL,
-                   MAVLinkCommands::Params {pitch_deg, roll_deg, yaw_deg, NAN, NAN, NAN,
-                                            MAV_MOUNT_MODE_MAVLINK_TARGETING},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    cmd.command = MAV_CMD_DO_MOUNT_CONTROL;
+    cmd.params.param1 = pitch_deg;
+    cmd.params.param2 = roll_deg;
+    cmd.params.param3 = yaw_deg;
+    cmd.params.param7 = float(MAV_MOUNT_MODE_MAVLINK_TARGETING);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return gimbal_result_from_command_result(_parent->send_command(cmd));
 }
 
 void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
                                          Gimbal::result_callback_t callback)
 {
     const float roll_deg = 0.0f;
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_MOUNT_CONTROL,
-        MAVLinkCommands::Params {pitch_deg, roll_deg, yaw_deg, NAN, NAN, NAN,
-                                 MAV_MOUNT_MODE_MAVLINK_TARGETING},
-        std::bind(&GimbalImpl::receive_command_result, std::placeholders::_1, callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_DO_MOUNT_CONTROL;
+    cmd.params.param1 = pitch_deg;
+    cmd.params.param2 = roll_deg;
+    cmd.params.param3 = yaw_deg;
+    cmd.params.param7 = float(MAV_MOUNT_MODE_MAVLINK_TARGETING);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&GimbalImpl::receive_command_result,
+                                               std::placeholders::_1, callback));
 }
 
 Gimbal::Result GimbalImpl::set_roi_location(double latitude_deg, double longitude_deg,
                                             float altitude_m)
 {
-    return gimbal_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_DO_SET_ROI_LOCATION,
-                   MAVLinkCommands::Params {NAN, NAN, NAN, NAN, (float)latitude_deg, (float)longitude_deg,
-                                            altitude_m},
-                   MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT));
+    MAVLinkCommands::CmdInt cmd {};
+
+    cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
+    cmd.params.lat_deg = int32_t(latitude_deg * 1e7);
+    cmd.params.lon_deg = int32_t(longitude_deg * 1e7);
+    cmd.params.alt_m = altitude_m;
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return gimbal_result_from_command_result(_parent->send_command(cmd));
 }
 
 void GimbalImpl::set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
                                         Gimbal::result_callback_t callback)
 {
-    _parent->send_command_with_ack_async(
-        MAV_CMD_DO_SET_ROI_LOCATION,
-        MAVLinkCommands::Params {NAN, NAN, NAN, NAN, (float)latitude_deg, (float)longitude_deg,
-                                 altitude_m},
-        std::bind(&GimbalImpl::receive_command_result, std::placeholders::_1, callback),
-        MAVLinkCommands::DEFAULT_COMPONENT_ID_AUTOPILOT);
+    MAVLinkCommands::CmdInt cmd {};
+
+    cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
+    cmd.params.lat_deg = int32_t(latitude_deg * 1e7);
+    cmd.params.lon_deg = int32_t(longitude_deg * 1e7);
+    cmd.params.alt_m = altitude_m;
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&GimbalImpl::receive_command_result,
+                                               std::placeholders::_1, callback));
 }
 
 void GimbalImpl::receive_command_result(MAVLinkCommands::Result command_result,

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -63,9 +63,9 @@ Gimbal::Result GimbalImpl::set_roi_location(double latitude_deg, double longitud
     MAVLinkCommands::CommandInt cmd {};
 
     cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
-    cmd.params.lat_deg = int32_t(latitude_deg * 1e7);
-    cmd.params.lon_deg = int32_t(longitude_deg * 1e7);
-    cmd.params.alt_m = altitude_m;
+    cmd.params.x = int32_t(latitude_deg * 1e7);
+    cmd.params.y = int32_t(longitude_deg * 1e7);
+    cmd.params.z = altitude_m;
     cmd.target_component_id = _parent->get_autopilot_id();
 
     return gimbal_result_from_command_result(_parent->send_command(cmd));
@@ -77,9 +77,9 @@ void GimbalImpl::set_roi_location_async(double latitude_deg, double longitude_de
     MAVLinkCommands::CommandInt cmd {};
 
     cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
-    cmd.params.lat_deg = int32_t(latitude_deg * 1e7);
-    cmd.params.lon_deg = int32_t(longitude_deg * 1e7);
-    cmd.params.alt_m = altitude_m;
+    cmd.params.x = int32_t(latitude_deg * 1e7);
+    cmd.params.y = int32_t(longitude_deg * 1e7);
+    cmd.params.z = altitude_m;
     cmd.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(cmd, std::bind(&GimbalImpl::receive_command_result,

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -28,62 +28,62 @@ void GimbalImpl::disable() {}
 Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     const float roll_deg = 0.0f;
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_MOUNT_CONTROL;
-    cmd.params.param1 = pitch_deg;
-    cmd.params.param2 = roll_deg;
-    cmd.params.param3 = yaw_deg;
-    cmd.params.param7 = float(MAV_MOUNT_MODE_MAVLINK_TARGETING);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_MOUNT_CONTROL;
+    command.params.param1 = pitch_deg;
+    command.params.param2 = roll_deg;
+    command.params.param3 = yaw_deg;
+    command.params.param7 = float(MAV_MOUNT_MODE_MAVLINK_TARGETING);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return gimbal_result_from_command_result(_parent->send_command(cmd));
+    return gimbal_result_from_command_result(_parent->send_command(command));
 }
 
 void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
                                          Gimbal::result_callback_t callback)
 {
     const float roll_deg = 0.0f;
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_DO_MOUNT_CONTROL;
-    cmd.params.param1 = pitch_deg;
-    cmd.params.param2 = roll_deg;
-    cmd.params.param3 = yaw_deg;
-    cmd.params.param7 = float(MAV_MOUNT_MODE_MAVLINK_TARGETING);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_MOUNT_CONTROL;
+    command.params.param1 = pitch_deg;
+    command.params.param2 = roll_deg;
+    command.params.param3 = yaw_deg;
+    command.params.param7 = float(MAV_MOUNT_MODE_MAVLINK_TARGETING);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&GimbalImpl::receive_command_result,
-                                               std::placeholders::_1, callback));
+    _parent->send_command_async(command, std::bind(&GimbalImpl::receive_command_result,
+                                                   std::placeholders::_1, callback));
 }
 
 Gimbal::Result GimbalImpl::set_roi_location(double latitude_deg, double longitude_deg,
                                             float altitude_m)
 {
-    MAVLinkCommands::CommandInt cmd {};
+    MAVLinkCommands::CommandInt command {};
 
-    cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
-    cmd.params.x = int32_t(latitude_deg * 1e7);
-    cmd.params.y = int32_t(longitude_deg * 1e7);
-    cmd.params.z = altitude_m;
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_SET_ROI_LOCATION;
+    command.params.x = int32_t(latitude_deg * 1e7);
+    command.params.y = int32_t(longitude_deg * 1e7);
+    command.params.z = altitude_m;
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return gimbal_result_from_command_result(_parent->send_command(cmd));
+    return gimbal_result_from_command_result(_parent->send_command(command));
 }
 
 void GimbalImpl::set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
                                         Gimbal::result_callback_t callback)
 {
-    MAVLinkCommands::CommandInt cmd {};
+    MAVLinkCommands::CommandInt command {};
 
-    cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
-    cmd.params.x = int32_t(latitude_deg * 1e7);
-    cmd.params.y = int32_t(longitude_deg * 1e7);
-    cmd.params.z = altitude_m;
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_DO_SET_ROI_LOCATION;
+    command.params.x = int32_t(latitude_deg * 1e7);
+    command.params.y = int32_t(longitude_deg * 1e7);
+    command.params.z = altitude_m;
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&GimbalImpl::receive_command_result,
-                                               std::placeholders::_1, callback));
+    _parent->send_command_async(command, std::bind(&GimbalImpl::receive_command_result,
+                                                   std::placeholders::_1, callback));
 }
 
 void GimbalImpl::receive_command_result(MAVLinkCommands::Result command_result,

--- a/plugins/gimbal/gimbal_impl.cpp
+++ b/plugins/gimbal/gimbal_impl.cpp
@@ -28,7 +28,7 @@ void GimbalImpl::disable() {}
 Gimbal::Result GimbalImpl::set_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     const float roll_deg = 0.0f;
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_MOUNT_CONTROL;
     cmd.params.param1 = pitch_deg;
@@ -44,7 +44,7 @@ void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
                                          Gimbal::result_callback_t callback)
 {
     const float roll_deg = 0.0f;
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_DO_MOUNT_CONTROL;
     cmd.params.param1 = pitch_deg;
@@ -60,7 +60,7 @@ void GimbalImpl::set_pitch_and_yaw_async(float pitch_deg, float yaw_deg,
 Gimbal::Result GimbalImpl::set_roi_location(double latitude_deg, double longitude_deg,
                                             float altitude_m)
 {
-    MAVLinkCommands::CmdInt cmd {};
+    MAVLinkCommands::CommandInt cmd {};
 
     cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
     cmd.params.lat_deg = int32_t(latitude_deg * 1e7);
@@ -74,7 +74,7 @@ Gimbal::Result GimbalImpl::set_roi_location(double latitude_deg, double longitud
 void GimbalImpl::set_roi_location_async(double latitude_deg, double longitude_deg, float altitude_m,
                                         Gimbal::result_callback_t callback)
 {
-    MAVLinkCommands::CmdInt cmd {};
+    MAVLinkCommands::CommandInt cmd {};
 
     cmd.command = MAV_CMD_DO_SET_ROI_LOCATION;
     cmd.params.lat_deg = int32_t(latitude_deg * 1e7);

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -40,10 +40,10 @@ void LoggingImpl::disable() {}
 
 Logging::Result LoggingImpl::start_logging() const
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_START;
-    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     return logging_result_from_command_result(_parent->send_command(cmd));
@@ -51,10 +51,10 @@ Logging::Result LoggingImpl::start_logging() const
 
 Logging::Result LoggingImpl::stop_logging() const
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_STOP;
-    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     return logging_result_from_command_result(_parent->send_command(cmd));
@@ -62,10 +62,10 @@ Logging::Result LoggingImpl::stop_logging() const
 
 void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback)
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_START;
-    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,
@@ -75,10 +75,10 @@ void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback
 
 void LoggingImpl::stop_logging_async(const Logging::result_callback_t &callback)
 {
-    MAVLinkCommands::CmdLong cmd {};
+    MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_STOP;
-    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -40,50 +40,50 @@ void LoggingImpl::disable() {}
 
 Logging::Result LoggingImpl::start_logging() const
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_LOGGING_START;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_LOGGING_START;
+    MAVLinkCommands::CommandLong::set_as_reserved(command.params, 0.f);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return logging_result_from_command_result(_parent->send_command(cmd));
+    return logging_result_from_command_result(_parent->send_command(command));
 }
 
 Logging::Result LoggingImpl::stop_logging() const
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_LOGGING_STOP;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_LOGGING_STOP;
+    MAVLinkCommands::CommandLong::set_as_reserved(command.params, 0.f);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    return logging_result_from_command_result(_parent->send_command(cmd));
+    return logging_result_from_command_result(_parent->send_command(command));
 }
 
 void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback)
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_LOGGING_START;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_LOGGING_START;
+    MAVLinkCommands::CommandLong::set_as_reserved(command.params, 0.f);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,
-                                               std::placeholders::_1,
-                                               callback));
+    _parent->send_command_async(command, std::bind(&LoggingImpl::command_result_callback,
+                                                   std::placeholders::_1,
+                                                   callback));
 }
 
 void LoggingImpl::stop_logging_async(const Logging::result_callback_t &callback)
 {
-    MAVLinkCommands::CommandLong cmd {};
+    MAVLinkCommands::CommandLong command {};
 
-    cmd.command = MAV_CMD_LOGGING_STOP;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
-    cmd.target_component_id = _parent->get_autopilot_id();
+    command.command = MAV_CMD_LOGGING_STOP;
+    MAVLinkCommands::CommandLong::set_as_reserved(command.params, 0.f);
+    command.target_component_id = _parent->get_autopilot_id();
 
-    _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,
-                                               std::placeholders::_1,
-                                               callback));
+    _parent->send_command_async(command, std::bind(&LoggingImpl::command_result_callback,
+                                                   std::placeholders::_1,
+                                                   callback));
 }
 
 void LoggingImpl::process_logging_data(const mavlink_message_t &message)

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -40,40 +40,50 @@ void LoggingImpl::disable() {}
 
 Logging::Result LoggingImpl::start_logging() const
 {
-    return logging_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_LOGGING_START,
-                   MAVLinkCommands::Params {0.0f, // Format: ULog
-                                            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_LOGGING_START;
+    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return logging_result_from_command_result(_parent->send_command(cmd));
 }
 
 Logging::Result LoggingImpl::stop_logging() const
 {
-    return logging_result_from_command_result(
-               _parent->send_command_with_ack(
-                   MAV_CMD_LOGGING_STOP,
-                   MAVLinkCommands::Params {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_LOGGING_STOP;
+    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    return logging_result_from_command_result(_parent->send_command(cmd));
 }
 
 void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback)
 {
-    _parent->send_command_with_ack_async(
-        MAV_CMD_LOGGING_START,
-        MAVLinkCommands::Params {0.0f, // Format: ULog
-                                 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        std::bind(&LoggingImpl::command_result_callback,
-                  std::placeholders::_1,
-                  callback));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_LOGGING_START;
+    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,
+                                               std::placeholders::_1,
+                                               callback));
 }
 
 void LoggingImpl::stop_logging_async(const Logging::result_callback_t &callback)
 {
-    _parent->send_command_with_ack_async(
-        MAV_CMD_LOGGING_STOP,
-        MAVLinkCommands::Params {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        std::bind(&LoggingImpl::command_result_callback,
-                  std::placeholders::_1,
-                  callback));
+    MAVLinkCommands::CmdLong cmd {};
+
+    cmd.command = MAV_CMD_LOGGING_STOP;
+    MAVLinkCommands::CmdLong::set_as_reserved(cmd.params);
+    cmd.target_component_id = _parent->get_autopilot_id();
+
+    _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,
+                                               std::placeholders::_1,
+                                               callback));
 }
 
 void LoggingImpl::process_logging_data(const mavlink_message_t &message)

--- a/plugins/logging/logging_impl.cpp
+++ b/plugins/logging/logging_impl.cpp
@@ -43,7 +43,7 @@ Logging::Result LoggingImpl::start_logging() const
     MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_START;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     return logging_result_from_command_result(_parent->send_command(cmd));
@@ -54,7 +54,7 @@ Logging::Result LoggingImpl::stop_logging() const
     MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_STOP;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     return logging_result_from_command_result(_parent->send_command(cmd));
@@ -65,7 +65,7 @@ void LoggingImpl::start_logging_async(const Logging::result_callback_t &callback
     MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_START;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,
@@ -78,7 +78,7 @@ void LoggingImpl::stop_logging_async(const Logging::result_callback_t &callback)
     MAVLinkCommands::CommandLong cmd {};
 
     cmd.command = MAV_CMD_LOGGING_STOP;
-    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params);
+    MAVLinkCommands::CommandLong::set_as_reserved(cmd.params, 0.f);
     cmd.target_component_id = _parent->get_autopilot_id();
 
     _parent->send_command_async(cmd, std::bind(&LoggingImpl::command_result_callback,

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -85,7 +85,7 @@ private:
     import_mission_items(Mission::mission_items_t &mission_items,
                          const Json &mission_json);
     static Mission::Result
-    build_mission_items(MAV_CMD cmd, std::vector<double> params,
+    build_mission_items(MAV_CMD command, std::vector<double> params,
                         std::shared_ptr<MissionItem> &new_mission_item,
                         Mission::mission_items_t &all_mission_items);
 


### PR DESCRIPTION
Adds new types `MAVLinkCommands::CmdInt` and `MAVLinkCommands::CmdLong` types that abstract to those of MAVLink protocol:

- http://mavlink.org/messages/common/#COMMAND_INT
- http://mavlink.org/messages/common/#COMMAND_LONG

Also includes the changes in core and plugins, wherever these commands are used. `COMMAND_INT` is used only in Gimbal plugin as of now for `MAV_CMD_DO_SET_ROI_LOCATION`.