### PR TITLE
fly_qgc_mission: link to json11

### DIFF
--- a/example/fly_mission/CMakeLists.txt
+++ b/example/fly_mission/CMakeLists.txt
@@ -19,5 +19,4 @@ target_link_libraries(fly_mission
     dronecore_action
     dronecore_mission
     dronecore_telemetry
-    json11
 )

--- a/example/fly_qgc_mission/CMakeLists.txt
+++ b/example/fly_qgc_mission/CMakeLists.txt
@@ -18,6 +18,5 @@ target_link_libraries(fly_qgc_mission
     dronecore
     dronecore_action
     dronecore_mission
-    json11 # Needed by dronecore_mission for QGC mission plan import
     dronecore_telemetry
 )

--- a/example/fly_qgc_mission/CMakeLists.txt
+++ b/example/fly_qgc_mission/CMakeLists.txt
@@ -18,5 +18,6 @@ target_link_libraries(fly_qgc_mission
     dronecore
     dronecore_action
     dronecore_mission
+    json11 # Needed by dronecore_mission for QGC mission plan import
     dronecore_telemetry
 )

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories(
     SYSTEM ${CMAKE_SOURCE_DIR}/third_party/mavlink/include
 )
 
-if(IOS OR ANDROID OR APPLE)
+if(IOS OR ANDROID)
     set(PLUGIN_LIBRARY_TYPE STATIC)
 else()
     set(PLUGIN_LIBRARY_TYPE SHARED)


### PR DESCRIPTION
We need to link to libjson11 as well because libdronecore_mission.so doesn't include it.

@JonasVautherin any better idea? Or should we include json11 inside `libdronecore.a` like tinyxml2 to prevent this?

Fixes #381.