### PR TITLE
mission: warn if changing takeoff/land to waypoint

### DIFF
--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -1120,6 +1120,11 @@ Mission::Result MissionImpl::build_mission_items(MAV_CMD command,
         if (command == MAV_CMD_NAV_WAYPOINT || command == MAV_CMD_NAV_TAKEOFF ||
             command == MAV_CMD_NAV_LAND) {
             if (new_mission_item->has_position_set()) {
+                if (command == MAV_CMD_NAV_TAKEOFF) {
+                    LogWarn() << "Converted takeoff mission item to normal waypoint";
+                } else if (command == MAV_CMD_NAV_LAND) {
+                    LogWarn() << "Converted land mission item to normal waypoint";
+                }
                 all_mission_items.push_back(new_mission_item);
                 new_mission_item = std::make_shared<MissionItem>();
             }


### PR DESCRIPTION
We should not silently change takeoff or land mission items to
waypoints. We should at least warn the user about it, even though PX4 is
supposed to do the right thing.

@shakthi-prashanth-m I know that PX4 handles a missing takeoff item fine but what happens when a land item is changed?

FYI @nicovanduijn

Related to #286.