### PR TITLE
core: fix conversion that now generates a warning

### DIFF
--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -476,7 +476,7 @@ public:
             } else if (_value.is<int16_t>()) {
                 return _value.as<int16_t>() == std::stoi(value_str.c_str());
             } else if (_value.is<uint32_t>()) {
-                return _value.as<uint32_t>() == std::stol(value_str.c_str());
+                return _value.as<uint32_t>() == std::stoul(value_str.c_str());
             } else if (_value.is<int32_t>()) {
                 return _value.as<int32_t>() == std::stol(value_str.c_str());
             } else if (_value.is<uint64_t>()) {


### PR DESCRIPTION
With an updated iOS system, the clang version gives a warning for that, that we treat as an error.