### PR TITLE
third_party: use fork of json11 so that it builds as a static lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 	ignore = dirty
 [submodule "json11"]
 	path = plugins/mission/third_party/json11
-	url = https://github.com/dropbox/json11
+	url = https://github.com/dronecore/json11


### PR DESCRIPTION
iOS needs json11 to be built statically. We use json11 as a submodule, and it is not made for choosing this in a straightforward way. So for now I just forked it. I'll try to fix that on their CMakeLists.txt and make a PR.

NOTE: locally, I had to run `git submodule update --init --recursive --remote` for the change to take effect.