### PR TITLE
Add plugin warnings

### DIFF
--- a/core/global_include.cpp
+++ b/core/global_include.cpp
@@ -3,6 +3,7 @@
 #include <cfloat>
 #include <cstdint>
 #include <limits>
+#include <cmath>
 
 namespace dronecode_sdk {
 
@@ -149,12 +150,12 @@ float to_deg_from_rad(float rad)
 
 bool are_equal(float one, float two)
 {
-    return (fabsf(one - two) < std::numeric_limits<float>::epsilon());
+    return (std::fabs(one - two) < std::numeric_limits<float>::epsilon());
 }
 
 bool are_equal(double one, double two)
 {
-    return (fabs(one - two) < std::numeric_limits<double>::epsilon());
+    return (std::fabs(one - two) < std::numeric_limits<double>::epsilon());
 }
 
 } // namespace dronecode_sdk

--- a/core/global_include.h
+++ b/core/global_include.h
@@ -5,14 +5,15 @@
 #include <chrono>
 #include <thread>
 
-#ifdef WINDOWS
-#ifndef _USE_MATH_DEFINES
-#define _USE_MATH_DEFINES
+// Instead of using the constant from math.h or cmath we define it ourselves. This way
+// we don't import all the other C math functions and make sure to use the C++ functions
+// from the standard library (e.g. std::abs() instead of abs()).
+#ifndef M_PI
+constexpr double M_PI = 3.14159265358979323846;
 #endif
-// cmath doesn't contain M_PI
-#include <math.h>
-#else
-#include <cmath>
+
+#ifndef M_PI_F
+constexpr float M_PI_F = float(M_PI);
 #endif
 
 #define MIN(x_, y_) ((x_) > (y_)) ? (y_) : (x_)
@@ -22,10 +23,6 @@
 #define STRNCPY strncpy_s
 #else
 #define STRNCPY strncpy
-#endif
-
-#ifndef M_PI_F
-#define M_PI_F float(M_PI)
 #endif
 
 namespace dronecode_sdk {

--- a/integration_tests/mission.cpp
+++ b/integration_tests/mission.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <future>
 #include <atomic>
+#include <cmath>
 #include "integration_test_helper.h"
 #include "dronecode_sdk.h"
 #include "plugins/telemetry/telemetry.h"

--- a/integration_tests/simple_hover.cpp
+++ b/integration_tests/simple_hover.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cmath>
 #include "integration_test_helper.h"
 #include "dronecode_sdk.h"
 #include "plugins/action/action.h"

--- a/plugins/action/CMakeLists.txt
+++ b/plugins/action/CMakeLists.txt
@@ -7,6 +7,10 @@ target_link_libraries(dronecode_sdk_action
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_action
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     action.h
     action_result.h

--- a/plugins/calibration/CMakeLists.txt
+++ b/plugins/calibration/CMakeLists.txt
@@ -8,6 +8,10 @@ target_link_libraries(dronecode_sdk_calibration
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_calibration
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     calibration.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/calibration/calibration_impl.cpp
+++ b/plugins/calibration/calibration_impl.cpp
@@ -330,7 +330,7 @@ void CalibrationImpl::process_statustext(const mavlink_message_t &message)
             // FALLTHROUGH
         case CalibrationStatustextParser::Status::CANCELLED:
             _calibration_callback = nullptr;
-            _state == State::NONE;
+            _state = State::NONE;
             break;
         default:
             break;

--- a/plugins/camera/CMakeLists.txt
+++ b/plugins/camera/CMakeLists.txt
@@ -10,6 +10,10 @@ target_link_libraries(dronecode_sdk_camera
     ${CURL_LIBRARY}
 )
 
+set_target_properties(dronecode_sdk_camera
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 include_directories(
     ${CURL_INCLUDE_DIRS}
 )

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -5,6 +5,7 @@
 #include "mavlink_include.h"
 #include "http_loader.h"
 #include <functional>
+#include <cmath>
 
 namespace dronecode_sdk {
 

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -396,8 +396,8 @@ Camera::Result CameraImpl::get_video_stream_info(Camera::VideoStreamInfo &info)
     auto prom = std::make_shared<std::promise<Camera::Result>>();
     auto ret = prom->get_future();
 
-    get_video_stream_info_async([prom](Camera::Result result, Camera::VideoStreamInfo info) {
-        UNUSED(info);
+    get_video_stream_info_async([prom](Camera::Result result, Camera::VideoStreamInfo info_gotten) {
+        UNUSED(info_gotten);
         prom->set_value(result);
     });
 
@@ -426,6 +426,7 @@ void CameraImpl::get_video_stream_info_async(
 
     auto command = make_command_request_video_stream_info();
     _parent->send_command_async(command, [this](MAVLinkCommands::Result result, float progress) {
+        UNUSED(progress);
         Camera::Result camera_result = camera_result_from_command_result(result);
         if (camera_result != Camera::Result::SUCCESS) {
             if (_video_stream_info.callback) {
@@ -1102,7 +1103,7 @@ void CameraImpl::get_option_async(const std::string &setting_id,
         LogWarn() << "The param was probably outdated, trying to fetch it";
         _parent->get_param_async(
             setting_id,
-            [setting_id, this](bool success, MAVLinkParameters::ParamValue value) {
+            [setting_id, this](bool success, MAVLinkParameters::ParamValue value_gotten) {
                 if (!success) {
                     LogWarn() << "Fetching the param failed";
                     return;
@@ -1111,7 +1112,7 @@ void CameraImpl::get_option_async(const std::string &setting_id,
                 if (!this->_camera_definition) {
                     return;
                 }
-                this->_camera_definition->set_setting(setting_id, value);
+                this->_camera_definition->set_setting(setting_id, value_gotten);
             },
             true);
 
@@ -1204,7 +1205,7 @@ void CameraImpl::refresh_params()
         return;
     }
 
-    int count = 0;
+    unsigned count = 0;
     for (const auto &param : params) {
         std::string param_name = param;
         const bool is_last = (count + 1 == params.size());

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -510,8 +510,13 @@ Camera::Result CameraImpl::set_mode(const Camera::Mode mode)
 
 void CameraImpl::save_camera_mode(const float mavlink_camera_mode)
 {
+    if (!std::isfinite(mavlink_camera_mode)) {
+        LogWarn() << "Can't save NAN as camera mode";
+        return;
+    }
+
     MAVLinkParameters::ParamValue value;
-    value.set_uint32(mavlink_camera_mode);
+    value.set_uint32(uint32_t(mavlink_camera_mode));
     _camera_definition->set_setting("CAM_MODE", value);
     refresh_params();
 }

--- a/plugins/follow_me/CMakeLists.txt
+++ b/plugins/follow_me/CMakeLists.txt
@@ -7,6 +7,10 @@ target_link_libraries(dronecode_sdk_follow_me
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_follow_me
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     follow_me.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/gimbal/CMakeLists.txt
+++ b/plugins/gimbal/CMakeLists.txt
@@ -7,6 +7,10 @@ target_link_libraries(dronecode_sdk_gimbal
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_gimbal
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     gimbal.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/info/CMakeLists.txt
+++ b/plugins/info/CMakeLists.txt
@@ -7,6 +7,10 @@ target_link_libraries(dronecode_sdk_info
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_info
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     info.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -100,11 +100,11 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
 
     product.vendor_id = autopilot_version.vendor_id;
     const char *vendor_name = vendor_id_str(autopilot_version.vendor_id);
-    STRNCPY(product.vendor_name, vendor_name, sizeof(product.vendor_name - 1));
+    STRNCPY(product.vendor_name, vendor_name, sizeof(product.vendor_name) - 1);
 
     product.product_id = autopilot_version.product_id;
     const char *product_name = product_id_str(autopilot_version.product_id);
-    STRNCPY(product.product_name, product_name, sizeof(product.product_name - 1));
+    STRNCPY(product.product_name, product_name, sizeof(product.product_name) - 1);
 
     set_product(product);
 }

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -100,11 +100,11 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
 
     product.vendor_id = autopilot_version.vendor_id;
     const char *vendor_name = vendor_id_str(autopilot_version.vendor_id);
-    STRNCPY(product.vendor_name, vendor_name, sizeof(product.vendor_name));
+    STRNCPY(product.vendor_name, vendor_name, sizeof(product.vendor_name - 1));
 
     product.product_id = autopilot_version.product_id;
     const char *product_name = product_id_str(autopilot_version.product_id);
-    STRNCPY(product.product_name, product_name, sizeof(product.product_name));
+    STRNCPY(product.product_name, product_name, sizeof(product.product_name - 1));
 
     set_product(product);
 }

--- a/plugins/logging/CMakeLists.txt
+++ b/plugins/logging/CMakeLists.txt
@@ -7,6 +7,10 @@ target_link_libraries(dronecode_sdk_logging
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_logging
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     logging.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/mission/CMakeLists.txt
+++ b/plugins/mission/CMakeLists.txt
@@ -10,6 +10,10 @@ include_directories(
     SYSTEM third_party/json11
 )
 
+set_target_properties(dronecode_sdk_mission
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 # JSON parser library for parsing QGC plan for Mission
 add_subdirectory(third_party/json11)
 

--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -1210,7 +1210,7 @@ Mission::Result MissionImpl::import_mission_items(Mission::mission_items_t &all_
         for (auto &p : json_mission_item["params"].array_items()) {
             if (p.is_null()) {
                 // QGC sets params as `null` if they should be unchanged.
-                params.push_back(NAN);
+                params.push_back(double(NAN));
             } else {
                 params.push_back(p.number_value());
             }

--- a/plugins/mission/mission_import_qgc_test.cpp
+++ b/plugins/mission/mission_import_qgc_test.cpp
@@ -5,7 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <atomic>
-#include <atomic>
+#include <cmath>
 #include "mission.h"
 #include "mavlink_include.h"
 #include "global_include.h"

--- a/plugins/offboard/CMakeLists.txt
+++ b/plugins/offboard/CMakeLists.txt
@@ -7,6 +7,10 @@ target_link_libraries(dronecode_sdk_offboard
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_offboard
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     offboard.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/telemetry/CMakeLists.txt
+++ b/plugins/telemetry/CMakeLists.txt
@@ -8,6 +8,10 @@ target_link_libraries(dronecode_sdk_telemetry
     dronecode_sdk
 )
 
+set_target_properties(dronecode_sdk_telemetry
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
 install(FILES
     telemetry.h
     DESTINATION ${dronecode_sdk_install_include_dir}

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -319,17 +319,17 @@ const char *Telemetry::result_str(Result result)
 bool operator==(const Telemetry::PositionVelocityNED &lhs,
                 const Telemetry::PositionVelocityNED &rhs)
 {
-    return abs(lhs.position.north_m - rhs.position.north_m) <=
-               std::numeric_limits<double>::epsilon() &&
-           abs(lhs.position.east_m - rhs.position.east_m) <=
-               std::numeric_limits<double>::epsilon() &&
-           abs(lhs.position.down_m - rhs.position.down_m) <=
+    return fabs(lhs.position.north_m - rhs.position.north_m) <=
                std::numeric_limits<float>::epsilon() &&
-           abs(lhs.velocity.north_m_s - rhs.velocity.north_m_s) <=
+           fabs(lhs.position.east_m - rhs.position.east_m) <=
                std::numeric_limits<float>::epsilon() &&
-           abs(lhs.velocity.east_m_s - rhs.velocity.east_m_s) <=
+           fabs(lhs.position.down_m - rhs.position.down_m) <=
                std::numeric_limits<float>::epsilon() &&
-           abs(lhs.velocity.down_m_s - rhs.velocity.down_m_s) <=
+           fabs(lhs.velocity.north_m_s - rhs.velocity.north_m_s) <=
+               std::numeric_limits<float>::epsilon() &&
+           fabs(lhs.velocity.east_m_s - rhs.velocity.east_m_s) <=
+               std::numeric_limits<float>::epsilon() &&
+           fabs(lhs.velocity.down_m_s - rhs.velocity.down_m_s) <=
                std::numeric_limits<float>::epsilon();
 }
 

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -1,6 +1,7 @@
 #include "telemetry.h"
 
 #include <limits>
+#include <cmath>
 
 #include "telemetry_impl.h"
 
@@ -319,27 +320,29 @@ const char *Telemetry::result_str(Result result)
 bool operator==(const Telemetry::PositionVelocityNED &lhs,
                 const Telemetry::PositionVelocityNED &rhs)
 {
-    return fabs(lhs.position.north_m - rhs.position.north_m) <=
+    return std::fabs(lhs.position.north_m - rhs.position.north_m) <=
                std::numeric_limits<float>::epsilon() &&
-           fabs(lhs.position.east_m - rhs.position.east_m) <=
+           std::fabs(lhs.position.east_m - rhs.position.east_m) <=
                std::numeric_limits<float>::epsilon() &&
-           fabs(lhs.position.down_m - rhs.position.down_m) <=
+           std::fabs(lhs.position.down_m - rhs.position.down_m) <=
                std::numeric_limits<float>::epsilon() &&
-           fabs(lhs.velocity.north_m_s - rhs.velocity.north_m_s) <=
+           std::fabs(lhs.velocity.north_m_s - rhs.velocity.north_m_s) <=
                std::numeric_limits<float>::epsilon() &&
-           fabs(lhs.velocity.east_m_s - rhs.velocity.east_m_s) <=
+           std::fabs(lhs.velocity.east_m_s - rhs.velocity.east_m_s) <=
                std::numeric_limits<float>::epsilon() &&
-           fabs(lhs.velocity.down_m_s - rhs.velocity.down_m_s) <=
+           std::fabs(lhs.velocity.down_m_s - rhs.velocity.down_m_s) <=
                std::numeric_limits<float>::epsilon();
 }
 
 bool operator==(const Telemetry::Position &lhs, const Telemetry::Position &rhs)
 {
-    return abs(lhs.latitude_deg - rhs.latitude_deg) <= std::numeric_limits<double>::epsilon() &&
-           abs(lhs.longitude_deg - rhs.longitude_deg) <= std::numeric_limits<double>::epsilon() &&
-           abs(lhs.absolute_altitude_m - rhs.absolute_altitude_m) <=
+    return std::abs(lhs.latitude_deg - rhs.latitude_deg) <=
+               std::numeric_limits<double>::epsilon() &&
+           std::abs(lhs.longitude_deg - rhs.longitude_deg) <=
+               std::numeric_limits<double>::epsilon() &&
+           std::abs(lhs.absolute_altitude_m - rhs.absolute_altitude_m) <=
                std::numeric_limits<float>::epsilon() &&
-           abs(lhs.relative_altitude_m - rhs.relative_altitude_m) <=
+           std::abs(lhs.relative_altitude_m - rhs.relative_altitude_m) <=
                std::numeric_limits<float>::epsilon();
 }
 


### PR DESCRIPTION
By oversight we did not have the special warnings enabled for the plugins.

This enables the warnings again and fixes a few that crept in. And one was actually a bug so that confirms that warnings are important!