### PR TITLE
Add telemetry features

### DIFF
--- a/backend/src/plugins/telemetry/telemetry_service_impl.h
+++ b/backend/src/plugins/telemetry/telemetry_service_impl.h
@@ -92,6 +92,20 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SubscribeArmed(grpc::ServerContext * /* context */,
+                                const dronecore::rpc::telemetry::SubscribeArmedRequest * /* request */,
+                                grpc::ServerWriter<rpc::telemetry::ArmedResponse> *writer) override
+    {
+        _telemetry.armed_async([&writer](bool is_armed) {
+            dronecore::rpc::telemetry::ArmedResponse rpc_armed_response;
+            rpc_armed_response.set_is_armed(is_armed);
+            writer->Write(rpc_armed_response);
+        });
+
+        _stop_future.wait();
+        return grpc::Status::OK;
+    }
+
     void stop()
     {
         _stop_promise.set_value();

--- a/backend/src/plugins/telemetry/telemetry_service_impl.h
+++ b/backend/src/plugins/telemetry/telemetry_service_impl.h
@@ -78,6 +78,20 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SubscribeInAir(grpc::ServerContext * /* context */,
+                                const dronecore::rpc::telemetry::SubscribeInAirRequest * /* request */,
+                                grpc::ServerWriter<rpc::telemetry::InAirResponse> *writer) override
+    {
+        _telemetry.in_air_async([&writer](bool is_in_air) {
+            dronecore::rpc::telemetry::InAirResponse rpc_in_air_response;
+            rpc_in_air_response.set_is_in_air(is_in_air);
+            writer->Write(rpc_in_air_response);
+        });
+
+        _stop_future.wait();
+        return grpc::Status::OK;
+    }
+
     void stop()
     {
         _stop_promise.set_value();

--- a/plugins/telemetry/mocks/telemetry_mock.h
+++ b/plugins/telemetry/mocks/telemetry_mock.h
@@ -1,19 +1,16 @@
 #include <gmock/gmock.h>
 
-// TODO remove this include!
 #include "telemetry/telemetry.h"
 
 namespace dronecore {
 namespace testing {
 
-typedef std::function<void(Telemetry::Position)> position_callback_t;
-typedef std::function<void(Telemetry::Health health)> health_callback_t;
-
 class MockTelemetry
 {
 public:
-    MOCK_CONST_METHOD1(position_async, void(position_callback_t));
-    MOCK_CONST_METHOD1(health_async, void(health_callback_t));
+    MOCK_CONST_METHOD1(position_async, void(Telemetry::position_callback_t));
+    MOCK_CONST_METHOD1(health_async, void(Telemetry::health_callback_t));
+    MOCK_CONST_METHOD1(home_position_async, void(Telemetry::position_callback_t));
 };
 
 } // namespace testing

--- a/plugins/telemetry/mocks/telemetry_mock.h
+++ b/plugins/telemetry/mocks/telemetry_mock.h
@@ -14,6 +14,7 @@ public:
     MOCK_CONST_METHOD1(in_air_async, void(Telemetry::in_air_callback_t));
     MOCK_CONST_METHOD1(armed_async, void(Telemetry::armed_callback_t));
     MOCK_CONST_METHOD1(gps_info_async, void(Telemetry::gps_info_callback_t));
+    MOCK_CONST_METHOD1(battery_async, void(Telemetry::battery_callback_t));
 };
 
 } // namespace testing

--- a/plugins/telemetry/mocks/telemetry_mock.h
+++ b/plugins/telemetry/mocks/telemetry_mock.h
@@ -12,6 +12,7 @@ public:
     MOCK_CONST_METHOD1(health_async, void(Telemetry::health_callback_t));
     MOCK_CONST_METHOD1(home_position_async, void(Telemetry::position_callback_t));
     MOCK_CONST_METHOD1(in_air_async, void(Telemetry::in_air_callback_t));
+    MOCK_CONST_METHOD1(armed_async, void(Telemetry::armed_callback_t));
 };
 
 } // namespace testing

--- a/plugins/telemetry/mocks/telemetry_mock.h
+++ b/plugins/telemetry/mocks/telemetry_mock.h
@@ -11,6 +11,7 @@ public:
     MOCK_CONST_METHOD1(position_async, void(Telemetry::position_callback_t));
     MOCK_CONST_METHOD1(health_async, void(Telemetry::health_callback_t));
     MOCK_CONST_METHOD1(home_position_async, void(Telemetry::position_callback_t));
+    MOCK_CONST_METHOD1(in_air_async, void(Telemetry::in_air_callback_t));
 };
 
 } // namespace testing

--- a/plugins/telemetry/mocks/telemetry_mock.h
+++ b/plugins/telemetry/mocks/telemetry_mock.h
@@ -13,6 +13,7 @@ public:
     MOCK_CONST_METHOD1(home_position_async, void(Telemetry::position_callback_t));
     MOCK_CONST_METHOD1(in_air_async, void(Telemetry::in_air_callback_t));
     MOCK_CONST_METHOD1(armed_async, void(Telemetry::armed_callback_t));
+    MOCK_CONST_METHOD1(gps_info_async, void(Telemetry::gps_info_callback_t));
 };
 
 } // namespace testing

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -338,4 +338,16 @@ std::ostream &operator<<(std::ostream &str, Telemetry::Health const &health)
            ", home_position_ok: " << health.home_position_ok << "]";
 }
 
+bool operator==(const Telemetry::GPSInfo &lhs, const Telemetry::GPSInfo &rhs)
+{
+    return lhs.num_satellites == rhs.num_satellites
+           && lhs.fix_type == rhs.fix_type;
+}
+
+std::ostream &operator<<(std::ostream &str, Telemetry::GPSInfo const &gps_info)
+{
+    return str << "[num_sat: " << gps_info.num_satellites
+           << ", fix_type: " << gps_info.fix_type << "]";
+}
+
 } // namespace dronecore

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -350,4 +350,16 @@ std::ostream &operator<<(std::ostream &str, Telemetry::GPSInfo const &gps_info)
            << ", fix_type: " << gps_info.fix_type << "]";
 }
 
+bool operator==(const Telemetry::Battery &lhs, const Telemetry::Battery &rhs)
+{
+    return lhs.voltage_v == rhs.voltage_v
+           && lhs.remaining_percent == rhs.remaining_percent;
+}
+
+std::ostream &operator<<(std::ostream &str, Telemetry::Battery const &battery)
+{
+    return str << "[voltage_v: " << battery.voltage_v
+           << ", remaining_percent: " << battery.remaining_percent << "]";
+}
+
 } // namespace dronecore

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -643,4 +643,7 @@ std::ostream &operator<<(std::ostream &str, Telemetry::Position const &position)
 bool operator==(const Telemetry::Health &lhs, const Telemetry::Health &rhs);
 std::ostream &operator<<(std::ostream &str, Telemetry::Health const &health);
 
+bool operator==(const Telemetry::GPSInfo &lhs, const Telemetry::GPSInfo &rhs);
+std::ostream &operator<<(std::ostream &str, Telemetry::GPSInfo const &gps_info);
+
 } // namespace dronecore

--- a/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/telemetry.h
@@ -646,4 +646,7 @@ std::ostream &operator<<(std::ostream &str, Telemetry::Health const &health);
 bool operator==(const Telemetry::GPSInfo &lhs, const Telemetry::GPSInfo &rhs);
 std::ostream &operator<<(std::ostream &str, Telemetry::GPSInfo const &gps_info);
 
+bool operator==(const Telemetry::Battery &lhs, const Telemetry::Battery &rhs);
+std::ostream &operator<<(std::ostream &str, Telemetry::Battery const &battery);
+
 } // namespace dronecore


### PR DESCRIPTION
Add the following features to the telemetry module: 

* SubscribeHome
* SubscribeInAir
* SubscribeArmed
* SubscribeGPSInfo
* SubscribeBattery

The tests for all those functions all seem quite similar, but I did not find a good way to have something more compact (e.g. templates). I am not sure it is actually possible (because of the googlemock macros, for one), and I am open to suggestions :-).