### PR TITLE
Make all examples use add_any_connection()

### DIFF
--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -76,12 +76,12 @@ int main(int argc, char **argv)
         std::string connection_url;
         ConnectionResult connection_result;
 
-        if (argc == 1) {
-            usage(argv[0]);
-            return 1;
-        } else {
+        if (argc == 2) {
             connection_url = argv[1];
             connection_result = dc.add_any_connection(connection_url);
+        } else {
+            usage(argv[0]);
+            return 1;
         }
 
         if (connection_result != ConnectionResult::SUCCESS) {

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -48,9 +48,9 @@ static std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
                                                       float gimbal_yaw_deg,
                                                       MissionItem::CameraAction camera_action);
 
-void usage(std::string arg)
+void usage(std::string bin_name)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -54,8 +54,8 @@ void usage(std::string bin_name)
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
 

--- a/example/fly_mission/fly_mission.cpp
+++ b/example/fly_mission/fly_mission.cpp
@@ -48,7 +48,16 @@ static std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
                                                       float gimbal_yaw_deg,
                                                       MissionItem::CameraAction camera_action);
 
-void usage(std::string arg);
+void usage(std::string arg)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
+    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
 
 int main(int argc, char **argv)
 {
@@ -319,12 +328,4 @@ inline void handle_connection_err_exit(ConnectionResult result,
     }
 }
 
-void usage(std::string arg)
-{
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " [connection_url]" << std::endl
-              << "Connection URL format should be :" << std::endl
-              << " For TCP : tcp://[server_host][:server_port]" << std::endl
-              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "Default connection URL is udp://:14540" << std::endl;
-}
+

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -46,20 +46,42 @@ inline void handle_mission_err_exit(Mission::Result result, const std::string &m
 inline void handle_connection_err_exit(ConnectionResult result,
                                        const std::string &message);
 
+
+
+void usage(std::string arg)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url> [path of QGC Mission plan]" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
+    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
 int main(int argc, char **argv)
 {
+    DroneCore dc;
+    std::string connection_url;
+    ConnectionResult connection_result;
+
+
     // Locate path of QGC Sample plan
     std::string qgc_plan = "../../../plugins/mission/qgroundcontrol_sample.plan";
 
-    if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " <path of QGC Mission plan>\n";
-        std::cout << "Importing mission from Default mission plan: " << qgc_plan << std::endl;
-    } else if (argc == 2) {
-        std::cout << "Importing mission from mission plan: " << qgc_plan << std::endl;
-        qgc_plan = argv[1];
+    if (argc == 1) {
+        usage(argv[0]);
+        return 1;
+    } 
+    if (argc >= 2) {
+        connection_url = argv[1];
     }
+    if (argc >= 3) { 
+        qgc_plan = argv[2];
+    }
+    std::cout << "Connection URL: " << connection_url << std::endl;
+    std::cout << "Importing mission from mission plan: " << qgc_plan << std::endl;
 
-    DroneCore dc;
 
     {
         auto prom = std::make_shared<std::promise<void>>();
@@ -71,7 +93,7 @@ int main(int argc, char **argv)
             prom->set_value();
         });
 
-        ConnectionResult connection_result = dc.add_udp_connection();
+        connection_result = dc.add_any_connection(connection_url);
         handle_connection_err_exit(connection_result, "Connection failed: ");
 
         future_result.get();

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -70,16 +70,16 @@ int main(int argc, char **argv)
     // Locate path of QGC Sample plan
     std::string qgc_plan = "../../../plugins/mission/qgroundcontrol_sample.plan";
 
-    if (argc == 1) {
+    if (argc != 2 && argc != 3) {
         usage(argv[0]);
         return 1;
     }
-    if (argc >= 2) {
-        connection_url = argv[1];
-    }
-    if (argc >= 3) {
+
+    connection_url = argv[1];
+    if (argc == 3) {
         qgc_plan = argv[2];
     }
+
     std::cout << "Connection URL: " << connection_url << std::endl;
     std::cout << "Importing mission from mission plan: " << qgc_plan << std::endl;
 

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -48,9 +48,9 @@ inline void handle_connection_err_exit(ConnectionResult result,
 
 
 
-void usage(std::string arg)
+void usage(std::string bin_name)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg <<
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name <<
               " <connection_url> [path of QGC Mission plan]" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -50,7 +50,8 @@ inline void handle_connection_err_exit(ConnectionResult result,
 
 void usage(std::string arg)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url> [path of QGC Mission plan]" << std::endl
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg <<
+              " <connection_url> [path of QGC Mission plan]" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
@@ -72,11 +73,11 @@ int main(int argc, char **argv)
     if (argc == 1) {
         usage(argv[0]);
         return 1;
-    } 
+    }
     if (argc >= 2) {
         connection_url = argv[1];
     }
-    if (argc >= 3) { 
+    if (argc >= 3) {
         qgc_plan = argv[2];
     }
     std::cout << "Connection URL: " << connection_url << std::endl;

--- a/example/fly_qgc_mission/fly_qgc_mission.cpp
+++ b/example/fly_qgc_mission/fly_qgc_mission.cpp
@@ -55,8 +55,8 @@ void usage(std::string bin_name)
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
 

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -35,12 +35,38 @@ inline void action_error_exit(ActionResult result, const std::string &message);
 inline void follow_me_error_exit(FollowMe::Result result, const std::string &message);
 inline void connection_error_exit(ConnectionResult result, const std::string &message);
 
-int main(int, char **)
+void usage(std::string arg)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
+    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
+int main(int argc, char **argv)
 {
     DroneCore dc;
+    std::string connection_url;
+    ConnectionResult connection_result;
 
-    ConnectionResult conn_result = dc.add_udp_connection();
-    connection_error_exit(conn_result, "Connection failed");
+    if (argc == 1) {
+        usage(argv[0]);
+        return 1;
+    } else {
+        connection_url = argv[1];
+        connection_result = dc.add_any_connection(connection_url);
+    }
+
+    if (connection_result != ConnectionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Connection failed: "
+                  << connection_result_str(connection_result)
+                  << NORMAL_CONSOLE_TEXT << std::endl;
+        return 1;
+    }
+
 
     // Wait for the system to connect via heartbeat
     while (!dc.is_connected()) {
@@ -144,3 +170,5 @@ inline void connection_error_exit(ConnectionResult result, const std::string &me
         exit(EXIT_FAILURE);
     }
 }
+
+

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -35,9 +35,9 @@ inline void action_error_exit(ActionResult result, const std::string &message);
 inline void follow_me_error_exit(FollowMe::Result result, const std::string &message);
 inline void connection_error_exit(ConnectionResult result, const std::string &message);
 
-void usage(std::string arg)
+void usage(std::string bin_name)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -41,8 +41,8 @@ void usage(std::string bin_name)
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
 

--- a/example/follow_me/follow_me.cpp
+++ b/example/follow_me/follow_me.cpp
@@ -52,12 +52,12 @@ int main(int argc, char **argv)
     std::string connection_url;
     ConnectionResult connection_result;
 
-    if (argc == 1) {
-        usage(argv[0]);
-        return 1;
-    } else {
+    if (argc == 2) {
         connection_url = argv[1];
         connection_result = dc.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
     }
 
     if (connection_result != ConnectionResult::SUCCESS) {

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -168,9 +168,9 @@ bool offb_ctrl_body(std::shared_ptr<dronecore::Offboard> offboard)
 }
 
 
-void usage(std::string arg)
+void usage(std::string bin_name)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -174,8 +174,8 @@ void usage(std::string bin_name)
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
 

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -167,12 +167,39 @@ bool offb_ctrl_body(std::shared_ptr<dronecore::Offboard> offboard)
     return true;
 }
 
-int main(int, char **)
+
+void usage(std::string arg)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
+    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
+int main(int argc, char **argv)
 {
     DroneCore dc;
+    std::string connection_url;
+    ConnectionResult connection_result;
 
-    ConnectionResult conn_result = dc.add_udp_connection();
-    connection_error_exit(conn_result, "Connection failed");
+    if (argc == 1) {
+        usage(argv[0]);
+        return 1;
+    } else {
+        connection_url = argv[1];
+        connection_result = dc.add_any_connection(connection_url);
+    }
+
+    if (connection_result != ConnectionResult::SUCCESS) {
+        std::cout << ERROR_CONSOLE_TEXT << "Connection failed: "
+                  << connection_result_str(connection_result)
+                  << NORMAL_CONSOLE_TEXT << std::endl;
+        return 1;
+    }
+
 
     // Wait for the system to connect via heartbeat
     while (!dc.is_connected()) {

--- a/example/offboard_velocity/offboard_velocity.cpp
+++ b/example/offboard_velocity/offboard_velocity.cpp
@@ -185,12 +185,12 @@ int main(int argc, char **argv)
     std::string connection_url;
     ConnectionResult connection_result;
 
-    if (argc == 1) {
-        usage(argv[0]);
-        return 1;
-    } else {
+    if (argc == 2) {
         connection_url = argv[1];
         connection_result = dc.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
     }
 
     if (connection_result != ConnectionResult::SUCCESS) {

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -19,7 +19,16 @@ using namespace std::chrono;
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
-void usage(std::string arg);
+void usage(std::string arg)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
+    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
 
 int main(int argc, char **argv)
 {
@@ -124,12 +133,3 @@ int main(int argc, char **argv)
     return 0;
 }
 
-void usage(std::string arg)
-{
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " [connection_url]" << std::endl
-              << "Connection URL format should be :" << std::endl
-              << " For TCP : tcp://[server_host][:server_port]" << std::endl
-              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "Default connection URL is udp://:14540" << std::endl;
-}

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -25,8 +25,8 @@ void usage(std::string bin_name)
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
 

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -19,9 +19,9 @@ using namespace std::chrono;
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
-void usage(std::string arg)
+void usage(std::string bin_name)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl

--- a/example/takeoff_land/takeoff_and_land.cpp
+++ b/example/takeoff_land/takeoff_and_land.cpp
@@ -37,12 +37,12 @@ int main(int argc, char **argv)
     ConnectionResult connection_result;
 
     bool discovered_system = false;
-    if (argc == 1) {
-        usage(argv[0]);
-        return 1;
-    } else {
+    if (argc == 2) {
         connection_url = argv[1];
         connection_result = dc.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
     }
 
     if (connection_result != ConnectionResult::SUCCESS) {

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -16,9 +16,9 @@ using namespace dronecore;
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
 
-void usage(std::string arg)
+void usage(std::string bin_name)
 {
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -15,13 +15,32 @@ using namespace dronecore;
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
-int main(int /*argc*/, char ** /*argv*/)
+
+void usage(std::string arg)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
+    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
+int main(int argc, char **argv)
 {
     DroneCore dc;
+    std::string connection_url;
+    ConnectionResult connection_result;
 
     bool discovered_system = false;
-
-    ConnectionResult connection_result = dc.add_udp_connection();
+    if (argc == 1) {
+        usage(argv[0]);
+        return 1;
+    } else {
+        connection_url = argv[1];
+        connection_result = dc.add_any_connection(connection_url);
+    }
 
     if (connection_result != ConnectionResult::SUCCESS) {
         std::cout << ERROR_CONSOLE_TEXT << "Connection failed: "
@@ -37,7 +56,8 @@ int main(int /*argc*/, char ** /*argv*/)
     });
 
     // We usually receive heartbeats at 1Hz, therefore we should find a system after around 2 seconds.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    sleep_for(std::chrono::seconds(2));
+
 
     if (!discovered_system) {
         std::cout << ERROR_CONSOLE_TEXT << "No system found, exiting." << NORMAL_CONSOLE_TEXT << std::endl;

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -34,12 +34,13 @@ int main(int argc, char **argv)
     ConnectionResult connection_result;
 
     bool discovered_system = false;
-    if (argc == 1) {
-        usage(argv[0]);
-        return 1;
-    } else {
+
+    if (argc == 2) {
         connection_url = argv[1];
         connection_result = dc.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
     }
 
     if (connection_result != ConnectionResult::SUCCESS) {

--- a/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
+++ b/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp
@@ -22,8 +22,8 @@ void usage(std::string bin_name)
               << "Connection URL format should be :" << std::endl
               << " For TCP : tcp://[server_host][:server_port]" << std::endl
               << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
 


### PR DESCRIPTION
Some of the examples used `add_any_connection()` and others used `add_udp_connection()`. This changes all examples to have a usage printout and to use `add_any_connection()`.

Note that it doesn't fix all the problems with the examples. Any that fail before, will still fail afterwards.  All it does is make sure that they are started using the same method, allows them to pass a URL, and tells people the URL for the simulator. 