### PR TITLE
core: fix macOS warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
       env:
       - MATRIX_EVAL="BUILD_TARGET=docker_build_fedora_28"
     - os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3
       env:
         - BUILD_TARGET=osx_build
 

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -26,9 +26,9 @@ else()
 
         set(warnings "${warnings} -Wlogical-op")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(warnings "${warnings} -Wno-missing-braces")
+        set(warnings "${warnings} -Wno-missing-braces -Wno-unused-lambda-capture")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-        set(warnings "${warnings} -Wno-missing-braces -Wno-unused-parameter")
+        set(warnings "${warnings} -Wno-missing-braces -Wno-unused-parameter -Wno-unused-lambda-capture")
     endif()
 
     # Otherwise tinyxml2 complains.


### PR DESCRIPTION
Clang and MSVC are not agreeing on this issue, so we'll ignore
the clang warning for now.