### PR TITLE
camera: add set_mode (synchronous)

### DIFF
--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -747,7 +747,7 @@ MAVLinkCommands::Result SystemImpl::send_command(MAVLinkCommands::CommandInt &co
 }
 
 void SystemImpl::send_command_async(MAVLinkCommands::CommandLong &command,
-                                    command_result_callback_t callback)
+                                    const command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
         if (callback) {
@@ -761,7 +761,7 @@ void SystemImpl::send_command_async(MAVLinkCommands::CommandLong &command,
 }
 
 void SystemImpl::send_command_async(MAVLinkCommands::CommandInt &command,
-                                    command_result_callback_t callback)
+                                    const command_result_callback_t callback)
 {
     if (_system_id == 0 && _components.size() == 0) {
         if (callback) {

--- a/core/system_impl.h
+++ b/core/system_impl.h
@@ -79,9 +79,9 @@ public:
     // FIXME: I tried to use templates for these;
     // but I get undefined reference. Need to dig it later.
     void send_command_async(MAVLinkCommands::CommandLong &command,
-                            command_result_callback_t callback);
+                            const command_result_callback_t callback);
     void send_command_async(MAVLinkCommands::CommandInt &command,
-                            command_result_callback_t callback);
+                            const command_result_callback_t callback);
 
     MAVLinkCommands::Result set_msg_rate(uint16_t message_id,
                                          double rate_hz,

--- a/integration_tests/camera_mode.cpp
+++ b/integration_tests/camera_mode.cpp
@@ -8,7 +8,33 @@
 
 using namespace dronecore;
 
-TEST(CameraTest, ChangeMode)
+TEST(CameraTest, SetMode)
+{
+    DroneCore dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::SUCCESS);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto &system = dc.system();
+    ASSERT_TRUE(system.has_camera());
+    auto camera = std::make_shared<Camera>(system);
+
+    std::vector<Camera::Mode> modes_to_test;
+    modes_to_test.push_back(Camera::Mode::PHOTO);
+    modes_to_test.push_back(Camera::Mode::VIDEO);
+    modes_to_test.push_back(Camera::Mode::PHOTO);
+    modes_to_test.push_back(Camera::Mode::VIDEO);
+
+    for (auto mode : modes_to_test) {
+        auto result = camera->set_mode(mode);
+        EXPECT_EQ(result, Camera::Result::SUCCESS);
+    }
+}
+
+TEST(CameraTest, SetModeAsync)
 {
     DroneCore dc;
 
@@ -22,43 +48,43 @@ TEST(CameraTest, ChangeMode)
     ASSERT_TRUE(system.has_camera());
     auto camera = std::make_shared<Camera>(system);
 
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     Camera::Mode new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::VIDEO);
+    set_mode_async(camera, Camera::Mode::VIDEO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::VIDEO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::VIDEO);
+    set_mode_async(camera, Camera::Mode::VIDEO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::VIDEO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::VIDEO);
+    set_mode_async(camera, Camera::Mode::VIDEO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::VIDEO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(2));
     new_mode = get_mode(camera);
     EXPECT_EQ(new_mode, Camera::Mode::PHOTO);

--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -34,7 +34,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
 
     if (is_e90 || is_e50 || is_et) {
         // Set to photo mode
-        set_mode(camera, Camera::Mode::PHOTO);
+        set_mode_async(camera, Camera::Mode::PHOTO);
 
         std::vector<std::string> settings;
         EXPECT_TRUE(camera->get_possible_settings(settings));
@@ -52,7 +52,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
             EXPECT_EQ(settings.size(), 5);
         }
 
-        set_mode(camera, Camera::Mode::VIDEO);
+        set_mode_async(camera, Camera::Mode::VIDEO);
 
         std::this_thread::sleep_for(std::chrono::seconds(2));
 
@@ -93,7 +93,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
         EXPECT_FALSE(camera->get_possible_options("CAM_BLABLA", options));
         EXPECT_EQ(options.size(), 0);
 
-        set_mode(camera, Camera::Mode::PHOTO);
+        set_mode_async(camera, Camera::Mode::PHOTO);
 
         if (is_e90) {
             // Try something that is specific to the camera mode.
@@ -129,7 +129,7 @@ TEST(CameraTest, SetSettings)
     // because we don't have a check yet.
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
 
     // Try setting garbage first
     EXPECT_EQ(set_setting(camera, "DOES_NOT", "EXIST"), Camera::Result::ERROR);
@@ -181,7 +181,7 @@ TEST(CameraTest, SetSettings)
         EXPECT_TRUE(camera->get_possible_options("CAM_METERING", options));
         EXPECT_EQ(options.size(), 3);
 
-        set_mode(camera, Camera::Mode::VIDEO);
+        set_mode_async(camera, Camera::Mode::VIDEO);
 
         // This should fail in video mode.
         EXPECT_EQ(set_setting(camera, "CAM_PHOTOQUAL", "1"), Camera::Result::ERROR);

--- a/integration_tests/camera_take_photo.cpp
+++ b/integration_tests/camera_take_photo.cpp
@@ -36,7 +36,7 @@ TEST(CameraTest, TakePhoto)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     // We want to take the picture in photo mode.
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
@@ -64,7 +64,7 @@ TEST(CameraTest, TakeMultiplePhotos)
     auto camera = std::make_shared<Camera>(system);
 
     // We want to take the picture in photo mode.
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 

--- a/integration_tests/camera_take_photo_interval.cpp
+++ b/integration_tests/camera_take_photo_interval.cpp
@@ -33,7 +33,7 @@ TEST(CameraTest, TakePhotoInterval)
     auto camera = std::make_shared<Camera>(system);
 
     // We want to take the pictures in photo mode.
-    set_mode(camera, Camera::Mode::PHOTO);
+    set_mode_async(camera, Camera::Mode::PHOTO);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     check_interval_on(camera, false);

--- a/integration_tests/camera_test_helpers.cpp
+++ b/integration_tests/camera_test_helpers.cpp
@@ -36,7 +36,7 @@ Camera::Mode get_mode(std::shared_ptr<Camera> camera)
     }
 }
 
-void set_mode(std::shared_ptr<Camera> camera, Camera::Mode mode)
+void set_mode_async(std::shared_ptr<Camera> camera, Camera::Mode mode)
 {
     //// FIXME: this should not be required.
     std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/integration_tests/camera_test_helpers.h
+++ b/integration_tests/camera_test_helpers.h
@@ -4,7 +4,7 @@
 #include "plugins/camera/camera.h"
 
 dronecore::Camera::Mode get_mode(std::shared_ptr<dronecore::Camera> camera);
-void set_mode(std::shared_ptr<dronecore::Camera> camera, dronecore::Camera::Mode mode);
+void set_mode_async(std::shared_ptr<dronecore::Camera> camera, dronecore::Camera::Mode mode);
 
 dronecore::Camera::Result set_setting(std::shared_ptr<dronecore::Camera> camera,
                                       const std::string &setting,

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -77,7 +77,12 @@ void Camera::stop_video_async(const result_callback_t &callback)
     _impl->stop_video_async(callback);
 }
 
-void Camera::set_mode_async(Mode mode, const mode_callback_t &callback)
+Camera::Result Camera::set_mode(const Mode mode)
+{
+    return _impl->set_mode(mode);
+}
+
+void Camera::set_mode_async(const Mode mode, const mode_callback_t &callback)
 {
     _impl->set_mode_async(mode, callback);
 }

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -177,12 +177,21 @@ public:
     typedef std::function<void(Result, const Mode &)> mode_callback_t;
 
     /**
+     * @brief Setter for camera mode (synchronous).
+     *
+     * @param mode Camera mode to set
+     *
+     * @return SUCCESS if mode is set, error otherwise.
+     */
+    Result set_mode(const Mode mode);
+
+    /**
      * @brief Setter for camera mode (asynchronous).
      *
      * @param mode Camera mode to set.
      * @param callback Function to call with result of request.
      */
-    void set_mode_async(Mode mode, const mode_callback_t &callback);
+    void set_mode_async(const Mode mode, const mode_callback_t &callback);
 
     /**
      * @brief Getter for camera mode (asynchronous).

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -482,6 +482,7 @@ void CameraImpl::get_mode_async(Camera::mode_callback_t callback)
     if (_get_mode.callback != nullptr) {
         if (callback) {
             callback(Camera::Result::BUSY, Camera::Mode::UNKNOWN);
+            return;
         }
     }
     _get_mode.callback = callback;

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -410,7 +410,8 @@ Camera::Result CameraImpl::get_video_stream_info(Camera::VideoStreamInfo &info)
     ;
 }
 
-Camera::Result CameraImpl::camera_result_from_command_result(const MAVLinkCommands::Result command_result)
+Camera::Result
+CameraImpl::camera_result_from_command_result(const MAVLinkCommands::Result command_result)
 {
     switch (command_result) {
         case MAVLinkCommands::Result::SUCCESS:

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -38,7 +38,8 @@ public:
     Camera::Result start_video_streaming();
     Camera::Result stop_video_streaming();
 
-    void set_mode_async(Camera::Mode mode, const Camera::mode_callback_t &callback);
+    Camera::Result set_mode(const Camera::Mode mode);
+    void set_mode_async(const Camera::Mode mode, const Camera::mode_callback_t &callback);
     void get_mode_async(Camera::mode_callback_t callback);
 
     void capture_info_async(Camera::capture_info_callback_t callback);
@@ -108,15 +109,15 @@ private:
         }
     } _video_stream_info;
 
-    void receive_set_mode_command_result(MAVLinkCommands::Result command_result,
+    void receive_set_mode_command_result(const MAVLinkCommands::Result command_result,
                                          const Camera::mode_callback_t &callback,
-                                         Camera::Mode mode);
+                                         const Camera::Mode mode);
 
     void get_mode_timeout_happened();
 
     void receive_get_mode_command_result(MAVLinkCommands::Result command_result);
 
-    static Camera::Result camera_result_from_command_result(MAVLinkCommands::Result command_result);
+    static Camera::Result camera_result_from_command_result(const MAVLinkCommands::Result command_result);
 
     static void receive_command_result(MAVLinkCommands::Result command_result,
                                        const Camera::result_callback_t &callback);
@@ -141,6 +142,10 @@ private:
 
     void refresh_params();
     void invalidate_params();
+
+    void save_camera_mode(const float mavlink_camera_mode);
+    float to_mavlink_camera_mode(const Camera::Mode mode) const;
+    Camera::Mode to_camera_mode(const uint8_t mavlink_camera_mode) const;
 
     // Utility methods for convenience
     MAVLinkCommands::CommandLong make_command_take_photo(float interval_s, float no_of_photos);

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -117,7 +117,8 @@ private:
 
     void receive_get_mode_command_result(MAVLinkCommands::Result command_result);
 
-    static Camera::Result camera_result_from_command_result(const MAVLinkCommands::Result command_result);
+    static Camera::Result
+    camera_result_from_command_result(const MAVLinkCommands::Result command_result);
 
     static void receive_command_result(MAVLinkCommands::Result command_result,
                                        const Camera::result_callback_t &callback);


### PR DESCRIPTION
Add a synchronous `set_mode` function to the camera interface.

Connects to #334.