### PR TITLE
Allow DroneCore to be added to built by a parent cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 if(BUILD_TESTS)
     enable_testing()
-    add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/gtest EXCLUDE_FROM_ALL)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/gtest EXCLUDE_FROM_ALL)
 
     add_subdirectory(integration_tests)
 

--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -45,8 +45,8 @@ target_link_libraries(backend
 
 target_include_directories(backend
     PRIVATE
-    ${CMAKE_SOURCE_DIR}/core
-    ${CMAKE_SOURCE_DIR}/plugins
+    ${CMAKE_CURRENT_SOURCE_DIR}/core
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugins
     ${CMAKE_BINARY_DIR}/backend/src
     ${PLUGINS_DIR}
 )
@@ -74,6 +74,6 @@ else()
 
     target_include_directories(backend_bin
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/core
+        ${CMAKE_CURRENT_SOURCE_DIR}/core
     )
 endif()

--- a/backend/test/CMakeLists.txt
+++ b/backend/test/CMakeLists.txt
@@ -16,9 +16,9 @@ target_include_directories(unit_tests_backend
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/plugins
-    ${CMAKE_SOURCE_DIR}/plugins
+    ${PROJECT_SOURCE_DIR}/plugins
     ${CMAKE_BINARY_DIR}/backend/src
-    ${CMAKE_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}
 )
 
 target_link_libraries(unit_tests_backend

--- a/cmake/curl.cmake
+++ b/cmake/curl.cmake
@@ -1,10 +1,10 @@
 # core and some plugins require curl
 if(ANDROID)
-    set(CURL_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/android/include)
-    set(CURL_LIBRARY ${CMAKE_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/android/${ANDROID_ABI}/libcurl.a)
+    set(CURL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/android/include)
+    set(CURL_LIBRARY ${PROJECT_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/android/${ANDROID_ABI}/libcurl.a)
 elseif(IOS)
-    set(CURL_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/iOS/include)
-    set(CURL_LIBRARY ${CMAKE_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/iOS/libcurl.a)
+    set(CURL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/iOS/include)
+    set(CURL_LIBRARY ${PROJECT_SOURCE_DIR}/core/third_party/curl-android-ios/prebuilt-with-ssl/iOS/libcurl.a)
 elseif(MSVC)
     # You need to call cmake with -DWIN_CURL_INCLUDE_DIR:STRING="C:\\curl-7.54.1\\include"
     if(NOT WIN_CURL_INCLUDE_DIR)

--- a/cmake/unit_tests.cmake
+++ b/cmake/unit_tests.cmake
@@ -1,5 +1,5 @@
-include_directories(${CMAKE_SOURCE_DIR}/core)
-include_directories(${CMAKE_SOURCE_DIR}/third_party/mavlink/include)
+include_directories(${PROJECT_SOURCE_DIR}/core)
+include_directories(${PROJECT_SOURCE_DIR}/third_party/mavlink/include)
 include_directories(${CURL_INCLUDE_DIRS})
 
 add_executable(unit_tests_runner

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -1,4 +1,4 @@
-set(ZLIB_ROOT_DIR ${CMAKE_SOURCE_DIR}/third_party/zlib)
+set(ZLIB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/zlib)
 
 set(SKIP_INSTALL_ALL "true")
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -86,7 +86,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/core/global_include_test.cpp
     ${PROJECT_SOURCE_DIR}/core/mavlink_channels_test.cpp
     ${PROJECT_SOURCE_DIR}/core/unittests_main.cpp
-    # TODO: add this again     
+    # TODO: add this again
     #${PROJECT_SOURCE_DIR}/core/http_loader_test.cpp
     ${PROJECT_SOURCE_DIR}/core/timeout_handler_test.cpp
     ${PROJECT_SOURCE_DIR}/core/call_every_handler_test.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Threads REQUIRED)
 include_directories(
     ${DRONECORE_ZLIB_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/mavlink/include
+    SYSTEM ${PROJECT_SOURCE_DIR}/third_party/mavlink/include
 )
 
 if(IOS OR MSVC OR APPLE)
@@ -83,17 +83,17 @@ install(FILES
 )
 
 list(APPEND UNIT_TEST_SOURCES
-    ${CMAKE_SOURCE_DIR}/core/global_include_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/mavlink_channels_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/unittests_main.cpp
-    # TODO: add this again
-    #${CMAKE_SOURCE_DIR}/core/http_loader_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/timeout_handler_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/call_every_handler_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/curl_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/any_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/cli_arg_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/locked_queue_test.cpp
-    ${CMAKE_SOURCE_DIR}/core/thread_pool_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/global_include_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/mavlink_channels_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/unittests_main.cpp
+    # TODO: add this again     
+    #${PROJECT_SOURCE_DIR}/core/http_loader_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/timeout_handler_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/call_every_handler_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/curl_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/any_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/cli_arg_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/locked_queue_test.cpp
+    ${PROJECT_SOURCE_DIR}/core/thread_pool_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/external_example/integration_tests/CMakeLists.txt
+++ b/external_example/integration_tests/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(external_example_integration_tests_runner
-    ${CMAKE_SOURCE_DIR}/core/unittests_main.cpp
+    ${PROJECT_SOURCE_DIR}/core/unittests_main.cpp
     hello_world.cpp
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/core
-    ${CMAKE_SOURCE_DIR}/external_example
+    ${PROJECT_SOURCE_DIR}/core
+    ${PROJECT_SOURCE_DIR}/external_example
 )
 
 target_link_libraries(external_example_integration_tests_runner

--- a/external_example/plugins/example/CMakeLists.txt
+++ b/external_example/plugins/example/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(dronecore_example SHARED
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/core
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/mavlink/include
+    ${PROJECT_SOURCE_DIR}/core
+    SYSTEM ${PROJECT_SOURCE_DIR}/third_party/mavlink/include
 )
 
 target_link_libraries(dronecore_example

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SYSTEM because we don't want warnings for gtest headers.
 include_directories(
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/gtest/googletest/include
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/gtest/googlemock/include
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/mavlink/include
+    SYSTEM ${PROJECT_SOURCE_DIR}/third_party/gtest/googletest/include
+    SYSTEM ${PROJECT_SOURCE_DIR}/third_party/gtest/googlemock/include
+    SYSTEM ${PROJECT_SOURCE_DIR}/third_party/mavlink/include
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTESTING")
@@ -41,8 +41,8 @@ add_executable(integration_tests_runner
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/core
-    ${CMAKE_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core
+    ${PROJECT_SOURCE_DIR}
 )
 
 set_target_properties(integration_tests_runner
@@ -72,13 +72,13 @@ add_test(integration_tests
 add_custom_command(TARGET integration_tests_runner
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_SOURCE_DIR}/start_px4_sitl.sh
+        ${PROJECT_SOURCE_DIR}/start_px4_sitl.sh
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 add_custom_command(TARGET integration_tests_runner
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_SOURCE_DIR}/stop_px4_sitl.sh
+        ${PROJECT_SOURCE_DIR}/stop_px4_sitl.sh
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(
-    ${CMAKE_SOURCE_DIR}/core
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/mavlink/include
+    ${PROJECT_SOURCE_DIR}/core
+    SYSTEM  ${PROJECT_SOURCE_DIR}/third_party/mavlink/include
 )
 
 if(IOS OR ANDROID)

--- a/plugins/camera/CMakeLists.txt
+++ b/plugins/camera/CMakeLists.txt
@@ -25,7 +25,7 @@ install(TARGETS dronecore_camera
 )
 
 list(APPEND UNIT_TEST_SOURCES
-    ${CMAKE_SOURCE_DIR}/plugins/camera/camera_definition_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/camera_definition_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)
 

--- a/plugins/mission/CMakeLists.txt
+++ b/plugins/mission/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(dronecore_mission ${PLUGIN_LIBRARY_TYPE}
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/core
-    #SYSTEM ${PROJECT_SOURCE_DIR}/third_party/include
     SYSTEM third_party/json11
 )
 

--- a/plugins/mission/CMakeLists.txt
+++ b/plugins/mission/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(dronecore_mission ${PLUGIN_LIBRARY_TYPE}
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/core
-    SYSTEM ${CMAKE_SOURCE_DIR}/third_party/include
+    #${CMAKE_CURRENT_SOURCE_DIR}/core
+    #SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/include
     SYSTEM third_party/json11
 )
 
@@ -37,6 +37,6 @@ if(ANDROID)
 endif()
 
 list(APPEND UNIT_TEST_SOURCES
-    ${CMAKE_SOURCE_DIR}/plugins/mission/mission_import_qgc_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mission_import_qgc_test.cpp
 )
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/plugins/mission/CMakeLists.txt
+++ b/plugins/mission/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(dronecore_mission ${PLUGIN_LIBRARY_TYPE}
 )
 
 include_directories(
-    #${CMAKE_CURRENT_SOURCE_DIR}/core
-    #SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/include
+    ${PROJECT_SOURCE_DIR}/core
+    #SYSTEM ${PROJECT_SOURCE_DIR}/third_party/include
     SYSTEM third_party/json11
 )
 


### PR DESCRIPTION
This allows DroneCore to be added to any cmake project just by doing:
```
add_subdirectory(path/to/dronecore)
```