### PR TITLE
mission: fix warning about missing return

### DIFF
--- a/plugins/mission/mission_item.cpp
+++ b/plugins/mission/mission_item.cpp
@@ -183,6 +183,8 @@ std::ostream &operator<<(std::ostream &str, MissionItem::CameraAction const &cam
             return str << "CameraAction::STOP_VIDEO";
         case MissionItem::CameraAction::NONE:
             return str << "CameraAction::NONE";
+        default:
+            return str << "Unknown";
     }
 }
 


### PR DESCRIPTION
@JonasVautherin is this the right fix, or should we add an enum named `UNKNOWN`?

It's a bit silly but it seems the compiler doesn't realize that all cases are covered and we don't need `default`.

The warning with gcc 8.1.1 is:
```
/home/julianoes/src/DroneCore/plugins/mission/mission_item.cpp: In function ‘std::ostream& dronecore::operator<<(std::ostream&, const dronecore::MissionItem::CameraAction&)’:
/home/julianoes/src/DroneCore/plugins/mission/mission_item.cpp:187:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
```