### PR TITLE
mavlink command fixes

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -93,5 +93,6 @@ list(APPEND UNIT_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/core/curl_test.cpp
     ${CMAKE_SOURCE_DIR}/core/any_test.cpp
     ${CMAKE_SOURCE_DIR}/core/cli_arg_test.cpp
+    ${CMAKE_SOURCE_DIR}/core/locked_queue_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/core/locked_queue.h
+++ b/core/locked_queue.h
@@ -35,6 +35,9 @@ public:
     // This allows to return a borrowed queue.
     void return_front()
     {
+        // We don't know if the mutex is locked and Windows doesn't let us
+        // unlock an unowned mutex.
+        _mutex.try_lock();
         _mutex.unlock();
     }
 

--- a/core/locked_queue.h
+++ b/core/locked_queue.h
@@ -1,8 +1,8 @@
 #pragma once
 
-
 #include <queue>
 #include <mutex>
+#include <memory>
 
 namespace dronecore {
 
@@ -10,43 +10,55 @@ template <class T>
 class LockedQueue
 {
 public:
-    LockedQueue() :
-        _queue(),
-        _mutex()
-    {};
-
+    LockedQueue() {};
+    ~LockedQueue() {};
 
     void push_back(T item)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-
         _queue.push_back(item);
     }
 
-    T &front()
+    // This allows to get access to the front and keep others
+    // from using it. This blocks if the front is already borrowed.
+    std::shared_ptr<T> borrow_front()
     {
-        std::lock_guard<std::mutex> lock(_mutex);
+        _mutex.lock();
+        if (_queue.size() == 0) {
+            // We couldn't borrow anything, therefore don't keep the lock.
+            _mutex.unlock();
+            return nullptr;
+        }
+        return std::make_shared<T>(_queue.front());
+    }
 
-        return _queue.front();
+    // This allows to return a borrowed queue.
+    void return_front()
+    {
+        _mutex.unlock();
     }
 
     void pop_front()
     {
-        std::lock_guard<std::mutex> lock(_mutex);
+        // In case it's not returned, do that now.
+        return_front();
 
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_queue.size() == 0) {
+            return;
+        }
         _queue.pop_front();
     }
 
     size_t size()
     {
         std::lock_guard<std::mutex> lock(_mutex);
-
         return _queue.size();
     }
 
 private:
-    std::deque<T> _queue;
-    std::mutex _mutex;
+    std::deque<T> _queue {};
+    std::mutex _mutex {};
 };
 
 } // namespace dronecore

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -97,6 +97,6 @@ TEST(LockedQueue, ConcurrantAccess)
 
     locked_queue.return_front();
 
-    status = fut.wait_for(std::chrono::milliseconds(10));
+    status = fut.wait_for(std::chrono::milliseconds(100));
     EXPECT_EQ(status, std::future_status::ready);
 }

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -1,0 +1,102 @@
+
+#include "locked_queue.h"
+
+#include <string>
+#include <future>
+#include <gtest/gtest.h>
+
+using namespace dronecore;
+
+TEST(LockedQueue, FillAndEmpty)
+{
+    int one = 1;
+    int two = 2;
+    int three = 3;
+
+    LockedQueue<int> locked_queue {};
+
+    locked_queue.push_back(one);
+    EXPECT_EQ(locked_queue.size(), 1);
+    locked_queue.push_back(two);
+    locked_queue.push_back(three);
+    EXPECT_EQ(locked_queue.size(), 3);
+
+    locked_queue.pop_front();
+    EXPECT_EQ(locked_queue.size(), 2);
+    locked_queue.pop_front();
+    locked_queue.pop_front();
+    EXPECT_EQ(locked_queue.size(), 0);
+
+    // Popping an empty queue should just fail silently.
+    locked_queue.pop_front();
+    EXPECT_EQ(locked_queue.size(), 0);
+}
+
+TEST(LockedQueue, BorrowAndReturn)
+{
+    int one = 1;
+    int two = 2;
+    int three = 3;
+
+    LockedQueue<int> locked_queue {};
+
+    locked_queue.push_back(one);
+    locked_queue.push_back(two);
+    locked_queue.push_back(three);
+
+    auto borrowed_item = locked_queue.borrow_front();
+    EXPECT_EQ(*borrowed_item, 1);
+    locked_queue.return_front();
+    locked_queue.pop_front();
+
+    borrowed_item = locked_queue.borrow_front();
+    EXPECT_EQ(*borrowed_item, 2);
+    locked_queue.return_front();
+    // Double returning shouldn't matter.
+    locked_queue.return_front();
+    locked_queue.pop_front();
+
+    borrowed_item = locked_queue.borrow_front();
+    EXPECT_EQ(*borrowed_item, 3);
+    // Popping without returning should automatically return it.
+    locked_queue.pop_front();
+    EXPECT_EQ(locked_queue.size(), 0);
+
+    borrowed_item = locked_queue.borrow_front();
+    EXPECT_EQ(borrowed_item, nullptr);
+}
+
+TEST(LockedQueue, ConcurrantAccess)
+{
+    int one = 1;
+    int two = 2;
+
+    LockedQueue<int> locked_queue {};
+
+    locked_queue.push_back(one);
+    locked_queue.push_back(two);
+
+    auto borrowed_item = locked_queue.borrow_front();
+    EXPECT_EQ(*borrowed_item, 1);
+
+    auto prom = std::make_shared<std::promise<void>>();
+    auto fut = prom->get_future();
+
+    auto some_future = std::async(std::launch::async | std::launch::deferred,
+            [&prom, &locked_queue]() {
+        // This will wait in the lock until the first item is returned.
+        auto second_borrowed_item = locked_queue.borrow_front();
+        locked_queue.return_front();
+        prom->set_value();
+    });
+
+    // The promise should not be fulfilled yet because we have not
+    // returned the borrowed item.
+    auto status = fut.wait_for(std::chrono::milliseconds(10));
+    EXPECT_EQ(status, std::future_status::timeout);
+
+    locked_queue.return_front();
+
+    status = fut.wait_for(std::chrono::milliseconds(10));
+    EXPECT_EQ(status, std::future_status::ready);
+}

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -82,7 +82,7 @@ TEST(LockedQueue, ConcurrantAccess)
     auto prom = std::make_shared<std::promise<void>>();
     auto fut = prom->get_future();
 
-    auto some_future = std::async(std::launch::async | std::launch::deferred,
+    auto some_future = std::async(std::launch::async,
     [&prom, &locked_queue]() {
         // This will wait in the lock until the first item is returned.
         auto second_borrowed_item = locked_queue.borrow_front();
@@ -96,7 +96,6 @@ TEST(LockedQueue, ConcurrantAccess)
     EXPECT_EQ(status, std::future_status::timeout);
 
     locked_queue.return_front();
-
-    status = fut.wait_for(std::chrono::milliseconds(100));
+    status = fut.wait_for(std::chrono::milliseconds(10));
     EXPECT_EQ(status, std::future_status::ready);
 }

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -83,7 +83,7 @@ TEST(LockedQueue, ConcurrantAccess)
     auto fut = prom->get_future();
 
     auto some_future = std::async(std::launch::async | std::launch::deferred,
-            [&prom, &locked_queue]() {
+    [&prom, &locked_queue]() {
         // This will wait in the lock until the first item is returned.
         auto second_borrowed_item = locked_queue.borrow_front();
         locked_queue.return_front();

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -111,16 +111,14 @@ private:
     enum class State {
         NONE,
         WAITING,
-        IN_PROGRESS,
-        DONE,
-        FAILED
-    } _state = State::NONE;
+        IN_PROGRESS
+    } _state {State::NONE};
     std::mutex _state_mutex {};
 
     struct Work {
-        int retries_to_do = 3;
-        double timeout_s = 0.5;
-        uint16_t mavlink_command = 0;
+        int retries_to_do {3};
+        double timeout_s {0.5};
+        uint16_t mavlink_command {0};
         mavlink_message_t mavlink_message {};
         command_result_callback_t callback {};
     };

--- a/core/safe_queue.h
+++ b/core/safe_queue.h
@@ -16,11 +16,7 @@ template <class T>
 class SafeQueue
 {
 public:
-    SafeQueue() :
-        _queue(),
-        _mutex(),
-        _condition_var()
-    {}
+    SafeQueue() {}
     ~SafeQueue() {}
 
     void enqueue(T item)
@@ -55,10 +51,10 @@ public:
     }
 
 private:
-    std::queue<T> _queue;
-    mutable std::mutex _mutex;
-    std::condition_variable _condition_var;
-    bool _should_exit = false;
+    std::queue<T> _queue {};
+    mutable std::mutex _mutex {};
+    std::condition_variable _condition_var {};
+    bool _should_exit {false};
 };
 
 } // namespace dronecore


### PR DESCRIPTION
These are a bunch of fixes to prevent promises getting set more than
once which triggers an abort.

This needs further cleanup, the changes are rather ugly.