### PR TITLE
core: use 251 as compid

### DIFF
--- a/core/mavlink_system.h
+++ b/core/mavlink_system.h
@@ -26,7 +26,8 @@ class PluginImplBase;
 // Type that represents DroneCore client application which is a GCS.
 struct GCSClient {
     static constexpr uint8_t system_id = 0;
-    static constexpr uint8_t component_id = MAV_COMP_ID_SYSTEM_CONTROL;
+    // FIXME: This is a workaround for now. We should revert it later or add a compid for the SDK.
+    static constexpr uint8_t component_id = MAV_COMP_ID_SYSTEM_CONTROL + 1;
     static constexpr MAV_TYPE type = MAV_TYPE_GCS;
 };
 


### PR DESCRIPTION
This is a workaround for now because we are conflicting with a component
using MAV_COMP_ID_SYSTEM_CONTROL.