### PR TITLE
camera: adding subscription APIs

### DIFF
--- a/integration_tests/camera_mode.cpp
+++ b/integration_tests/camera_mode.cpp
@@ -22,6 +22,15 @@ TEST(CameraTest, SetMode)
     ASSERT_TRUE(system.has_camera());
     auto camera = std::make_shared<Camera>(system);
 
+    bool received_mode_change = false;
+    Camera::Mode last_mode = Camera::Mode::UNKNOWN;
+
+    camera->subscribe_mode([&received_mode_change, &last_mode](Camera::Mode mode) {
+        LogInfo() << "Got mode: " << int(mode);
+        received_mode_change = true;
+        last_mode = mode;
+    });
+
     std::vector<Camera::Mode> modes_to_test;
     modes_to_test.push_back(Camera::Mode::PHOTO);
     modes_to_test.push_back(Camera::Mode::VIDEO);
@@ -31,6 +40,10 @@ TEST(CameraTest, SetMode)
     for (auto mode : modes_to_test) {
         auto result = camera->set_mode(mode);
         EXPECT_EQ(result, Camera::Result::SUCCESS);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        EXPECT_TRUE(received_mode_change);
+        EXPECT_EQ(last_mode, mode);
+        received_mode_change = false;
     }
 }
 

--- a/integration_tests/camera_take_photo.cpp
+++ b/integration_tests/camera_take_photo.cpp
@@ -40,7 +40,7 @@ TEST(CameraTest, TakePhoto)
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    camera->capture_info_async(std::bind(&receive_capture_info, _1));
+    camera->subscribe_capture_info(std::bind(&receive_capture_info, _1));
 
     camera->take_photo_async(std::bind(&receive_camera_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(5));
@@ -68,7 +68,7 @@ TEST(CameraTest, TakeMultiplePhotos)
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    camera->capture_info_async(std::bind(&receive_capture_info, _1));
+    camera->subscribe_capture_info(std::bind(&receive_capture_info, _1));
 
     for (unsigned i = 0; i < num_photos_to_take; ++i) {
         camera->take_photo_async(std::bind(&receive_camera_result, _1));

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -72,6 +72,11 @@ Camera::Result Camera::get_video_stream_info(VideoStreamInfo &info)
     return _impl->get_video_stream_info(info);
 }
 
+void Camera::subscribe_video_stream_info(const subscribe_video_stream_info_callback_t callback)
+{
+    _impl->subscribe_video_stream_info(callback);
+}
+
 void Camera::stop_video_async(const result_callback_t &callback)
 {
     _impl->stop_video_async(callback);

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -107,9 +107,9 @@ void Camera::get_status_async(get_status_callback_t callback)
     _impl->get_status_async(callback);
 }
 
-void Camera::capture_info_async(capture_info_callback_t callback)
+void Camera::subscribe_capture_info(capture_info_callback_t callback)
 {
-    _impl->capture_info_async(callback);
+    _impl->subscribe_capture_info(callback);
 }
 
 void Camera::set_option_async(const std::string &setting,

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -107,6 +107,11 @@ void Camera::get_status_async(get_status_callback_t callback)
     _impl->get_status_async(callback);
 }
 
+void Camera::subscribe_status(const Camera::subscribe_status_callback_t callback)
+{
+    _impl->subscribe_status(callback);
+}
+
 void Camera::subscribe_capture_info(capture_info_callback_t callback)
 {
     _impl->subscribe_capture_info(callback);

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -167,6 +167,11 @@ void Camera::subscribe_current_options(const subscribe_current_options_callback_
     _impl->subscribe_current_options(callback);
 }
 
+void Camera::subscribe_possible_options(const subscribe_possible_options_callback_t &callback)
+{
+    _impl->subscribe_possible_options(callback);
+}
+
 std::string Camera::result_str(Result result)
 {
     switch (result) {

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -122,21 +122,21 @@ void Camera::subscribe_capture_info(capture_info_callback_t callback)
     _impl->subscribe_capture_info(callback);
 }
 
-void Camera::set_option_async(const std::string &setting,
-                              const std::string &option,
+void Camera::set_option_async(const std::string &setting_id,
+                              const Option &option,
                               const result_callback_t &callback)
 {
-    _impl->set_option_async(setting, option, callback);
+    _impl->set_option_async(setting_id, option, callback);
 }
 
-Camera::Result Camera::get_option(const std::string &setting, std::string &option)
+Camera::Result Camera::get_option(const std::string &setting_id, Option &option)
 {
-    return _impl->get_option(setting, option);
+    return _impl->get_option(setting_id, option);
 }
 
-void Camera::get_option_async(const std::string &setting, const get_option_callback_t &callback)
+void Camera::get_option_async(const std::string &setting_id, const get_option_callback_t &callback)
 {
-    _impl->get_option_async(setting, callback);
+    _impl->get_option_async(setting_id, callback);
 }
 
 bool Camera::get_possible_settings(std::vector<std::string> &settings)
@@ -144,32 +144,32 @@ bool Camera::get_possible_settings(std::vector<std::string> &settings)
     return _impl->get_possible_settings(settings);
 }
 
-bool Camera::get_possible_options(const std::string &setting_name,
-                                  std::vector<std::string> &options)
+bool Camera::get_possible_options(const std::string &setting_id,
+                                  std::vector<Camera::Option> &options)
 {
-    return _impl->get_possible_options(setting_name, options);
+    return _impl->get_possible_options(setting_id, options);
 }
 
-bool Camera::get_setting_str(const std::string &setting_name, std::string &description)
+bool Camera::get_setting_str(const std::string &setting_id, std::string &description)
 {
-    return _impl->get_setting_str(setting_name, description);
+    return _impl->get_setting_str(setting_id, description);
 }
 
-bool Camera::get_option_str(const std::string &setting_name,
-                            const std::string &option_name,
+bool Camera::get_option_str(const std::string &setting_id,
+                            const std::string &option_id,
                             std::string &description)
 {
-    return _impl->get_option_str(setting_name, option_name, description);
+    return _impl->get_option_str(setting_id, option_id, description);
 }
 
-void Camera::subscribe_current_options(const subscribe_current_options_callback_t &callback)
+void Camera::subscribe_current_settings(const subscribe_current_settings_callback_t &callback)
 {
-    _impl->subscribe_current_options(callback);
+    _impl->subscribe_current_settings(callback);
 }
 
-void Camera::subscribe_possible_options(const subscribe_possible_options_callback_t &callback)
+void Camera::subscribe_possible_settings(const subscribe_possible_settings_callback_t &callback)
 {
-    _impl->subscribe_possible_options(callback);
+    _impl->subscribe_possible_settings(callback);
 }
 
 std::string Camera::result_str(Result result)

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -129,6 +129,11 @@ void Camera::set_option_async(const std::string &setting,
     _impl->set_option_async(setting, option, callback);
 }
 
+Camera::Result Camera::get_option(const std::string &setting, std::string &option)
+{
+    return _impl->get_option(setting, option);
+}
+
 void Camera::get_option_async(const std::string &setting, const get_option_callback_t &callback)
 {
     _impl->get_option_async(setting, callback);
@@ -155,6 +160,11 @@ bool Camera::get_option_str(const std::string &setting_name,
                             std::string &description)
 {
     return _impl->get_option_str(setting_name, option_name, description);
+}
+
+void Camera::subscribe_current_options(const subscribe_current_options_callback_t &callback)
+{
+    _impl->subscribe_current_options(callback);
 }
 
 std::string Camera::result_str(Result result)

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -72,6 +72,11 @@ Camera::Result Camera::get_video_stream_info(VideoStreamInfo &info)
     return _impl->get_video_stream_info(info);
 }
 
+void Camera::get_video_stream_info_async(const get_video_stream_info_callback_t callback)
+{
+    _impl->get_video_stream_info_async(callback);
+}
+
 void Camera::subscribe_video_stream_info(const subscribe_video_stream_info_callback_t callback)
 {
     _impl->subscribe_video_stream_info(callback);

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -92,6 +92,11 @@ void Camera::get_mode_async(const mode_callback_t &callback)
     _impl->get_mode_async(callback);
 }
 
+void Camera::subscribe_mode(const subscribe_mode_callback_t callback)
+{
+    _impl->subscribe_mode(callback);
+}
+
 void Camera::get_status_async(get_status_callback_t callback)
 {
     _impl->get_status_async(callback);

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -201,6 +201,18 @@ public:
     void get_mode_async(const mode_callback_t &callback);
 
     /**
+     * @brief Callback type for camera mode subscription.
+     */
+    typedef std::function<void(Mode)> subscribe_mode_callback_t;
+
+    /**
+     * @brief Async subscription for camera mode updates.
+     *
+     * @param callback Function to call with camera mode updates.
+     */
+    void subscribe_mode(const subscribe_mode_callback_t callback);
+
+    /**
      * @brief Information about a picture just captured.
      */
     struct CaptureInfo {

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -324,6 +324,18 @@ public:
     Result get_video_stream_info(VideoStreamInfo &info);
 
     /**
+     * @brief Callback type for video stream info.
+     */
+    typedef std::function<void(VideoStreamInfo)> subscribe_video_stream_info_callback_t;
+
+    /**
+     * @brief Async subscription for video stream info updates.
+     *
+     * @param callback Function to call with video stream updates.
+     */
+    void subscribe_video_stream_info(const subscribe_video_stream_info_callback_t callback);
+
+    /**
      * @brief Starts video streaming (synchronous).
      *
      * Sends a request to start video streaming.

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -324,6 +324,18 @@ public:
     Result get_video_stream_info(VideoStreamInfo &info);
 
     /**
+     * @brief Callback type for asynchronous video stream info call.
+     */
+    typedef std::function<void(Result, VideoStreamInfo)> get_video_stream_info_callback_t;
+
+    /**
+     * @brief Get video stream information (asynchronous).
+     *
+     * @param callback Function to call with video stream info.
+     */
+    void get_video_stream_info_async(const get_video_stream_info_callback_t callback);
+
+    /**
      * @brief Callback type for video stream info.
      */
     typedef std::function<void(VideoStreamInfo)> subscribe_video_stream_info_callback_t;

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -452,6 +452,15 @@ public:
     bool get_possible_options(const std::string &setting_name, std::vector<std::string> &options);
 
     /**
+     * @brief Get an option of a setting (synchronous).
+     *
+     * @param setting The machine readable name of the setting.
+     * @param option A reference to the option string to set.
+     * @return Result of request.
+     */
+    Camera::Result get_option(const std::string &setting, std::string &option);
+
+    /**
      * @brief Callback type to get an option.
      */
     typedef std::function<void(Result, const std::string &)> get_option_callback_t;
@@ -474,6 +483,20 @@ public:
     void set_option_async(const std::string &setting,
                           const std::string &option,
                           const result_callback_t &callback);
+
+    /**
+     * @brief Callback type to get the currently selected options.
+     */
+    typedef std::function<void(const std::vector<std::pair<std::string, std::string>>)>
+        subscribe_current_options_callback_t;
+
+    /**
+     * @brief Subscribe to currently selected options (asynchronous).
+     *
+     * @param callback Function to call when current options have been updated.
+     */
+    void subscribe_current_options(const subscribe_current_options_callback_t &callback);
+
     /**
      * @brief Get the human readable string of a setting.
      *

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -498,6 +498,19 @@ public:
     void subscribe_current_options(const subscribe_current_options_callback_t &callback);
 
     /**
+     * @brief Callback type to get possible options.
+     */
+    typedef std::function<void(const std::vector<std::pair<std::string, std::vector<std::string>>>)>
+        subscribe_possible_options_callback_t;
+
+    /**
+     * @brief Subscribe to all possible options (asynchronous).
+     *
+     * @param callback Function to call when possible options have been updated.
+     */
+    void subscribe_possible_options(const subscribe_possible_options_callback_t &callback);
+
+    /**
      * @brief Get the human readable string of a setting.
      *
      * @param setting_name The machine readable setting name.

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -401,6 +401,18 @@ public:
     void get_status_async(get_status_callback_t callback);
 
     /**
+     * @brief Callback type to subscribe to status updates.
+     */
+    typedef std::function<void(Status)> subscribe_status_callback_t;
+
+    /**
+     * @brief Subscribe to status updates (asynchronous).
+     *
+     * @param callback Function to call with status update.
+     */
+    void subscribe_status(const subscribe_status_callback_t callback);
+
+    /**
      * @brief Get settings that can be changed.
      *
      * The list of settings consists of machine readable parameters,

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -206,7 +206,7 @@ public:
     typedef std::function<void(Mode)> subscribe_mode_callback_t;
 
     /**
-     * @brief Async subscription for camera mode updates.
+     * @brief Async subscription for camera mode updates (asynchronous).
      *
      * @param callback Function to call with camera mode updates.
      */
@@ -329,7 +329,7 @@ public:
     typedef std::function<void(VideoStreamInfo)> subscribe_video_stream_info_callback_t;
 
     /**
-     * @brief Async subscription for video stream info updates.
+     * @brief Async subscription for video stream info updates (asynchronous).
      *
      * @param callback Function to call with video stream updates.
      */

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -425,6 +425,32 @@ public:
     void subscribe_status(const subscribe_status_callback_t callback);
 
     /**
+     * @brief Type to represent a setting option.
+     *
+     * This can be e.g. a color mode option such as "enhanced" or a shutter speed
+     * value like "1/50".
+     */
+    struct Option {
+        std::string option_id; /**< Name of the option (machine readable). */
+    };
+
+    /**
+     * @brief Type to represent a setting with a selected option.
+     */
+    struct Setting {
+        std::string setting_id; /**< Name of the setting (machine readable). */
+        Option option; /**< Selected option. */
+    };
+
+    /**
+     * @brief Type to represent a setting with a list of options to choose from.
+     */
+    struct SettingOptions {
+        std::string setting_id; /**< Name of the setting (machine readable). */
+        std::vector<Option> options; /**< List of options. */
+    };
+
+    /**
      * @brief Get settings that can be changed.
      *
      * The list of settings consists of machine readable parameters,
@@ -445,90 +471,89 @@ public:
      *
      * @sa `get_option_str`
      *
-     * @param setting_name Name of setting (machine readable).
-     * @param options List of options to select from.
+     * @param setting_id Name of setting (machine readable).
+     * @param options List of `Option` objects to select from.
      * @return true if request was successful.
      */
-    bool get_possible_options(const std::string &setting_name, std::vector<std::string> &options);
+    bool get_possible_options(const std::string &setting_id, std::vector<Camera::Option> &options);
 
     /**
      * @brief Get an option of a setting (synchronous).
      *
-     * @param setting The machine readable name of the setting.
-     * @param option A reference to the option string to set.
+     * @param setting_id The machine readable name of the setting.
+     * @param option A reference to the option to set.
      * @return Result of request.
      */
-    Camera::Result get_option(const std::string &setting, std::string &option);
+    Camera::Result get_option(const std::string &setting_id, Option &option);
 
     /**
      * @brief Callback type to get an option.
      */
-    typedef std::function<void(Result, const std::string &)> get_option_callback_t;
+    typedef std::function<void(Result, const Option &)> get_option_callback_t;
 
     /**
      * @brief Get an option of a setting (asynchronous).
      *
-     * @param setting The machine readable name of the setting.
+     * @param setting_id The machine readable name of the setting.
      * @param callback The callback to get the result and selected option.
      */
-    void get_option_async(const std::string &setting, const get_option_callback_t &callback);
+    void get_option_async(const std::string &setting_id, const get_option_callback_t &callback);
 
     /**
      * @brief Set an option of a setting (asynchronous).
      *
-     * @param setting The machine readable name of the setting.
+     * @param setting_id The machine readable name of the setting.
      * @param option The machine readable name of the option value.
      * @param callback The callback to get the result.
      */
-    void set_option_async(const std::string &setting,
-                          const std::string &option,
+    void set_option_async(const std::string &setting_id,
+                          const Camera::Option &option,
                           const result_callback_t &callback);
 
     /**
-     * @brief Callback type to get the currently selected options.
+     * @brief Callback type to get the currently selected settings.
      */
-    typedef std::function<void(const std::vector<std::pair<std::string, std::string>>)>
-        subscribe_current_options_callback_t;
+    typedef std::function<void(const std::vector<Setting>)> subscribe_current_settings_callback_t;
 
     /**
-     * @brief Subscribe to currently selected options (asynchronous).
+     * @brief Callback type to get possible settings.
+     */
+    typedef std::function<void(const std::vector<SettingOptions>)>
+        subscribe_possible_settings_callback_t;
+
+    /**
+     * @brief Subscribe to currently selected settings (asynchronous).
      *
      * @param callback Function to call when current options have been updated.
      */
-    void subscribe_current_options(const subscribe_current_options_callback_t &callback);
+    void subscribe_current_settings(const subscribe_current_settings_callback_t &callback);
 
     /**
-     * @brief Callback type to get possible options.
-     */
-    typedef std::function<void(const std::vector<std::pair<std::string, std::vector<std::string>>>)>
-        subscribe_possible_options_callback_t;
-
-    /**
-     * @brief Subscribe to all possible options (asynchronous).
+     * @brief Subscribe to all possible settings (asynchronous).
      *
      * @param callback Function to call when possible options have been updated.
      */
-    void subscribe_possible_options(const subscribe_possible_options_callback_t &callback);
+    void subscribe_possible_settings(const subscribe_possible_settings_callback_t &callback);
 
     /**
      * @brief Get the human readable string of a setting.
      *
-     * @param setting_name The machine readable setting name.
+     * @param setting_id The machine readable setting name.
      * @param description The human readable string of the setting to get.
      * @return true if call was successful and the description has been set.
      */
-    bool get_setting_str(const std::string &setting_name, std::string &description);
+    bool get_setting_str(const std::string &setting_id, std::string &description);
 
     /**
      * @brief Get the human readable string of an option.
      *
-     * @param setting_name The machine readable setting name.
-     * @param option_name The machine readable option value.
+     * @param setting_id The machine readable setting name.
+     * @param option_id The machine readable option value.
      * @param description The human readable string of the option to get.
      * @return true if call was successful and the description has been set.
      */
-    bool get_option_str(const std::string &setting_name,
-                        const std::string &option_name,
+    bool get_option_str(const std::string &setting_id,
+                        const std::string &option_id,
                         std::string &description);
 
     /**

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -367,7 +367,7 @@ public:
      *
      * @param callback Function to call with updates.
      */
-    void capture_info_async(capture_info_callback_t callback);
+    void subscribe_capture_info(capture_info_callback_t callback);
 
     /**
      * @brief Information about camera status.

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -44,7 +44,7 @@ public:
     void get_mode_async(Camera::mode_callback_t callback);
     void subscribe_mode(const Camera::subscribe_mode_callback_t callback);
 
-    void capture_info_async(Camera::capture_info_callback_t callback);
+    void subscribe_capture_info(Camera::capture_info_callback_t callback);
 
     void get_status_async(Camera::get_status_callback_t callback);
 
@@ -139,6 +139,7 @@ private:
 
     void notify_mode(const Camera::Mode mode);
     void notify_video_stream_info();
+    void notify_capture_info(Camera::CaptureInfo capture_info);
 
     void check_status();
 

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -47,6 +47,7 @@ public:
     void subscribe_capture_info(Camera::capture_info_callback_t callback);
 
     void get_status_async(Camera::get_status_callback_t callback);
+    void subscribe_status(const Camera::subscribe_status_callback_t callback);
 
     void set_option_async(const std::string &setting,
                           const std::string &option,
@@ -75,6 +76,7 @@ private:
         bool received_camera_capture_status{false};
         bool received_storage_information{false};
         void *timeout_cookie{nullptr};
+        void *call_every_cookie{nullptr};
     } _status;
 
     static constexpr double DEFAULT_TIMEOUT_S = 3.0;
@@ -140,6 +142,7 @@ private:
     void notify_mode(const Camera::Mode mode);
     void notify_video_stream_info();
     void notify_capture_info(Camera::CaptureInfo capture_info);
+    void notify_status(Camera::Status status);
 
     void check_status();
 
@@ -179,6 +182,7 @@ private:
 
     Camera::subscribe_mode_callback_t _subscribe_mode_callback{nullptr};
     Camera::subscribe_video_stream_info_callback_t _subscribe_video_stream_info_callback{nullptr};
+    Camera::subscribe_status_callback_t _subscribe_status_callback{nullptr};
 };
 
 } // namespace dronecore

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -54,6 +54,7 @@ public:
                           const std::string &option,
                           const Camera::result_callback_t &callback);
 
+    Camera::Result get_option(const std::string &setting, std::string &option);
     void get_option_async(const std::string &setting,
                           const Camera::get_option_callback_t &callback);
 
@@ -64,6 +65,8 @@ public:
     bool get_option_str(const std::string &setting_name,
                         const std::string &option_name,
                         std::string &description);
+
+    void subscribe_current_options(const Camera::subscribe_current_options_callback_t &callback);
 
     // Non-copyable
     CameraImpl(const CameraImpl &) = delete;
@@ -137,6 +140,7 @@ private:
     void notify_video_stream_info();
     void notify_capture_info(Camera::CaptureInfo capture_info);
     void notify_status(Camera::Status status);
+    void notify_current_options();
 
     void check_status();
 
@@ -178,6 +182,7 @@ private:
     Camera::subscribe_mode_callback_t _subscribe_mode_callback{nullptr};
     Camera::subscribe_video_stream_info_callback_t _subscribe_video_stream_info_callback{nullptr};
     Camera::subscribe_status_callback_t _subscribe_status_callback{nullptr};
+    Camera::subscribe_current_options_callback_t _subscribe_current_options_callback{nullptr};
 };
 
 } // namespace dronecore

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -41,6 +41,7 @@ public:
     Camera::Result set_mode(const Camera::Mode mode);
     void set_mode_async(const Camera::Mode mode, const Camera::mode_callback_t &callback);
     void get_mode_async(Camera::mode_callback_t callback);
+    void subscribe_mode(const Camera::subscribe_mode_callback_t callback);
 
     void capture_info_async(Camera::capture_info_callback_t callback);
 
@@ -135,6 +136,8 @@ private:
     void receive_storage_information_result(MAVLinkCommands::Result result);
     void receive_camera_capture_status_result(MAVLinkCommands::Result result);
 
+    void notify_mode(const Camera::Mode mode);
+
     void check_status();
 
     void status_timeout_happened();
@@ -170,6 +173,8 @@ private:
     MAVLinkCommands::CommandLong make_command_request_video_stream_info();
 
     std::unique_ptr<CameraDefinition> _camera_definition{};
+
+    Camera::subscribe_mode_callback_t _subscribe_mode_callback{nullptr};
 };
 
 } // namespace dronecore

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -50,24 +50,25 @@ public:
     void get_status_async(Camera::get_status_callback_t callback);
     void subscribe_status(const Camera::subscribe_status_callback_t callback);
 
-    void set_option_async(const std::string &setting,
-                          const std::string &option,
+    void set_option_async(const std::string &setting_id,
+                          const Camera::Option &option,
                           const Camera::result_callback_t &callback);
 
-    Camera::Result get_option(const std::string &setting, std::string &option);
-    void get_option_async(const std::string &setting,
+    Camera::Result get_option(const std::string &setting_id, Camera::Option &option);
+    void get_option_async(const std::string &setting_id,
                           const Camera::get_option_callback_t &callback);
 
     bool get_possible_settings(std::vector<std::string> &settings);
-    bool get_possible_options(const std::string &setting_name, std::vector<std::string> &options);
+    bool get_possible_options(const std::string &setting_id, std::vector<Camera::Option> &options);
 
-    bool get_setting_str(const std::string &setting_name, std::string &description);
-    bool get_option_str(const std::string &setting_name,
-                        const std::string &option_name,
+    bool get_setting_str(const std::string &setting_id, std::string &description);
+    bool get_option_str(const std::string &setting_id,
+                        const std::string &option_id,
                         std::string &description);
 
-    void subscribe_current_options(const Camera::subscribe_current_options_callback_t &callback);
-    void subscribe_possible_options(const Camera::subscribe_possible_options_callback_t &callback);
+    void subscribe_current_settings(const Camera::subscribe_current_settings_callback_t &callback);
+    void
+    subscribe_possible_settings(const Camera::subscribe_possible_settings_callback_t &callback);
 
     // Non-copyable
     CameraImpl(const CameraImpl &) = delete;
@@ -141,8 +142,8 @@ private:
     void notify_video_stream_info();
     void notify_capture_info(Camera::CaptureInfo capture_info);
     void notify_status(Camera::Status status);
-    void notify_current_options();
-    void notify_possible_options();
+    void notify_current_settings();
+    void notify_possible_settings();
 
     void check_status();
 
@@ -184,8 +185,8 @@ private:
     Camera::subscribe_mode_callback_t _subscribe_mode_callback{nullptr};
     Camera::subscribe_video_stream_info_callback_t _subscribe_video_stream_info_callback{nullptr};
     Camera::subscribe_status_callback_t _subscribe_status_callback{nullptr};
-    Camera::subscribe_current_options_callback_t _subscribe_current_options_callback{nullptr};
-    Camera::subscribe_possible_options_callback_t _subscribe_possible_options_callback{nullptr};
+    Camera::subscribe_current_settings_callback_t _subscribe_current_settings_callback{nullptr};
+    Camera::subscribe_possible_settings_callback_t _subscribe_possible_settings_callback{nullptr};
 };
 
 } // namespace dronecore

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -34,6 +34,7 @@ public:
 
     void set_video_stream_settings(const Camera::VideoStreamSettings &settings);
     Camera::Result get_video_stream_info(Camera::VideoStreamInfo &info);
+    void subscribe_video_stream_info(const Camera::subscribe_video_stream_info_callback_t callback);
 
     Camera::Result start_video_streaming();
     Camera::Result stop_video_streaming();
@@ -137,6 +138,7 @@ private:
     void receive_camera_capture_status_result(MAVLinkCommands::Result result);
 
     void notify_mode(const Camera::Mode mode);
+    void notify_video_stream_info();
 
     void check_status();
 
@@ -175,6 +177,7 @@ private:
     std::unique_ptr<CameraDefinition> _camera_definition{};
 
     Camera::subscribe_mode_callback_t _subscribe_mode_callback{nullptr};
+    Camera::subscribe_video_stream_info_callback_t _subscribe_video_stream_info_callback{nullptr};
 };
 
 } // namespace dronecore

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -67,6 +67,7 @@ public:
                         std::string &description);
 
     void subscribe_current_options(const Camera::subscribe_current_options_callback_t &callback);
+    void subscribe_possible_options(const Camera::subscribe_possible_options_callback_t &callback);
 
     // Non-copyable
     CameraImpl(const CameraImpl &) = delete;
@@ -141,6 +142,7 @@ private:
     void notify_capture_info(Camera::CaptureInfo capture_info);
     void notify_status(Camera::Status status);
     void notify_current_options();
+    void notify_possible_options();
 
     void check_status();
 
@@ -183,6 +185,7 @@ private:
     Camera::subscribe_video_stream_info_callback_t _subscribe_video_stream_info_callback{nullptr};
     Camera::subscribe_status_callback_t _subscribe_status_callback{nullptr};
     Camera::subscribe_current_options_callback_t _subscribe_current_options_callback{nullptr};
+    Camera::subscribe_possible_options_callback_t _subscribe_possible_options_callback{nullptr};
 };
 
 } // namespace dronecore


### PR DESCRIPTION
This PR adds missing camera subscription APIs:
- [x] camera mode
- [x] video stream info
- [x] capture info
- [x] camera status
- [x] current setting
- [x] possible settings

Connects to #334.