### PR TITLE
core: notify already-connected systems on register_on_discover

### DIFF
--- a/core/dronecore.h
+++ b/core/dronecore.h
@@ -152,6 +152,9 @@ public:
      *
      * This sets a callback that will be notified if a new system is discovered.
      *
+     * If systems have been discovered before this callback is registered, they will be notified
+     * at the time this callback is registered.
+     *
      * **Note** Only one callback can be registered at a time. If this function is called several
      * times, previous callbacks will be overwritten.
      *

--- a/core/dronecore_impl.cpp
+++ b/core/dronecore_impl.cpp
@@ -328,7 +328,6 @@ bool DroneCoreImpl::does_system_exist(uint8_t system_id)
 
 void DroneCoreImpl::notify_on_discover(const uint64_t uuid)
 {
-    LogDebug() << "Discovered " << uuid;
     if (_on_discover_callback != nullptr) {
         _on_discover_callback(uuid);
     }
@@ -344,6 +343,12 @@ void DroneCoreImpl::notify_on_timeout(const uint64_t uuid)
 
 void DroneCoreImpl::register_on_discover(const DroneCore::event_callback_t callback)
 {
+    std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
+
+    for (auto const &connected_system : _systems) {
+        callback(connected_system.second->get_uuid());
+    }
+
     _on_discover_callback = callback;
 }
 

--- a/core/mavlink_system.cpp
+++ b/core/mavlink_system.cpp
@@ -455,8 +455,9 @@ void MAVLinkSystem::set_connected()
 
         if (!_connected && _uuid_initialized) {
 
-            LogDebug() << "We have found " << _components.size() << " component(s).";
+            LogDebug() << "Found " << _components.size() << " component(s).";
 
+            LogDebug() << "Discovered " << _uuid;
             _parent.notify_on_discover(_uuid);
             _connected = true;
 


### PR DESCRIPTION
This PR changes `register_on_discover` in such a way that it directly publishes the uuids of the systems that are already connected. 

Before that, one had query the list of already connected systems, but it probably never makes sense to register to the callback without wanting to know which ones are already connected.

Working on an integration test from Swift.