### PR TITLE
backend: fix framework Info.plist

### DIFF
--- a/backend/cmake/MacOSXFrameworkInfo.plist.in
+++ b/backend/cmake/MacOSXFrameworkInfo.plist.in
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_FRAMEWORK_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.dronecore.backend</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.1</string>
+        <key>MinimumOSVersion</key>
+        <string>11.3</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+</dict>
+</plist>

--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -56,11 +56,9 @@ if(IOS)
         FRAMEWORK TRUE
         BUILD_WITH_INSTALL_RPATH TRUE
         INSTALL_NAME_DIR @rpath
-        MACOSX_FRAMEWORK_IDENTIFIER io.dronecore.backend
-        VERSION 0.0.1
-        SOVERSION 0.0.1
         PUBLIC_HEADER backend_api.h
         XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "DroneCore"
+        MACOSX_FRAMEWORK_INFO_PLIST ${PROJECT_SOURCE_DIR}/backend/cmake/MacOSXFrameworkInfo.plist.in
     )
 else()
     add_executable(backend_bin


### PR DESCRIPTION
We need more fields than what cmake was giving us by default. Without this fix, an app using `backend.framework` (e.g. with the Swift frontend) will not pass the Apple validation.

Connects to https://github.com/dronecore/DroneCore-Swift/issues/58.