### PR TITLE
build_system: build tinyxml2 statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,9 @@ project(dronecore)
 option(BUILD_TESTS "Build tests" ON)
 
 include(cmake/compiler_flags.cmake)
-include(cmake/zlib.cmake)
 include(cmake/curl.cmake)
+include(cmake/tinyxml2.cmake)
+include(cmake/zlib.cmake)
 
 if(BUILD_TESTS AND (IOS OR ANDROID))
     message(STATUS "Building for iOS or Android: forcing BUILD_TESTS to FALSE...")
@@ -30,41 +31,6 @@ endif()
 
 set(dronecore_install_include_dir "include/dronecore")
 set(dronecore_install_lib_dir ${lib_path})
-
-# We need tinyxml2 for the camera definition parsing.
-add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
-link_directories(third_party/tinyxml2)
-include_directories(SYSTEM third_party/tinyxml2)
-set(TINYXML2_LIBRARY tinyxml2)
-
-if(APPLE AND NOT IOS)
-    # We install the tinyxml2 library manually for macOS and iOS.
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        # Need to remove that d again.
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2d.6.0.0.dylib
-            DESTINATION ${lib_path}
-            #RENAME libtinyxml2.dylib
-        )
-    else()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2.6.0.0.dylib
-            DESTINATION ${lib_path}
-            #RENAME libtinyxml2.dylib
-        )
-    endif()
-elseif(ANDROID)
-    # We install the tinyxml2 library manually for Android.
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        # Need to remove that d again.
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2d.so
-            DESTINATION ${lib_path}
-            RENAME libtinyxml2.so
-        )
-    else()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/third_party/tinyxml2/libtinyxml2.so
-            DESTINATION ${lib_path}
-        )
-    endif()
-endif()
 
 add_subdirectory(core)
 add_subdirectory(plugins)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -148,7 +148,6 @@ test_script:
       copy build\third_party\gtest\googlemock\Debug\gmockd.dll build\Debug\ &&
       copy build\plugins\mission\Debug\dronecore_mission.dll build\Debug\ &&
       copy build\plugins\camera\Debug\dronecore_camera.dll build\Debug\ &&
-      copy build\third_party\tinyxml2\Debug\tinyxml2d.dll build\Debug\ &&
       build\Debug\unit_tests_runner.exe
     ) else (
       copy build\third_party\gtest\googlemock\gtest\Release\gtest.dll build\Release\ &&
@@ -156,6 +155,5 @@ test_script:
       copy build\third_party\gtest\googlemock\Release\gmock.dll build\Release\ &&
       copy build\plugins\mission\Release\dronecore_mission.dll build\Release\ &&
       copy build\plugins\camera\Release\dronecore_camera.dll build\Release\ &&
-      copy build\third_party\tinyxml2\Release\tinyxml2.dll build\Release\ &&
       build\Release\unit_tests_runner.exe
     )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -143,16 +143,16 @@ test: on
 test_script:
   - cd %dronecore_dir%
   - if "%configuration%"=="Debug" (
-      copy build\third_party\gtest\googlemock\gtest\Debug\gtestd.dll build\Debug\ &&
-      copy build\third_party\gtest\googlemock\gtest\Debug\gtest_maind.dll build\Debug\ &&
-      copy build\third_party\gtest\googlemock\Debug\gmockd.dll build\Debug\ &&
+      copy build\third_party\gtest\googlemock\gtest\Debug\gtestd.lib build\Debug\ &&
+      copy build\third_party\gtest\googlemock\gtest\Debug\gtest_maind.lib build\Debug\ &&
+      copy build\third_party\gtest\googlemock\Debug\gmockd.lib build\Debug\ &&
       copy build\plugins\mission\Debug\dronecore_mission.dll build\Debug\ &&
       copy build\plugins\camera\Debug\dronecore_camera.dll build\Debug\ &&
       build\Debug\unit_tests_runner.exe
     ) else (
-      copy build\third_party\gtest\googlemock\gtest\Release\gtest.dll build\Release\ &&
-      copy build\third_party\gtest\googlemock\gtest\Release\gtest_main.dll build\Release\ &&
-      copy build\third_party\gtest\googlemock\Release\gmock.dll build\Release\ &&
+      copy build\third_party\gtest\googlemock\gtest\Release\gtest.lib build\Release\ &&
+      copy build\third_party\gtest\googlemock\gtest\Release\gtest_main.lib build\Release\ &&
+      copy build\third_party\gtest\googlemock\Release\gmock.lib build\Release\ &&
       copy build\plugins\mission\Release\dronecore_mission.dll build\Release\ &&
       copy build\plugins\camera\Release\dronecore_camera.dll build\Release\ &&
       build\Release\unit_tests_runner.exe

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -1,6 +1,7 @@
 if(MSVC)
     add_definitions(-DWINDOWS)
     set(warnings "-WX -W2")
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
     # We need this so Windows links to e.g. dronecore_telemetry.dll.
     # Without this option it will look for dronecore_telemetry.lib and fail.

--- a/cmake/tinyxml2.cmake
+++ b/cmake/tinyxml2.cmake
@@ -1,0 +1,43 @@
+# We need tinyxml2 for the camera definition parsing.
+
+# We save the value of BUILD_STATIC_LIBRARY and BUILD_SHARED_LIBRARY before altering them
+set(BEFORE_TINYXML_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+set(BEFORE_TINYXML_BUILD_STATIC_LIBS ${BUILD_STATIC_LIBS})
+# This trick is needed with the cache as it is an option of tinyxml2,
+# and tinyxml2 is used as a submodule
+set(BUILD_SHARED_LIBS CACHE BOOL OFF)
+set(BUILD_STATIC_LIBS CACHE BOOL ON)
+set(BUILD_SHARED_LIBS OFF)
+set(BUILD_STATIC_LIBS ON)
+
+# Being linked to a shared lib later, tinyxml2_static needs to be compiled with -fPIC
+# Same trick here, we don't want to set -fPIC outside of this file
+set(BEFORE_TINYXML_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Actually include tinyxml2
+add_subdirectory(third_party/tinyxml2 EXCLUDE_FROM_ALL)
+link_directories(third_party/tinyxml2)
+include_directories(SYSTEM third_party/tinyxml2)
+
+set(TINYXML2_LIBRARY tinyxml2_static)
+
+# We set CMAKE_POSITION_INDEPENDENT_CODE back to what it was before including this file
+set(CMAKE_POSITION_INDEPENDENT_CODE ${BEFORE_TINYXML_POSITION_INDEPENDENT_CODE})
+
+# We set BUILD_STATIC_LIBRARY back to what it was before including this file
+if (DEFINED BEFORE_TINYXML_BUILD_SHARED_LIBS)
+    set(BUILD_SHARED_LIBS CACHE BOOL ${BEFORE_TINYXML_BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS ${BEFORE_TINYXML_BUILD_SHARED_LIBS})
+else()
+    unset(BUILD_SHARED_LIBS CACHE)
+    unset(BUILD_SHARED_LIBS)
+endif()
+
+if (DEFINED BEFORE_TINYXML_BUILD_STATIC_LIBS)
+    set(BUILD_STATIC_LIBS CACHE BOOL ${BEFORE_TINYXML_BUILD_STATIC_LIBS})
+    set(BUILD_STATIC_LIBS ${BEFORE_TINYXML_BUILD_STATIC_LIBS})
+else()
+    unset(BUILD_STATIC_LIBS CACHE)
+    unset(BUILD_STATIC_LIBS)
+endif()

--- a/core/integration_test_helper.h
+++ b/core/integration_test_helper.h
@@ -18,8 +18,7 @@ protected:
             abort();
         }
         // We need to wait a bit until it's up and running.
-        std::this_thread::sleep_for(std::chrono::seconds(3));
-#else
+#else        std::this_thread::sleep_for(std::chrono::seconds(3));
         dronecore::LogErr() << "Auto-starting SITL not supported on Windows.";
 #endif
     }

--- a/core/integration_test_helper.h
+++ b/core/integration_test_helper.h
@@ -18,7 +18,8 @@ protected:
             abort();
         }
         // We need to wait a bit until it's up and running.
-#else        std::this_thread::sleep_for(std::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+#else
         dronecore::LogErr() << "Auto-starting SITL not supported on Windows.";
 #endif
     }

--- a/core/integration_test_helper.h
+++ b/core/integration_test_helper.h
@@ -9,7 +9,7 @@
 class SitlTest : public testing::Test
 {
 protected:
-    virtual void SetUp()
+    virtual void SetUp() override
     {
 #ifndef WINDOWS
         const int ret = system("./start_px4_sitl.sh");
@@ -19,9 +19,11 @@ protected:
         }
         // We need to wait a bit until it's up and running.
         std::this_thread::sleep_for(std::chrono::seconds(3));
+#else
+        dronecore::LogErr() << "Auto-starting SITL not supported on Windows.";
 #endif
     }
-    virtual void TearDown()
+    virtual void TearDown() override
     {
 #ifndef WINDOWS
         // Don't rush this either.
@@ -31,6 +33,8 @@ protected:
             dronecore::LogErr() << "./stop_px4_sitl.sh failed, giving up.";
             abort();
         }
+#else
+        dronecore::LogErr() << "Auto-starting SITL not supported on Windows.";
 #endif
     }
 };

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -65,12 +65,6 @@ target_link_libraries(integration_tests_runner
     gmock
 )
 
-if (MSVC)
-    # We need this to prevent linking errors from happening in the Windows build.
-    target_compile_definitions(integration_tests_runner PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
-    target_compile_options(integration_tests_runner PUBLIC "/wd4251" "/wd4275")
-endif()
-
 add_test(integration_tests
     integration_tests_runner
 )


### PR DESCRIPTION
Build tinyxml2 statically (to fix the build for iOS).

It may look a bit hacky, but I did not want to pollute the whole scope with options set only for tinyxml2. One alternative would be to fork tinyxml2 and modify its `CMakeLists.txt`, and another one would be to not build tinyxml2 as a submodule (I would like to do that at some point, some kind of "super-build" scheme).

At least it is contained into `cmake/tinyxml2.cmake` for now.

@julianoes let me know if you think we should link it dynamically for some platforms.