### PR TITLE
core: fix bad-cast on param_get fail

### DIFF
--- a/core/mavlink_system.cpp
+++ b/core/mavlink_system.cpp
@@ -679,7 +679,11 @@ void MAVLinkSystem::receive_float_param(bool success, MAVLinkParameters::ParamVa
                                         get_param_float_callback_t callback)
 {
     if (callback) {
-        callback(success, value.get_float());
+        if (success) {
+            callback(success, value.get_float());
+        } else {
+            callback(success, NAN);
+        }
     }
 }
 
@@ -687,7 +691,11 @@ void MAVLinkSystem::receive_int_param(bool success, MAVLinkParameters::ParamValu
                                       get_param_int_callback_t callback)
 {
     if (callback) {
-        callback(success, value.get_int32());
+        if (success) {
+            callback(success, value.get_int32());
+        } else {
+            callback(success, 0);
+        }
     }
 }
 


### PR DESCRIPTION
If we did not successfully receive a param we should not try to cast it
otherwise it will crash with an abort and we'll be quite unhappy.