### PR TITLE
README cleanup

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,0 @@
-Contributors in order of first contribution:
-
-* [Julian Oes](https://github.com/julianoes)
-* [Dario Röthlisberger](https://github.com/darioxz)

--- a/README.md
+++ b/README.md
@@ -20,47 +20,46 @@ It is written in C++ and aiming to be:
 
 The next steps will be:
 
-- Add Camera settings and actions interface.
 - Add language bindings for Android, iOS, and Python
 
 ## Interfacing
 
-DroneCore currently takes care of the mavlink messaging using a UDP network connection to the drone. Connecting via TCP, or serial is planned but not implemeted yet.
+DroneCore currently takes care of the mavlink messaging. Connections over serial, UDP, and TCP are supported on Linux, macOS, and Windows.
 
 The library provides both synchronous (blocking) API calls, as well as asynchronous API calls using callbacks.
 
 ## API Overview
 
-API consumers use the `DroneCore` class to discover and manage vehicles (`Device` objects), which in turn provide access to all other drone information and control objects (e.g. `Telemetry`, `Mission` etc.).
+API consumers use the `DroneCore` class to discover and manage vehicles (`System` objects). Using the `System` object plugins such as e.g. `Action`, `Telemetry`, or `Mission` can be instantiated which provide information about the state of the drone and allow to interact with it.
 
 The links below take you to the respective header files:
 
 - [dronecore](include/dronecore.h): set up connection, discover devices
-- [device](include/device.h): a device providing access to modules below using ...
-- [device_plugin_container.h.in](include/device_plugin_container.h.in) which is auto-generated on build.
+- [system](include/system.h): an class representing one drone which can consist of multiple components
 - [info](plugins/info/info.h): general info about a device
 - [telemetry](plugins/telemetry/telemetry.h): to receive telemetry data
 - [action](plugins/action/action.h): to send commands such as arm, disarm, takeoff, land to drone
 - [mission](plugins/mission/mission.h)/[mission_item](plugins/mission/mission_item.h): to upload a waypoint mission
 - [offboard](plugins/offboard/offboard.h): for velocity control
 - [gimbal](plugins/gimbal/gimbal.h): control a gimbal
+- [camera](plugins/camera/camera.h): capture images, videos, and set camera settings
 - [follow_me](plugins/follow_me/follow_me.h): drone tracks a position supplied by DroneCore.
 - [logging](plugins/logging/logging.h): (not implemented) data logging and streaming from the vehicle.
 
-For more information see the [API Overview](https://docs.dronecore.io/en/getting_started/#api-overview) in the DroneCore Guide.
+For more information see the [API Overview](https://sdk.dronecode.org/en/#api-overview) in the DroneCore Guide.
 
 
-## Guide Docs (Build instructions etc.)
+## Docs (Build instructions etc.)
 
-Instructions for how to use the library can be found in the [DroneCore Guide](https://docs.dronecore.io/en/).
+Instructions for how to use the library can be found in the [DroneCore Guide](https://sdk.dronecode.org/en).
 
 Quick Links:
 
-- [QuickStart](https://docs.dronecore.io/en/getting_started/)
-- [Building the Library](https://docs.dronecore.io/en/contributing/build.html)
-- [Examples](https://docs.dronecore.io/en/examples/)
-- [API Reference](https://docs.dronecore.io/en/api_reference/)
-- [FAQ](https://docs.dronecore.io/en/getting_started/faq.html)
+- [QuickStart](https://sdk.dronecode.org/en/getting_started/)
+- [Building the Library](https://sdk.dronecode.org/en/contributing/build.html)
+- [Examples](https://sdk.dronecode.org/en/examples/)
+- [API Reference](https://sdk.dronecode.org/en/api_reference/)
+- [FAQ](https://sdk.dronecode.org/en/getting_started/faq.html)
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -65,9 +65,3 @@ Quick Links:
 ## License
 
 The DroneCore project is licensed under the permissive BSD 3-clause, see [LICENSE.md](LICENSE.md).
-
-## Authors
-
-See [AUTHORS.md](AUTHORS.md).
-
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![DroneCore](https://raw.githubusercontent.com/dronecore/docs/master/assets/site/dronecore_logo_full.png)
+![DroneCore](https://raw.githubusercontent.com/dronecore/docs/master/assets/site/dronecore_logo_full.png) 
 
 [![jenkins build status](http://ci.px4.io:8080/buildStatus/icon?job=DroneCore/develop)](http://ci.px4.io:8080/blue/organizations/jenkins/DroneCore/activity)
 [![travis-ci build status](https://travis-ci.org/dronecore/DroneCore.svg?branch=develop)](https://travis-ci.org/dronecore/DroneCore)
@@ -7,7 +7,7 @@
 
 ## Description
 
-DroneCore is an API and library for the [PX4 flight stack](http://github.com/PX4/Firmware) using [Mavlink](http://mavlink.org).
+The [Dronecode SDK](https://www.dronecode.org/sdk/) (previously known as "DroneCore") is an API and library for the [PX4 flight stack](http://github.com/PX4/Firmware) using [Mavlink](https://mavlink.io/en/).
 
 It is written in C++ and aiming to be:
 
@@ -24,7 +24,7 @@ The next steps will be:
 
 ## Interfacing
 
-DroneCore currently takes care of the mavlink messaging. Connections over serial, UDP, and TCP are supported on Linux, macOS, and Windows.
+The SDK currently takes care of the MAVLink messaging. Connections over serial, UDP, and TCP are supported on Linux, macOS, and Windows.
 
 The library provides both synchronous (blocking) API calls, as well as asynchronous API calls using callbacks.
 
@@ -46,12 +46,12 @@ The links below take you to the respective header files:
 - [follow_me](plugins/follow_me/follow_me.h): drone tracks a position supplied by DroneCore.
 - [logging](plugins/logging/logging.h): (not implemented) data logging and streaming from the vehicle.
 
-For more information see the [API Overview](https://sdk.dronecode.org/en/#api-overview) in the DroneCore Guide.
+For more information see the [API Overview](https://sdk.dronecode.org/en/#api-overview) in the Dronecode SDK Guide.
 
 
 ## Docs (Build instructions etc.)
 
-Instructions for how to use the library can be found in the [DroneCore Guide](https://sdk.dronecode.org/en).
+Instructions for how to use the library can be found in the [SDK Guide](https://sdk.dronecode.org/en).
 
 Quick Links:
 
@@ -64,4 +64,4 @@ Quick Links:
 
 ## License
 
-The DroneCore project is licensed under the permissive BSD 3-clause, see [LICENSE.md](LICENSE.md).
+This project is licensed under the permissive BSD 3-clause, see [LICENSE.md](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![DroneCore](https://raw.githubusercontent.com/dronecore/docs/master/assets/site/dronecore_logo_full.png)
 
+[![jenkins build status](http://ci.px4.io:8080/buildStatus/icon?job=DroneCore/develop)](http://ci.px4.io:8080/blue/organizations/jenkins/DroneCore/activity)
 [![travis-ci build status](https://travis-ci.org/dronecore/DroneCore.svg?branch=develop)](https://travis-ci.org/dronecore/DroneCore)
 [![appveyor build status](https://ci.appveyor.com/api/projects/status/1ntjvooywpxmoir8/branch/develop?svg=true)](https://ci.appveyor.com/project/julianoes/dronecore/branch/develop)
 [![Coverage Status](https://coveralls.io/repos/github/dronecore/DroneCore/badge.svg?branch=develop)](https://coveralls.io/github/dronecore/DroneCore?branch=develop)


### PR DESCRIPTION
The README has not received much love in the past months and it was time to go through it.

- Removed AUTHORS.md, we didn't use or update it anywa.
- Added Jenkins CI badge.
- Various corrections, mostly `Device` -> `System`, and new plugins
- Updated URLs to sdk.dronecode.org.