### PR TITLE
build_system: remove unused-parameter flag for AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_BINARY_DIR}/third_party)
 
+cmake_policy(SET CMP0025 NEW)
+
 project(dronecore)
 
 option(BUILD_TESTS "Build tests" ON)

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -24,8 +24,10 @@ else()
         endif()
 
         set(warnings "${warnings} -Wlogical-op")
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set(warnings "${warnings} -Wno-missing-braces")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        set(warnings "${warnings} -Wno-missing-braces -Wno-unused-parameter")
     endif()
 endif()
 


### PR DESCRIPTION
Sources generated by protobuf do not compile otherwise. I tried to set the flag only for the generated files with `set_source_files_properties`, but didn't manage to make it work this way.