### PR TITLE
build_system: fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ distclean:
 	@rm -rf logs/
 
 clean:
-	@if [ -d build ]; then find build -mindepth 2 -delete -path "build/*/third_party"; fi
+	@if [ -d build ]; then find build -mindepth 2 ! -regex 'build/\w+/third_party.*' -delete; fi
 
 android_env_check:
 ifndef ANDROID_TOOLCHAIN_CMAKE


### PR DESCRIPTION
So now it should remove everything except for what is in `build/.../third_party/`. It works on my computer, but it's difficult to test more than that...