### PR TITLE
Parallelize the builds of dependencies

### DIFF
--- a/backend/cmake/helpers/build_target.cmake
+++ b/backend/cmake/helpers/build_target.cmake
@@ -1,3 +1,5 @@
+include(ProcessorCount)
+
 function(build_target SRC_DIR TARGET_DIR)
     file(MAKE_DIRECTORY ${TARGET_DIR}/build)
 
@@ -18,6 +20,9 @@ function(build_target SRC_DIR TARGET_DIR)
         WORKING_DIRECTORY "${TARGET_DIR}/build"
     )
 
+    ProcessorCount(NUM_PROCS)
+
+    set(ENV{MAKEFLAGS} -j${NUM_PROCS})
     execute_process(COMMAND ${CMAKE_COMMAND} --build .
         WORKING_DIRECTORY ${TARGET_DIR}/build
     )


### PR DESCRIPTION
This commit just sets the number of jobs used by make to the number of cpus in the system. This greatly accelerated builds on my system.
I might have more cores than most, but with all current-gen laptops having at least 8 (hyper-/SMT) threads, this should give a nice boost for most users.

TESTED:
`git clone https://github.com/thomasetter/DroneCore.git --recurse-submodules -j 20 && cd DroneCore/ && mkdir build && cd build && cmake .. && make -j12`