### PR TITLE
Fix timeout handler segfault

### DIFF
--- a/core/timeout_handler.cpp
+++ b/core/timeout_handler.cpp
@@ -48,6 +48,7 @@ void TimeoutHandler::remove(const void *cookie)
     auto it = _timeouts.find(const_cast<void *>(cookie));
     if (it != _timeouts.end()) {
         _timeouts.erase(const_cast<void *>(cookie));
+        _iterator_invalidated = true;
     }
 }
 
@@ -79,6 +80,13 @@ void TimeoutHandler::run_once()
 
         } else {
             ++it;
+        }
+
+        // We leave the loop if anyone has messed with this while we called the callback.
+        // FIXME: there should be a nicer way to do this.
+        if (_iterator_invalidated) {
+            _iterator_invalidated = false;
+            break;
         }
     }
     _timeouts_mutex.unlock();

--- a/core/timeout_handler.cpp
+++ b/core/timeout_handler.cpp
@@ -82,11 +82,10 @@ void TimeoutHandler::run_once()
             ++it;
         }
 
-        // We leave the loop if anyone has messed with this while we called the callback.
-        // FIXME: there should be a nicer way to do this.
+        // We start over if anyone has messed with this while we called the callback.
         if (_iterator_invalidated) {
             _iterator_invalidated = false;
-            break;
+            it = _timeouts.begin();
         }
     }
     _timeouts_mutex.unlock();

--- a/core/timeout_handler.h
+++ b/core/timeout_handler.h
@@ -35,6 +35,7 @@ private:
 
     std::map<void *, std::shared_ptr<Timeout>> _timeouts {};
     std::mutex _timeouts_mutex {};
+    bool _iterator_invalidated {false};
 
     Time &_time;
 };

--- a/core/timeout_handler_test.cpp
+++ b/core/timeout_handler_test.cpp
@@ -159,7 +159,8 @@ TEST(TimeoutHandler, NextTimeoutRemovedDuringCallback)
 
     th.add([&th, &cookie2]() {
         // This is evil but can potentially happen. We remove the other timer while
-        // being called. This triggers that the iterator is invalid and causes a segfault.
+        // being called. This triggers that the iterator is invalid and causes a segfault
+        // if not handled properly.
         th.remove(cookie2);
     }, 0.5, &cookie1);
 


### PR DESCRIPTION
This fixes the rare case where the "next" timer was deleted during the timeout callback which caused a segfault when iterating (`++`).