### PR TITLE
camera: switch to possible setting options

### DIFF
--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -37,7 +37,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
         set_mode_async(camera, Camera::Mode::PHOTO);
 
         std::vector<std::string> settings;
-        EXPECT_TRUE(camera->get_possible_settings(settings));
+        EXPECT_TRUE(camera->get_possible_setting_options(settings));
 
         LogDebug() << "Possible settings in photo mode: ";
         for (auto setting : settings) {
@@ -56,7 +56,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
 
         std::this_thread::sleep_for(std::chrono::seconds(2));
 
-        EXPECT_TRUE(camera->get_possible_settings(settings));
+        EXPECT_TRUE(camera->get_possible_setting_options(settings));
 
         LogDebug() << "Possible settings in video mode: ";
         for (auto setting : settings) {
@@ -281,8 +281,9 @@ TEST(CameraTest, SubscribeCurrentSettings)
     EXPECT_TRUE(subscription_called);
 }
 
-static void receive_possible_settings(bool &subscription_called,
-                                      const std::vector<Camera::SettingOptions> settings_options)
+static void
+receive_possible_setting_options(bool &subscription_called,
+                                 const std::vector<Camera::SettingOptions> settings_options)
 {
     LogDebug() << "Received possible options:";
     EXPECT_TRUE(settings_options.size() > 0);
@@ -318,8 +319,8 @@ TEST(CameraTest, SubscribePossibleSettings)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     bool subscription_called = false;
-    camera->subscribe_possible_settings(
-        std::bind(receive_possible_settings, std::ref(subscription_called), _1));
+    camera->subscribe_possible_setting_options(
+        std::bind(receive_possible_setting_options, std::ref(subscription_called), _1));
 
     EXPECT_EQ(camera->set_mode(Camera::Mode::PHOTO), Camera::Result::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -139,9 +139,9 @@ void Camera::get_option_async(const std::string &setting_id, const get_option_ca
     _impl->get_option_async(setting_id, callback);
 }
 
-bool Camera::get_possible_settings(std::vector<std::string> &settings)
+bool Camera::get_possible_setting_options(std::vector<std::string> &settings)
 {
-    return _impl->get_possible_settings(settings);
+    return _impl->get_possible_setting_options(settings);
 }
 
 bool Camera::get_possible_options(const std::string &setting_id,
@@ -167,9 +167,10 @@ void Camera::subscribe_current_settings(const subscribe_current_settings_callbac
     _impl->subscribe_current_settings(callback);
 }
 
-void Camera::subscribe_possible_settings(const subscribe_possible_settings_callback_t &callback)
+void Camera::subscribe_possible_setting_options(
+    const subscribe_possible_setting_options_callback_t &callback)
 {
-    _impl->subscribe_possible_settings(callback);
+    _impl->subscribe_possible_setting_options(callback);
 }
 
 std::string Camera::result_str(Result result)

--- a/plugins/camera/camera.h
+++ b/plugins/camera/camera.h
@@ -461,7 +461,7 @@ public:
      * @param settings List of settings that can be changed.
      * @return true request was successful.
      */
-    bool get_possible_settings(std::vector<std::string> &settings);
+    bool get_possible_setting_options(std::vector<std::string> &settings);
 
     /**
      * @brief Get possible options for a setting that can be selected.
@@ -516,10 +516,10 @@ public:
     typedef std::function<void(const std::vector<Setting>)> subscribe_current_settings_callback_t;
 
     /**
-     * @brief Callback type to get possible settings.
+     * @brief Callback type to get possible setting options.
      */
     typedef std::function<void(const std::vector<SettingOptions>)>
-        subscribe_possible_settings_callback_t;
+        subscribe_possible_setting_options_callback_t;
 
     /**
      * @brief Subscribe to currently selected settings (asynchronous).
@@ -529,11 +529,12 @@ public:
     void subscribe_current_settings(const subscribe_current_settings_callback_t &callback);
 
     /**
-     * @brief Subscribe to all possible settings (asynchronous).
+     * @brief Subscribe to all possible setting options (asynchronous).
      *
      * @param callback Function to call when possible options have been updated.
      */
-    void subscribe_possible_settings(const subscribe_possible_settings_callback_t &callback);
+    void subscribe_possible_setting_options(
+        const subscribe_possible_setting_options_callback_t &callback);
 
     /**
      * @brief Get the human readable string of a setting.

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -948,7 +948,7 @@ void CameraImpl::load_definition_file(const std::string &uri)
     refresh_params();
 }
 
-bool CameraImpl::get_possible_settings(std::vector<std::string> &settings)
+bool CameraImpl::get_possible_setting_options(std::vector<std::string> &settings)
 {
     settings.clear();
 
@@ -1127,10 +1127,10 @@ void CameraImpl::subscribe_current_settings(
     _subscribe_current_settings_callback = callback;
 }
 
-void CameraImpl::subscribe_possible_settings(
-    const Camera::subscribe_possible_settings_callback_t &callback)
+void CameraImpl::subscribe_possible_setting_options(
+    const Camera::subscribe_possible_setting_options_callback_t &callback)
 {
-    _subscribe_possible_settings_callback = callback;
+    _subscribe_possible_setting_options_callback = callback;
 }
 
 void CameraImpl::notify_current_settings()
@@ -1145,13 +1145,13 @@ void CameraImpl::notify_current_settings()
     }
 
     std::vector<Camera::Setting> current_settings{};
-    std::vector<std::string> possible_settings{};
-    if (!get_possible_settings(possible_settings)) {
+    std::vector<std::string> possible_setting_options{};
+    if (!get_possible_setting_options(possible_setting_options)) {
         LogErr() << "Could not get possible settings in current options subscription.";
         return;
     }
 
-    for (auto &possible_setting : possible_settings) {
+    for (auto &possible_setting : possible_setting_options) {
         // use the cache for this, presumably we updated it right before.
         MAVLinkParameters::ParamValue value;
         if (_camera_definition->get_setting(possible_setting, value)) {
@@ -1164,21 +1164,21 @@ void CameraImpl::notify_current_settings()
     _subscribe_current_settings_callback(current_settings);
 }
 
-void CameraImpl::notify_possible_settings()
+void CameraImpl::notify_possible_setting_options()
 {
-    if (!_subscribe_possible_settings_callback) {
+    if (!_subscribe_possible_setting_options_callback) {
         return;
     }
 
     if (!_camera_definition) {
-        LogErr() << "notify_possible_settings has no camera definition";
+        LogErr() << "notify_possible_setting_options has no camera definition";
         return;
     }
 
     std::vector<Camera::SettingOptions> possible_setting_options{};
 
     std::vector<std::string> possible_settings{};
-    if (!get_possible_settings(possible_settings)) {
+    if (!get_possible_setting_options(possible_settings)) {
         LogErr() << "Could not get possible settings in possible options subscription.";
         return;
     }
@@ -1190,7 +1190,7 @@ void CameraImpl::notify_possible_settings()
         possible_setting_options.push_back(setting_options);
     }
 
-    _subscribe_possible_settings_callback(possible_setting_options);
+    _subscribe_possible_setting_options_callback(possible_setting_options);
 }
 
 void CameraImpl::refresh_params()
@@ -1222,7 +1222,7 @@ void CameraImpl::refresh_params()
 
                 if (is_last) {
                     notify_current_settings();
-                    notify_possible_settings();
+                    notify_possible_setting_options();
                 }
             },
             true);

--- a/plugins/camera/camera_impl.h
+++ b/plugins/camera/camera_impl.h
@@ -58,7 +58,7 @@ public:
     void get_option_async(const std::string &setting_id,
                           const Camera::get_option_callback_t &callback);
 
-    bool get_possible_settings(std::vector<std::string> &settings);
+    bool get_possible_setting_options(std::vector<std::string> &settings);
     bool get_possible_options(const std::string &setting_id, std::vector<Camera::Option> &options);
 
     bool get_setting_str(const std::string &setting_id, std::string &description);
@@ -67,8 +67,8 @@ public:
                         std::string &description);
 
     void subscribe_current_settings(const Camera::subscribe_current_settings_callback_t &callback);
-    void
-    subscribe_possible_settings(const Camera::subscribe_possible_settings_callback_t &callback);
+    void subscribe_possible_setting_options(
+        const Camera::subscribe_possible_setting_options_callback_t &callback);
 
     // Non-copyable
     CameraImpl(const CameraImpl &) = delete;
@@ -143,7 +143,7 @@ private:
     void notify_capture_info(Camera::CaptureInfo capture_info);
     void notify_status(Camera::Status status);
     void notify_current_settings();
-    void notify_possible_settings();
+    void notify_possible_setting_options();
 
     void check_status();
 
@@ -186,7 +186,8 @@ private:
     Camera::subscribe_video_stream_info_callback_t _subscribe_video_stream_info_callback{nullptr};
     Camera::subscribe_status_callback_t _subscribe_status_callback{nullptr};
     Camera::subscribe_current_settings_callback_t _subscribe_current_settings_callback{nullptr};
-    Camera::subscribe_possible_settings_callback_t _subscribe_possible_settings_callback{nullptr};
+    Camera::subscribe_possible_setting_options_callback_t
+        _subscribe_possible_setting_options_callback{nullptr};
 };
 
 } // namespace dronecore


### PR DESCRIPTION
This change makes sure the API for current setting options is named consistently.