### PR TITLE
Add better support for note/warning types and update docs appopriately

### DIFF
--- a/core/dronecore.h
+++ b/core/dronecore.h
@@ -54,7 +54,7 @@ public:
      * Default URL : udp://:14540.
      * - Default Bind host IP is localhost(127.0.0.1)
      *
-     * Warning: serial connections are not supported on Windows (they are supported on Linux and macOS).
+     * @warning Serial connections are not supported on Windows (they are supported on Linux and macOS).
      *
      * @param connection_url connection URL string.
      * @return The result of adding the connection.
@@ -83,7 +83,7 @@ public:
      * @brief Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
      *
      *
-     * Warning: this method is not supported on Windows (it is supported on Linux and macOS).
+     * @warning This method is not supported on Windows (it is supported on Linux and macOS).
      *
      * @param dev_path COM or UART dev node name/path (defaults to "/dev/ttyS0").
      * @param baudrate Baudrate of the serial port (defaults to 57600).
@@ -160,7 +160,7 @@ public:
      * If systems have been discovered before this callback is registered, they will be notified
      * at the time this callback is registered.
      *
-     * **Note** Only one callback can be registered at a time. If this function is called several
+     * @note Only one callback can be registered at a time. If this function is called several
      * times, previous callbacks will be overwritten.
      *
      * @param callback Callback to register.
@@ -174,7 +174,7 @@ public:
      * This sets a callback that will be notified if no heartbeat of the system has been received
      * in 3 seconds.
      *
-     * **Note** Only one callback can be registered at a time. If this function is called several
+     * @note Only one callback can be registered at a time. If this function is called several
      * times, previous callbacks will be overwritten.
      *
      * @param callback Callback to register.

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -47,7 +47,7 @@ public:
     /**
      * @brief Send command to *arm* the drone (synchronous).
      *
-     * **Note** Arming a drone normally causes motors to spin at idle.
+     * @note Arming a drone normally causes motors to spin at idle.
      * Before arming take all safety precautions and stand clear of the drone!
      *
      * @return ActionResult of request.

--- a/plugins/action/action_result.h
+++ b/plugins/action/action_result.h
@@ -8,7 +8,7 @@ namespace dronecore {
 /**
  * @brief Possible results returned for commanded actions.
  *
- * **Note**: DroneCore does not throw exceptions. Instead a result of this type will be
+ * @note DroneCore does not throw exceptions. Instead a result of this type will be
  * returned when you execute actions.
  */
 enum class ActionResult {


### PR DESCRIPTION
This change should be fine. It implements supported note types using the same approach - notes, warnings, remark, attention and since notes in doxygen now propagate through to markdown with the same prefix - ie `@attention` becomes a note like `> **Attention** ...`