### PR TITLE
backend: improve backend api and initialization

### DIFF
--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(BACKEND_SOURCES
     backend_api.h
     backend_api.cpp
     backend.cpp
+    grpc_server.cpp
     ${GRPC_COMPILED_SOURCES}
     ${PB_COMPILED_SOURCES}
 )

--- a/backend/src/backend.cpp
+++ b/backend/src/backend.cpp
@@ -1,22 +1,10 @@
 #include "backend.h"
 
-#include <grpc/grpc.h>
-#include <grpc++/server.h>
-#include <grpc++/server_builder.h>
-#include <grpc++/server_context.h>
-#include <grpc++/security/server_credentials.h>
 #include <memory>
-#include <mutex>
 
-#include "action/action.h"
-#include "action/action_service_impl.h"
 #include "connection_initiator.h"
-#include "core/core_service_impl.h"
 #include "dronecore.h"
-#include "log.h"
-#include "mission/mission.h"
-#include "mission/mission_service_impl.h"
-#include "telemetry/telemetry_service_impl.h"
+#include "grpc_server.h"
 
 namespace dronecore {
 namespace backend {
@@ -27,53 +15,35 @@ public:
     Impl() {}
     ~Impl() {}
 
-    bool run(const int mavlink_listen_port)
+    void connect(const int mavlink_listen_port)
     {
         _connection_initiator.start(_dc, 14540);
         _connection_initiator.wait();
+    }
 
-        grpc::ServerBuilder builder;
-        setup_port(builder);
+    void startGRPCServer()
+    {
+        _server = std::unique_ptr<GRPCServer>(new GRPCServer(_dc));
+        _server->run();
+    }
 
-        CoreServiceImpl<> core(_dc);
-        builder.RegisterService(&core);
-
-        Action action(_dc.system());
-        ActionServiceImpl<> action_service(action);
-        builder.RegisterService(&action_service);
-
-        Mission mission(_dc.system());
-        MissionServiceImpl<> mission_service(mission);
-        builder.RegisterService(&mission_service);
-
-        Telemetry telemetry(_dc.system());
-        TelemetryServiceImpl<> telemetry_service(telemetry);
-        builder.RegisterService(&telemetry_service);
-
-        _server = builder.BuildAndStart();
-        LogInfo() << "Server started";
-        _server->Wait();
-
-        return true;
+    void wait()
+    {
+        _server->wait();
     }
 
 private:
-    void setup_port(grpc::ServerBuilder &builder)
-    {
-        std::string server_address("0.0.0.0:50051");
-        builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-        LogInfo() << "Server set to listen on " << server_address;
-    }
-
-    dronecore::DroneCore _dc;
-    dronecore::backend::ConnectionInitiator<dronecore::DroneCore> _connection_initiator;
-    std::unique_ptr<grpc::Server> _server;
+    DroneCore _dc;
+    ConnectionInitiator<dronecore::DroneCore> _connection_initiator;
+    std::unique_ptr<GRPCServer> _server;
 };
 
 DroneCoreBackend::DroneCoreBackend() : _impl(new Impl()) {}
 DroneCoreBackend::~DroneCoreBackend() = default;
 
-bool DroneCoreBackend::run(const int mavlink_listen_port) { return _impl->run(mavlink_listen_port); }
+void DroneCoreBackend::startGRPCServer() { _impl->startGRPCServer(); }
+void DroneCoreBackend::connect(const int mavlink_listen_port) { return _impl->connect(mavlink_listen_port); }
+void DroneCoreBackend::wait() { _impl->wait(); }
 
 } // namespace backend
 } // namespace dronecore

--- a/backend/src/backend.h
+++ b/backend/src/backend.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 
 namespace dronecore {
@@ -11,7 +13,9 @@ public:
     DroneCoreBackend(DroneCoreBackend &&) = delete;
     DroneCoreBackend &operator=(DroneCoreBackend &&) = delete;
 
-    bool run(const int mavlink_listen_port = 14540);
+    void startGRPCServer();
+    void connect(const int mavlink_listen_port = 14540);
+    void wait();
 
 private:
     class Impl;

--- a/backend/src/backend_api.cpp
+++ b/backend/src/backend_api.cpp
@@ -2,14 +2,15 @@
 
 #include "backend.h"
 
-int runBackend(const int mavlink_listen_port)
+void runBackend(const int mavlink_listen_port, void (*onServerStarted)(void *), void *context)
 {
     dronecore::backend::DroneCoreBackend backend;
-    bool had_error = backend.run(mavlink_listen_port);
+    backend.connect(mavlink_listen_port);
+    backend.startGRPCServer();
 
-    if (had_error) {
-        return 1;
-    } else {
-        return 0;
+    if (onServerStarted != nullptr) {
+        onServerStarted(context);
     }
+
+    backend.wait();
 }

--- a/backend/src/backend_api.h
+++ b/backend/src/backend_api.h
@@ -1,8 +1,11 @@
+#pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-__attribute__((visibility("default"))) int runBackend(int mavlink_listen_port);
+__attribute__((visibility("default"))) void runBackend(int mavlink_listen_port,
+                                                       void (*onServerStarted)(void *), void *context);
 
 #ifdef __cplusplus
 }

--- a/backend/src/connection_initiator.h
+++ b/backend/src/connection_initiator.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <future>
 
 #include "connection_result.h"

--- a/backend/src/dronecore_server.cpp
+++ b/backend/src/dronecore_server.cpp
@@ -1,12 +1,6 @@
-#include "backend.h"
+#include "backend_api.h"
 
 int main(int argc, char **argv)
 {
-    dronecore::backend::DroneCoreBackend backend;
-
-    if (!backend.run()) {
-        return 1;
-    } else {
-        return 0;
-    }
+    runBackend(14540, nullptr, nullptr);
 }

--- a/backend/src/grpc_server.cpp
+++ b/backend/src/grpc_server.cpp
@@ -1,0 +1,42 @@
+#include "grpc_server.h"
+
+#include <grpc++/server_builder.h>
+#include <grpc++/security/server_credentials.h>
+
+#include "log.h"
+
+namespace dronecore {
+namespace backend {
+
+void GRPCServer::run()
+{
+    grpc::ServerBuilder builder;
+    setup_port(builder);
+
+    builder.RegisterService(&_core);
+    builder.RegisterService(&_action_service);
+    builder.RegisterService(&_mission_service);
+    builder.RegisterService(&_telemetry_service);
+
+    _server = builder.BuildAndStart();
+    LogInfo() << "Server started";
+}
+
+void GRPCServer::wait()
+{
+    if (_server != nullptr) {
+        _server->Wait();
+    } else {
+        LogWarn() << "Calling 'wait()' on a non-existing server. Did you call 'run()' before?";
+    }
+}
+
+void GRPCServer::setup_port(grpc::ServerBuilder &builder)
+{
+    std::string server_address("0.0.0.0:50051");
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    LogInfo() << "Server set to listen on " << server_address;
+}
+
+} // namespace backend
+} // namespace dronecore

--- a/backend/src/grpc_server.h
+++ b/backend/src/grpc_server.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <grpc++/server.h>
+#include <memory>
+
+#include "action/action.h"
+#include "action/action_service_impl.h"
+#include "core/core_service_impl.h"
+#include "dronecore.h"
+#include "mission/mission.h"
+#include "mission/mission_service_impl.h"
+#include "telemetry/telemetry_service_impl.h"
+
+namespace dronecore {
+namespace backend {
+
+class GRPCServer
+{
+public:
+    GRPCServer(DroneCore &dc)
+        : _dc(dc),
+          _core(_dc),
+          _action(_dc.system()),
+          _action_service(_action),
+          _mission(_dc.system()),
+          _mission_service(_mission),
+          _telemetry(_dc.system()),
+          _telemetry_service(_telemetry)
+    {
+        assert(_dc.system_uuids().size() >= 1);
+    }
+
+    void run();
+    void wait();
+
+private:
+    void setup_port(grpc::ServerBuilder &builder);
+
+    DroneCore &_dc;
+
+    CoreServiceImpl<> _core;
+    Action _action;
+    ActionServiceImpl<> _action_service;
+    Mission _mission;
+    MissionServiceImpl<> _mission_service;
+    Telemetry _telemetry;
+    TelemetryServiceImpl<> _telemetry_service;
+
+    std::unique_ptr<grpc::Server> _server;
+};
+
+} // namespace backend
+} // namespace dronecore


### PR DESCRIPTION
This PR adds a callback notifying when the gRPC server is started to the backend C api. This is necessary when the frontend starts the backend on the phone, because it needs to wait for the gRPC server to be started before it can initiate a connection.